### PR TITLE
feature: 클라, 운영팀 요구사항 반영

### DIFF
--- a/src/main/java/org/sopt/app/application/auth/JwtTokenService.java
+++ b/src/main/java/org/sopt/app/application/auth/JwtTokenService.java
@@ -37,13 +37,14 @@ public class JwtTokenService {
         return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
     }
 
-    public PlaygroundAuthInfo.AppToken issueNewTokens(UserInfo.Id userId) {
-        val accessToken = this.encodeJwtToken(userId);
+    public PlaygroundAuthInfo.AppToken issueNewTokens(UserInfo.Id userId,
+            PlaygroundAuthInfo.PlaygroundMain playgroundMember) {
+        val accessToken = this.encodeJwtToken(userId, playgroundMember.getId());
         val refreshToken = this.encodeJwtRefreshToken(userId);
         return AppToken.builder().accessToken(accessToken).refreshToken(refreshToken).build();
     }
 
-    private String encodeJwtToken(UserInfo.Id userId) {
+    private String encodeJwtToken(UserInfo.Id userId, Long playgroundId) {
         val now = LocalDateTime.now();
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
@@ -52,6 +53,7 @@ public class JwtTokenService {
                 .setSubject(userId.getId().toString())
                 .setExpiration(now.plusDays(1).toDate())
                 .claim("id", userId.getId())
+                .claim("playgroundId", playgroundId)
                 .claim("roles", "USER")
                 .signWith(getSigningKey(JWT_SECRET), SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/java/org/sopt/app/application/auth/JwtTokenService.java
+++ b/src/main/java/org/sopt/app/application/auth/JwtTokenService.java
@@ -64,7 +64,7 @@ public class JwtTokenService {
         return Jwts.builder()
                 .setIssuedAt(now.toDate())
                 .setSubject(userId.getId().toString())
-                .setExpiration(now.plusDays(14).toDate())
+                .setExpiration(now.plusDays(30).toDate())
                 .claim("id", userId.getId())
                 .claim("roles", "USER")
                 .signWith(getSigningKey(JWT_SECRET), SignatureAlgorithm.HS256)

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -89,4 +89,21 @@ public class PlaygroundAuthInfo {
         private String profileImage;
         private List<Long> generationList;
     }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class AccessToken {
+
+        private String accessToken;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class RefreshedToken {
+
+        private String accessToken;
+        private String errorCode;
+    }
 }

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -37,6 +37,7 @@ public class PlaygroundAuthInfo {
         private String profileImage;
         private Boolean hasProfile;
         private String accessToken;
+        private UserStatus status;
     }
 
     @Getter

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
@@ -41,7 +41,7 @@ public class PlaygroundAuthService {
         return member;
     }
 
-    public PlaygroundAuthInfo.AccessToken getPlaygroundAccessToken(AuthRequest.CodeRequest codeRequest) {
+    public AuthRequest.AccessTokenRequest getPlaygroundAccessToken(AuthRequest.CodeRequest codeRequest) {
         val getTokenURL = baseURI + "/api/v1/idp/sso/auth";
 
         val headers = new HttpHeaders();
@@ -53,7 +53,7 @@ public class PlaygroundAuthService {
                 getTokenURL,
                 HttpMethod.POST,
                 entity,
-                PlaygroundAuthInfo.AccessToken.class
+                AuthRequest.AccessTokenRequest.class
         );
         return response.getBody();
     }

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.sopt.app.common.exception.UnauthorizedException;
+import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.enums.UserStatus;
 import org.sopt.app.presentation.auth.AuthRequest;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +13,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException.BadRequest;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -86,13 +89,17 @@ public class PlaygroundAuthService {
 
         val entity = new HttpEntity(tokenRequest, headers);
 
-        val response = restTemplate.exchange(
-                getTokenURL,
-                HttpMethod.POST,
-                entity,
-                PlaygroundAuthInfo.RefreshedToken.class
-        );
-        return response.getBody();
+        try {
+            val response = restTemplate.exchange(
+                    getTokenURL,
+                    HttpMethod.POST,
+                    entity,
+                    PlaygroundAuthInfo.RefreshedToken.class
+            );
+            return response.getBody();
+        } catch (BadRequest badRequest) {
+            throw new UnauthorizedException(ErrorCode.INVALID_PLAYGROUND_TOKEN.getMessage());
+        }
     }
 
     public PlaygroundAuthInfo.MainView getPlaygroundUserForMainView(String accessToken) {

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
@@ -25,14 +25,17 @@ public class PlaygroundAuthService {
 
     private RestTemplate restTemplate = new RestTemplate();
 
-    public PlaygroundAuthInfo.PlaygroundMain getPlaygroundInfo(AuthRequest.CodeRequest codeRequest) {
-        val tokenRequest = this.getPlaygroundAccessToken(codeRequest);
+    public PlaygroundAuthInfo.PlaygroundMain getPlaygroundInfo(AuthRequest.AccessTokenRequest tokenRequest) {
         val member = this.getPlaygroundMember(tokenRequest.getAccessToken());
+        val playgroundProfile = this.getPlaygroundMemberProfile(tokenRequest.getAccessToken());
+        val generationList = playgroundProfile.getActivities().stream()
+                .map(activity -> activity.getCardinalActivities().get(0).getGeneration()).collect(Collectors.toList());
         member.setAccessToken(tokenRequest.getAccessToken());
+        member.setStatus(this.getStatus(generationList));
         return member;
     }
 
-    private AuthRequest.AccessTokenRequest getPlaygroundAccessToken(AuthRequest.CodeRequest codeRequest) {
+    public AuthRequest.AccessTokenRequest getPlaygroundAccessToken(AuthRequest.CodeRequest codeRequest) {
         val getTokenURL = baseURI + "/api/v1/idp/sso/auth";
 
         val headers = new HttpHeaders();
@@ -68,7 +71,7 @@ public class PlaygroundAuthService {
     }
 
     public PlaygroundAuthInfo.MainView getPlaygroundUserForMainView(String accessToken) {
-        val playgroundProfile = getPlaygroundMemberProfile(accessToken);
+        val playgroundProfile = this.getPlaygroundMemberProfile(accessToken);
         val generationList = playgroundProfile.getActivities().stream()
                 .map(activity -> activity.getCardinalActivities().get(0).getGeneration()).collect(Collectors.toList());
         val mainViewUser = PlaygroundAuthInfo.MainViewUser.builder()

--- a/src/main/java/org/sopt/app/application/user/UserService.java
+++ b/src/main/java/org/sopt/app/application/user/UserService.java
@@ -92,6 +92,8 @@ public class UserService {
     public AuthRequest.AccessTokenRequest getPlaygroundToken(UserInfo.Id userId) {
         val user = userRepository.findUserById(userId.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
-        return AuthRequest.AccessTokenRequest.builder().accessToken(user.getPlaygroundToken()).build();
+        val token = new AuthRequest.AccessTokenRequest();
+        token.setAccessToken(user.getPlaygroundToken());
+        return token;
     }
 }

--- a/src/main/java/org/sopt/app/application/user/UserService.java
+++ b/src/main/java/org/sopt/app/application/user/UserService.java
@@ -1,13 +1,12 @@
 package org.sopt.app.application.user;
 
 import static org.sopt.app.common.ResponseCode.ENTITY_NOT_FOUND;
-import static org.sopt.app.common.ResponseCode.INVALID_REQUEST;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.application.auth.PlaygroundAuthInfo;
-import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.EntityNotFoundException;
+import org.sopt.app.common.exception.ExistUserException;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.interfaces.postgres.UserRepository;
 import org.springframework.stereotype.Service;
@@ -58,13 +57,16 @@ public class UserService {
         return username + Math.round(Math.random() * 10000);
     }
 
-    @Transactional
-    public UserInfo.Nickname editNickname(User user, String nickname) {
+    @Transactional(readOnly = true)
+    public void checkUserNickname(String nickname) {
         val nicknameUser = userRepository.findUserByNickname(nickname);
         if (nicknameUser.isPresent()) {
-            throw new BadRequestException(INVALID_REQUEST);
+            throw new ExistUserException("사용 중인 닉네임입니다.");
         }
+    }
 
+    @Transactional
+    public UserInfo.Nickname editNickname(User user, String nickname) {
         user.editNickname(nickname);
         userRepository.save(user);
         return UserInfo.Nickname.builder().nickname(nickname).build();

--- a/src/main/java/org/sopt/app/application/user/UserService.java
+++ b/src/main/java/org/sopt/app/application/user/UserService.java
@@ -9,6 +9,7 @@ import org.sopt.app.common.exception.EntityNotFoundException;
 import org.sopt.app.common.exception.ExistUserException;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.interfaces.postgres.UserRepository;
+import org.sopt.app.presentation.auth.AuthRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -88,9 +89,9 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public String getPlaygroundToken(UserInfo.Id userId) {
+    public AuthRequest.AccessTokenRequest getPlaygroundToken(UserInfo.Id userId) {
         val user = userRepository.findUserById(userId.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
-        return user.getPlaygroundToken();
+        return AuthRequest.AccessTokenRequest.builder().accessToken(user.getPlaygroundToken()).build();
     }
 }

--- a/src/main/java/org/sopt/app/common/config/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/app/common/config/JwtAuthenticationFilter.java
@@ -8,8 +8,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.auth.JwtTokenService;
-import org.sopt.app.common.ResponseCode;
 import org.sopt.app.common.exception.UnauthorizedException;
+import org.sopt.app.common.response.ErrorCode;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                 Authentication authentication = jwtTokenService.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } else {
-                throw new UnauthorizedException(ResponseCode.UNAUTHORIZED);
+                throw new UnauthorizedException(ErrorCode.INVALID_APP_TOKEN.getMessage());
             }
         }
         chain.doFilter(request, response);

--- a/src/main/java/org/sopt/app/common/config/JwtExceptionFilter.java
+++ b/src/main/java/org/sopt/app/common/config/JwtExceptionFilter.java
@@ -7,9 +7,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import org.sopt.app.common.ResponseCode;
 import org.sopt.app.common.exception.UnauthorizedException;
+import org.sopt.app.common.response.CommonResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -32,7 +31,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
             httpServletResponse.setCharacterEncoding("UTF-8");
             objectMapper.writeValue(httpServletResponse.getWriter(),
-                    new UnauthorizedException(ResponseCode.UNAUTHORIZED));
+                    CommonResponse.onFailure(e.getStatusCode(), e.getMessage()));
         }
     }
 }

--- a/src/main/java/org/sopt/app/common/exception/BaseException.java
+++ b/src/main/java/org/sopt/app/common/exception/BaseException.java
@@ -1,0 +1,25 @@
+package org.sopt.app.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    HttpStatus statusCode;
+    String responseMessage;
+
+    public BaseException() {
+    }
+
+    public BaseException(HttpStatus statusCode) {
+        super();
+        this.statusCode = statusCode;
+    }
+
+    public BaseException(HttpStatus statusCode, String responseMessage) {
+        super(responseMessage);
+        this.statusCode = statusCode;
+        this.responseMessage = responseMessage;
+    }
+}

--- a/src/main/java/org/sopt/app/common/exception/UnauthorizedException.java
+++ b/src/main/java/org/sopt/app/common/exception/UnauthorizedException.java
@@ -1,20 +1,14 @@
 package org.sopt.app.common.exception;
 
-import lombok.Getter;
-import org.sopt.app.common.ResponseCode;
 import org.springframework.http.HttpStatus;
 
-public class UnauthorizedException extends RuntimeException {
+public class UnauthorizedException extends BaseException {
 
+    public UnauthorizedException() {
+        super(HttpStatus.UNAUTHORIZED);
+    }
 
-    @Getter
-    private final String resultCode;
-    @Getter
-    private final HttpStatus httpStatus;
-
-    public UnauthorizedException(ResponseCode responseCode) {
-        super("[" + responseCode.getResponseCode() + "] " + responseCode.getMessage());
-        this.resultCode = responseCode.getResponseCode();
-        this.httpStatus = responseCode.getHttpStatus();
+    public UnauthorizedException(String message) {
+        super(HttpStatus.UNAUTHORIZED, message);
     }
 }

--- a/src/main/java/org/sopt/app/common/response/CommonControllerAdvice.java
+++ b/src/main/java/org/sopt/app/common/response/CommonControllerAdvice.java
@@ -1,0 +1,24 @@
+package org.sopt.app.common.response;
+
+import org.sopt.app.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class CommonControllerAdvice {
+
+    @ExceptionHandler(value = BaseException.class)
+    public ResponseEntity onKnownException(BaseException baseException) {
+        return new ResponseEntity<>(CommonResponse.onFailure(baseException.getStatusCode(),
+                baseException.getResponseMessage()), null, baseException.getStatusCode());
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity onException(Exception exception) {
+        exception.printStackTrace();
+        return new ResponseEntity<>(CommonResponse.onFailure(HttpStatus.INTERNAL_SERVER_ERROR,
+                "서버 에러가 발생했습니다."), null, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/sopt/app/common/response/CommonResponse.java
+++ b/src/main/java/org/sopt/app/common/response/CommonResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.app.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponse<T> {
+
+    HttpStatus statusCode;
+    String responseMessage;
+
+    public static CommonResponse onFailure(HttpStatus statusCode, String responseMessage) {
+        return new CommonResponse<>(statusCode, responseMessage);
+    }
+}

--- a/src/main/java/org/sopt/app/common/response/ErrorCode.java
+++ b/src/main/java/org/sopt/app/common/response/ErrorCode.java
@@ -1,0 +1,18 @@
+package org.sopt.app.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // COMMON
+    INVALID_PARAMETER("잘못된 파라미터 입니다."),
+
+    // TOKEN
+    INVALID_APP_TOKEN("유효하지 않은 앱 토큰입니다."),
+    INVALID_PLAYGROUND_TOKEN("유효하지 않은 플레이그라운드 토큰입니다.");
+
+    private final String message;
+}

--- a/src/main/java/org/sopt/app/presentation/auth/AuthController.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     @PostMapping(value = "/playground")
     public ResponseEntity<AuthResponse.Token> playgroundLogin(@RequestBody AuthRequest.CodeRequest codeRequest) {
         val playgroundToken = playgroundAuthService.getPlaygroundAccessToken(codeRequest);
-        val playgroundMember = playgroundAuthService.getPlaygroundInfo(playgroundToken);
+        val playgroundMember = playgroundAuthService.getPlaygroundInfo(playgroundToken.getAccessToken());
         val userId = userService.loginWithUserPlaygroundId(playgroundMember);
 
         val appToken = jwtTokenService.issueNewTokens(userId, playgroundMember);
@@ -42,8 +42,9 @@ public class AuthController {
     @PatchMapping(value = "/refresh")
     public ResponseEntity<AuthResponse.Token> refreshToken(@RequestBody AuthRequest.RefreshRequest refreshRequest) {
         val userId = jwtTokenService.getUserIdFromJwtToken(refreshRequest.getRefreshToken());
-        val playgroundToken = userService.getPlaygroundToken(userId);
-        val playgroundMember = playgroundAuthService.getPlaygroundInfo(playgroundToken);
+        val existingToken = userService.getPlaygroundToken(userId);
+        val playgroundToken = playgroundAuthService.refreshPlaygroundToken(existingToken);
+        val playgroundMember = playgroundAuthService.getPlaygroundInfo(playgroundToken.getAccessToken());
 
         val appToken = jwtTokenService.issueNewTokens(userId, playgroundMember);
         val response = authResponseMapper.of(appToken.getAccessToken(), appToken.getRefreshToken(),

--- a/src/main/java/org/sopt/app/presentation/auth/AuthController.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
         val playgroundMember = playgroundAuthService.getPlaygroundInfo(codeRequest);
         val userId = userService.loginWithUserPlaygroundId(playgroundMember);
 
-        val appToken = jwtTokenService.issueNewTokens(userId);
+        val appToken = jwtTokenService.issueNewTokens(userId, playgroundMember);
         val response = authResponseMapper.of(appToken.getAccessToken(), appToken.getRefreshToken(),
                 playgroundMember.getAccessToken());
         return ResponseEntity.status(HttpStatus.OK).body(response);
@@ -45,7 +45,7 @@ public class AuthController {
         val playgroundToken = userService.getPlaygroundToken(userId);
         // TODO: 플레이그라운드 토큰 갱신 playgroundAuthService
 
-        val appToken = jwtTokenService.issueNewTokens(userId);
+        val appToken = jwtTokenService.issueNewTokens(userId, null);
         val response = authResponseMapper.of(appToken.getAccessToken(), appToken.getRefreshToken(), playgroundToken);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/sopt/app/presentation/auth/AuthController.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthController.java
@@ -28,7 +28,8 @@ public class AuthController {
     @Operation(summary = "플그로 로그인/회원가입")
     @PostMapping(value = "/playground")
     public ResponseEntity<AuthResponse.Token> playgroundLogin(@RequestBody AuthRequest.CodeRequest codeRequest) {
-        val playgroundToken = playgroundAuthService.getPlaygroundAccessToken(codeRequest);
+        val temporaryToken = playgroundAuthService.getPlaygroundAccessToken(codeRequest);
+        val playgroundToken = playgroundAuthService.refreshPlaygroundToken(temporaryToken);
         val playgroundMember = playgroundAuthService.getPlaygroundInfo(playgroundToken.getAccessToken());
         val userId = userService.loginWithUserPlaygroundId(playgroundMember);
 

--- a/src/main/java/org/sopt/app/presentation/auth/AuthRequest.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthRequest.java
@@ -1,6 +1,7 @@
 package org.sopt.app.presentation.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -17,7 +18,7 @@ public class AuthRequest {
     }
 
     @Getter
-    @Setter
+    @Builder
     @ToString
     public static class AccessTokenRequest {
 

--- a/src/main/java/org/sopt/app/presentation/auth/AuthRequest.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthRequest.java
@@ -1,7 +1,6 @@
 package org.sopt.app.presentation.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -18,7 +17,7 @@ public class AuthRequest {
     }
 
     @Getter
-    @Builder
+    @Setter
     @ToString
     public static class AccessTokenRequest {
 

--- a/src/main/java/org/sopt/app/presentation/auth/AuthResponse.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.sopt.app.domain.enums.UserStatus;
 
 public class AuthResponse {
 
@@ -27,5 +28,8 @@ public class AuthResponse {
         private String refreshToken;
         @Schema(description = "플레이그라운드 AccessToken", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMiIsImV4cCI6MTY4MDAxNDQzNn0.asdfasdfasdfasdfasdfasdf")
         private String playgroundToken;
+
+        @Schema(description = "활동 기수 여부", example = "ACTIVE")
+        private UserStatus status;
     }
 }

--- a/src/main/java/org/sopt/app/presentation/auth/AuthResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/auth/AuthResponseMapper.java
@@ -3,6 +3,7 @@ package org.sopt.app.presentation.auth;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
+import org.sopt.app.domain.enums.UserStatus;
 
 @Mapper(
         componentModel = "spring",
@@ -11,5 +12,5 @@ import org.mapstruct.ReportingPolicy;
 )
 public interface AuthResponseMapper {
 
-    AuthResponse.Token of(String accessToken, String refreshToken, String playgroundToken);
+    AuthResponse.Token of(String accessToken, String refreshToken, String playgroundToken, UserStatus status);
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -44,9 +44,7 @@ public class UserController {
     @Operation(summary = "닉네임 중복 검사")
     @GetMapping(value = "/nickname/{nickname}")
     public ResponseEntity<UserResponse.AppUser> validateUserNickname(@PathVariable String nickname) {
-        System.out.println(nickname);
         userService.checkUserNickname(nickname);
-        System.out.println("check");
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 

--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,6 +39,15 @@ public class UserController {
     public ResponseEntity<UserResponse.Soptamp> getSoptampInfo(@AuthenticationPrincipal User user) {
         val response = userResponseMapper.ofSoptamp(user);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "닉네임 중복 검사")
+    @GetMapping(value = "/nickname/{nickname}")
+    public ResponseEntity<UserResponse.AppUser> validateUserNickname(@PathVariable String nickname) {
+        System.out.println(nickname);
+        userService.checkUserNickname(nickname);
+        System.out.println("check");
+        return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 
     @Operation(summary = "닉네임 변경")


### PR DESCRIPTION
## 📝 PR Summary
API 1차 배포 이후, 클라이언트와 운영팀 요구사항을 반영하였습니다.
아래 요구사항을 진행하려면 플그에서 활동 기수와 유저 아이디를 얻어 오는 작업이 필요하여, 플그 토큰을 리프레시하는 로직까지 함께 작업하게 되었습니다!
플레이그라운드 측에 토큰 교환을 요청했으나 실패한 경우 401을 뱉어 앱에서 플그 재로그인을 요청할 예정입니다.
추가로 현재 코드에는 에러 처리 방식이 혼용 되고 있으나 추후 하나로 통일하는 작업을 거칠 예정입니다!
지금은 조금 난잡해도 너그러이 봐주시면 감사하겠습니당

앱팀 요구사항
- 로그인 시 분기 처리 위한 활동 기수 여부 추가
- 닉네임 중복 검사 로직 API로 분리
- rT 한 달로 연장

운영팀 요구사항
- 토큰에 플레이그라운드 아이디 추가

#### 🌵 Working Branch
feature/requirements

#### 🌴 Works
- [x] 토큰에 playground id 추가
- [x] 닉네임 중복 검사 API 생성
- [x] 활동 기수 여부 추가
- [x] rT 1달로 연장
- [x] 플그 리프레시
- [x] 플그 최초 로그인 토큰 유효기간
- [x] 플그 400 재로그인 로직

#### 🌱 Related Issue
#53 
