### PR TITLE
feat: 앱 메인 뷰

### DIFF
--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.sopt.app.domain.enums.UserStatus;
 
 public class PlaygroundAuthInfo {
 
@@ -45,7 +46,7 @@ public class PlaygroundAuthInfo {
 
         private String name;
         private String profileImage;
-        private PlaygroundActivity activities;
+        private List<PlaygroundActivity> activities;
     }
 
     @Getter
@@ -67,5 +68,24 @@ public class PlaygroundAuthInfo {
         private String team;
         private String part;
         private Boolean isProject;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class MainView {
+
+        private MainViewUser user;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class MainViewUser {
+
+        private UserStatus status;
+        private String name;
+        private String profileImage;
+        private List<Long> generationList;
     }
 }

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -1,7 +1,9 @@
 package org.sopt.app.application.auth;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 public class PlaygroundAuthInfo {
@@ -21,5 +23,49 @@ public class PlaygroundAuthInfo {
 
         private String accessToken;
         private String refreshToken;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class PlaygroundMain {
+
+        private Long id;
+        private String name;
+        private Long generation;
+        private String profileImage;
+        private Boolean hasProfile;
+        private String accessToken;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class PlaygroundProfile {
+
+        private String name;
+        private String profileImage;
+        private PlaygroundActivity activities;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class PlaygroundActivity {
+
+        private String cardinalInfo;
+        private List<PlaygroundCardinalActivity> cardinalActivities;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class PlaygroundCardinalActivity {
+
+        private Long id;
+        private Long generation;
+        private String team;
+        private String part;
+        private Boolean isProject;
     }
 }

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
@@ -3,7 +3,6 @@ package org.sopt.app.application.auth;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.presentation.auth.AuthRequest;
-import org.sopt.app.presentation.auth.AuthResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -20,7 +19,7 @@ public class PlaygroundAuthService {
 
     private RestTemplate restTemplate = new RestTemplate();
 
-    public AuthResponse.PlaygroundResponse getPlaygroundInfo(AuthRequest.CodeRequest codeRequest) {
+    public PlaygroundAuthInfo.PlaygroundMain getPlaygroundInfo(AuthRequest.CodeRequest codeRequest) {
         val tokenRequest = this.getPlaygroundAccessToken(codeRequest);
         val member = this.getPlaygroundMember(tokenRequest.getAccessToken());
         member.setAccessToken(tokenRequest.getAccessToken());
@@ -44,7 +43,7 @@ public class PlaygroundAuthService {
         return response.getBody();
     }
 
-    private AuthResponse.PlaygroundResponse getPlaygroundMember(String accessToken) {
+    private PlaygroundAuthInfo.PlaygroundMain getPlaygroundMember(String accessToken) {
         val getUserURL = baseURI + "/internal/api/v1/members/me";
 
         val headers = new HttpHeaders();
@@ -57,10 +56,27 @@ public class PlaygroundAuthService {
                 getUserURL,
                 HttpMethod.GET,
                 entity,
-                AuthResponse.PlaygroundResponse.class
+                PlaygroundAuthInfo.PlaygroundMain.class
         );
         return response.getBody();
     }
 
+    private PlaygroundAuthInfo.PlaygroundProfile getPlaygroundMemberProfile(String accessToken) {
+        val getUserURL = baseURI + "/internal/api/v1/members/profile/me";
+
+        val headers = new HttpHeaders();
+        headers.add("content-type", "application/json;charset=UTF-8");
+        headers.add("Authorization", accessToken);
+
+        val entity = new HttpEntity(null, headers);
+
+        val response = restTemplate.exchange(
+                getUserURL,
+                HttpMethod.GET,
+                entity,
+                PlaygroundAuthInfo.PlaygroundProfile.class
+        );
+        return response.getBody();
+    }
 
 }

--- a/src/main/java/org/sopt/app/application/user/UserService.java
+++ b/src/main/java/org/sopt/app/application/user/UserService.java
@@ -5,11 +5,11 @@ import static org.sopt.app.common.ResponseCode.INVALID_REQUEST;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.sopt.app.application.auth.PlaygroundAuthInfo;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.EntityNotFoundException;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.interfaces.postgres.UserRepository;
-import org.sopt.app.presentation.auth.AuthResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +20,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public UserInfo.Id loginWithUserPlaygroundId(AuthResponse.PlaygroundResponse playgroundMemberResponse) {
+    public UserInfo.Id loginWithUserPlaygroundId(PlaygroundAuthInfo.PlaygroundMain playgroundMemberResponse) {
         val registeredUser = userRepository.findUserByPlaygroundId(playgroundMemberResponse.getId());
 
         if (registeredUser.isPresent()) {

--- a/src/main/java/org/sopt/app/common/config/WebSecurityConfig.java
+++ b/src/main/java/org/sopt/app/common/config/WebSecurityConfig.java
@@ -4,11 +4,8 @@ import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.auth.JwtTokenService;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.firewall.DefaultHttpFirewall;
@@ -42,9 +39,10 @@ public class WebSecurityConfig {
                 .csrf().disable()
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                .antMatchers("/api/v2/health/**").permitAll()
                 .antMatchers(SwaggerPatterns).permitAll()
+                .antMatchers("/api/v2/health/**").permitAll()
                 .antMatchers("/api/v2/auth/**").permitAll()
+                .antMatchers("/api/v2/config/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter,

--- a/src/main/java/org/sopt/app/domain/enums/UserStatus.java
+++ b/src/main/java/org/sopt/app/domain/enums/UserStatus.java
@@ -1,0 +1,7 @@
+package org.sopt.app.domain.enums;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE,
+    UNAUTHENTICATED
+}

--- a/src/main/java/org/sopt/app/presentation/auth/AuthResponse.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthResponse.java
@@ -10,19 +10,6 @@ public class AuthResponse {
     @Getter
     @Setter
     @ToString
-    public static class PlaygroundResponse {
-
-        private Long id;
-        private String name;
-        private Long generation;
-        private String profileImage;
-        private Boolean hasProfile;
-        private String accessToken;
-    }
-
-    @Getter
-    @Setter
-    @ToString
     public static class LoginResponse {
 
         private Long userId;
@@ -38,7 +25,6 @@ public class AuthResponse {
         private String accessToken;
         @Schema(description = "앱 서버 RefreshToken", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMiIsImV4cCI6MTY4MDAxNDQzNn0.asdfasdfasdfasdfasdfasdf")
         private String refreshToken;
-
         @Schema(description = "플레이그라운드 AccessToken", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMiIsImV4cCI6MTY4MDAxNDQzNn0.asdfasdfasdfasdfasdfasdf")
         private String playgroundToken;
     }

--- a/src/main/java/org/sopt/app/presentation/config/ConfigController.java
+++ b/src/main/java/org/sopt/app/presentation/config/ConfigController.java
@@ -1,0 +1,26 @@
+package org.sopt.app.presentation.config;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.presentation.config.ConfigResponse.Availability;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/config")
+public class ConfigController {
+
+    @Value("${makers.app.url.is-available}")
+    private Boolean isAvailable;
+
+    @Operation(summary = "앱 메인 뷰 분기 처리")
+    @GetMapping(value = "/availability")
+    public ResponseEntity<ConfigResponse.Availability> getUserInfo() {
+        return ResponseEntity.status(HttpStatus.OK).body(Availability.builder().isAvailable(isAvailable).build());
+    }
+}

--- a/src/main/java/org/sopt/app/presentation/config/ConfigResponse.java
+++ b/src/main/java/org/sopt/app/presentation/config/ConfigResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.app.presentation.config;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+public class ConfigResponse {
+
+    @Getter
+    @Builder
+    @ToString
+    public static class Availability {
+
+        private Boolean isAvailable;
+
+    }
+}

--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -65,7 +65,7 @@ public class UserController {
     }
 
     @Operation(summary = "한마디 편집")
-    @PatchMapping("/profileMessage")
+    @PatchMapping("/profile-message")
     public ResponseEntity<UserResponse.ProfileMessage> editProfileMessage(
             @AuthenticationPrincipal User user,
             @RequestBody RankRequest.EditProfileMessageRequest editProfileMessageRequest

--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -2,7 +2,6 @@ package org.sopt.app.presentation.user;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.application.user.UserService;
@@ -31,17 +30,6 @@ public class UserController {
     @GetMapping(value = "")
     public ResponseEntity<UserResponse.AppUser> getUserInfo(@AuthenticationPrincipal User user) {
         val response = userResponseMapper.ofAppUser(user);
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
-    @Operation(summary = "메인 뷰 조회")
-    @GetMapping(value = "/main")
-    public ResponseEntity<UserResponse.Main> getMainViewInfo(@AuthenticationPrincipal User user) {
-        // TODO: 추후 플그쪽 조회해서 제공해야 함
-        val dummyUser = UserResponse.User.builder().status("ACTIVE").name("김솝트").profileImage("")
-                .generationList(List.of(32L, 30L, 29L)).build();
-        val dummyOperation = UserResponse.Operation.builder().announcement("공지다!").attendanceScore(2D).build();
-        val response = userResponseMapper.ofMainView(dummyUser, dummyOperation);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
@@ -2,13 +2,11 @@ package org.sopt.app.presentation.user;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.application.auth.PlaygroundAuthService;
 import org.sopt.app.application.user.UserService;
 import org.sopt.app.domain.entity.User;
-import org.sopt.app.presentation.user.UserResponse.Main;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,13 +26,14 @@ public class UserOriginalController {
 
     @Operation(summary = "메인 뷰 조회")
     @GetMapping(value = "/main")
-    public ResponseEntity<Main> getMainViewInfo(@AuthenticationPrincipal User user) {
+    public ResponseEntity<?> getMainViewInfo(@AuthenticationPrincipal User user) {
         // TODO: 추후 플그쪽 조회해서 제공해야 함
-        val dummyUser = UserResponse.User.builder().status("ACTIVE").name("김솝트").profileImage("")
-                .generationList(List.of(32L, 30L, 29L)).build();
-        val dummyOperation = UserResponse.Operation.builder().announcement("공지다!").attendanceScore(2D).build();
-        val response = userResponseMapper.ofMainView(dummyUser, dummyOperation);
-        return ResponseEntity.status(HttpStatus.OK).body(response);
+        val mainViewUser = playgroundAuthService.getPlaygroundUserForMainView(user.getPlaygroundToken());
+//        val dummyUser = UserResponse.User.builder().status("ACTIVE").name("김솝트").profileImage("")
+//                .generationList(List.of(32L, 30L, 29L)).build();
+//        val dummyOperation = UserResponse.Operation.builder().announcement("공지다!").attendanceScore(2D).build();
+//        val response = userResponseMapper.ofMainView(dummyUser, dummyOperation);
+        return ResponseEntity.status(HttpStatus.OK).body(mainViewUser);
     }
 
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
@@ -1,0 +1,40 @@
+package org.sopt.app.presentation.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.app.application.auth.PlaygroundAuthService;
+import org.sopt.app.application.user.UserService;
+import org.sopt.app.domain.entity.User;
+import org.sopt.app.presentation.user.UserResponse.Main;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/user")
+@SecurityRequirement(name = "Authorization")
+public class UserOriginalController {
+
+    private final UserService userService;
+    private final PlaygroundAuthService playgroundAuthService;
+    private final UserResponseMapper userResponseMapper;
+
+    @Operation(summary = "메인 뷰 조회")
+    @GetMapping(value = "/main")
+    public ResponseEntity<Main> getMainViewInfo(@AuthenticationPrincipal User user) {
+        // TODO: 추후 플그쪽 조회해서 제공해야 함
+        val dummyUser = UserResponse.User.builder().status("ACTIVE").name("김솝트").profileImage("")
+                .generationList(List.of(32L, 30L, 29L)).build();
+        val dummyOperation = UserResponse.Operation.builder().announcement("공지다!").attendanceScore(2D).build();
+        val response = userResponseMapper.ofMainView(dummyUser, dummyOperation);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+}

--- a/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.application.auth.PlaygroundAuthService;
-import org.sopt.app.application.user.UserService;
 import org.sopt.app.domain.entity.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,20 +19,16 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "Authorization")
 public class UserOriginalController {
 
-    private final UserService userService;
     private final PlaygroundAuthService playgroundAuthService;
     private final UserResponseMapper userResponseMapper;
 
     @Operation(summary = "메인 뷰 조회")
     @GetMapping(value = "/main")
-    public ResponseEntity<?> getMainViewInfo(@AuthenticationPrincipal User user) {
-        // TODO: 추후 플그쪽 조회해서 제공해야 함
+    public ResponseEntity<UserResponse.Main> getMainViewInfo(@AuthenticationPrincipal User user) {
         val mainViewUser = playgroundAuthService.getPlaygroundUserForMainView(user.getPlaygroundToken());
-//        val dummyUser = UserResponse.User.builder().status("ACTIVE").name("김솝트").profileImage("")
-//                .generationList(List.of(32L, 30L, 29L)).build();
-//        val dummyOperation = UserResponse.Operation.builder().announcement("공지다!").attendanceScore(2D).build();
-//        val response = userResponseMapper.ofMainView(dummyUser, dummyOperation);
-        return ResponseEntity.status(HttpStatus.OK).body(mainViewUser);
+        val dummyOperation = UserResponse.Operation.builder().announcement("공지다!").attendanceScore(2D).build();
+        val response = userResponseMapper.ofMainView(mainViewUser, dummyOperation);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
@@ -3,6 +3,7 @@ package org.sopt.app.presentation.user;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
+import org.sopt.app.application.auth.PlaygroundAuthInfo;
 import org.sopt.app.application.user.UserInfo;
 import org.sopt.app.domain.entity.User;
 
@@ -15,7 +16,7 @@ public interface UserResponseMapper {
 
     UserResponse.AppUser ofAppUser(User user);
 
-    UserResponse.Main ofMainView(UserResponse.User user, UserResponse.Operation operation);
+    UserResponse.Main ofMainView(PlaygroundAuthInfo.MainView user, UserResponse.Operation operation);
 
     UserResponse.Soptamp ofSoptamp(User user);
 


### PR DESCRIPTION
## 📝 PR Summary
앱 메인 뷰 클라 작업을 위해 플레이그라운드 먼저 연동했습니다!
앱 메인 뷰 작업에 필요한 분기 데이터와 활동 기수 데이터를 생성하고, 분기 데이터를 조회하는 API를 작성했습니다.
앱 메인 뷰 API에 스프린트 1 이내에 운영팀으로부터 출석점수 조회 API를 제공받은 뒤 한 차례 수정이 있을 예정이며, 현재 더미 데이터를 제공 중입니다.
추가로 간단한 API 엔드포인트 변경이 있었습니다.

#### 🌵 Working Branch
feature/userOriginal

#### 🌴 Works
- [x] 앱 메인 분기 데이터
- [x] 활동 기수 데이터
- [x] 앱 메인 분기 데이터 조회 API
- [x] 유저 메인 뷰 API
- [x] 엔드포인트 변경 (REST API URI 규칙)


#### 🌱 Related Issue
#51 