### PR TITLE
Feat/#80 active user ranking

### DIFF
--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -1,5 +1,6 @@
 package org.sopt.app.application.auth;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -111,7 +112,8 @@ public class PlaygroundAuthInfo {
     @Setter
     @ToString
     public static class ActiveUserIds {
-        private List<Long> memberIds;
+        @JsonProperty("memberIds")
+        private List<Long> userIds;
     }
 
     @Getter

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -106,4 +106,11 @@ public class PlaygroundAuthInfo {
         private String accessToken;
         private String errorCode;
     }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class ActiveUserIds {
+        private List<Long> memberIds;
+    }
 }

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -113,4 +113,13 @@ public class PlaygroundAuthInfo {
     public static class ActiveUserIds {
         private List<Long> memberIds;
     }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class UserActiveInfo {
+        private Long currentGeneration;
+        private UserStatus status;
+    }
 }

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
@@ -149,4 +149,26 @@ public class PlaygroundAuthService {
         }
     }
 
+
+    public PlaygroundAuthInfo.ActiveUserIds getActiveUsers(String accessToken) {
+        val getActiveUserIds = baseURI + "/internal/api/v1/members/latest" + "?generation=" + currentGeneration;
+
+        val headers = new HttpHeaders();
+        headers.add("content-type", "application/json;charset=UTF-8");
+        headers.add("Authorization", accessToken);
+
+        val entity = new HttpEntity(null, headers);
+
+        try{
+            val response = restTemplate.exchange(
+                getActiveUserIds,
+                HttpMethod.GET,
+                entity,
+                PlaygroundAuthInfo.ActiveUserIds.class
+            );
+            return response.getBody();
+        } catch (BadRequest e) {
+            throw new BadRequestException(ErrorCode.PLAYGROUND_PROFILE_NOT_EXISTS.getMessage());
+        }
+    }
 }

--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthService.java
@@ -151,7 +151,7 @@ public class PlaygroundAuthService {
 
 
     public PlaygroundAuthInfo.ActiveUserIds getActiveUsers(String accessToken) {
-        val getActiveUserIds = baseURI + "/internal/api/v1/members/latest" + "?generation=" + currentGeneration;
+        val getActiveUserIdsURL = baseURI + "/internal/api/v1/members/latest" + "?generation=" + currentGeneration;
 
         val headers = new HttpHeaders();
         headers.add("content-type", "application/json;charset=UTF-8");
@@ -161,7 +161,7 @@ public class PlaygroundAuthService {
 
         try{
             val response = restTemplate.exchange(
-                getActiveUserIds,
+                getActiveUserIdsURL,
                 HttpMethod.GET,
                 entity,
                 PlaygroundAuthInfo.ActiveUserIds.class
@@ -170,5 +170,16 @@ public class PlaygroundAuthService {
         } catch (BadRequest e) {
             throw new BadRequestException(ErrorCode.PLAYGROUND_PROFILE_NOT_EXISTS.getMessage());
         }
+    }
+
+    public PlaygroundAuthInfo.UserActiveInfo getPlaygroundUserActiveInfo(String accessToken) {
+        val playgroundProfile = this.getPlaygroundMemberProfile(accessToken);
+        val generationList = playgroundProfile.getActivities().stream()
+            .map(activity -> activity.getCardinalActivities().get(0).getGeneration()).toList();
+        val userStatus = this.getStatus(generationList);
+        return PlaygroundAuthInfo.UserActiveInfo.builder()
+                .status(userStatus)
+                .currentGeneration(currentGeneration)
+                .build();
     }
 }

--- a/src/main/java/org/sopt/app/application/rank/RankService.java
+++ b/src/main/java/org/sopt/app/application/rank/RankService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.application.auth.PlaygroundAuthInfo.ActiveUserIds;
+import org.sopt.app.application.rank.RankInfo.Main;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.User;
@@ -21,16 +22,7 @@ public class RankService {
 
     public List<RankInfo.Main> findRanks() {
         val userList = userRepository.findAll();
-        val rankPoint = new AtomicInteger(1);
-        return userList.stream().sorted(
-                        Comparator.comparing(User::getPoints).reversed())
-                .map(user -> RankInfo.Main.builder()
-                        .rank(rankPoint.getAndIncrement())
-                        .nickname(user.getNickname())
-                        .point(user.getPoints())
-                        .profileMessage(user.getProfileMessage())
-                        .build())
-                .collect(Collectors.toList());
+        return this.getRanking(userList);
     }
 
     public User findRankByNickname(String nickname) {
@@ -40,16 +32,20 @@ public class RankService {
 
     public List<RankInfo.Main> findCurrentRanks(ActiveUserIds activeUserIds) {
         val userList = userRepository.findAllById(activeUserIds.getMemberIds());
+        return this.getRanking(userList);
+    }
+
+    private List<Main> getRanking(List<User> userList) {
         val rankPoint = new AtomicInteger(1);
         return userList.stream().sorted(
-                        Comparator.comparing(User::getPoints).reversed())
-                .map(user -> RankInfo.Main.builder()
-                        .rank(rankPoint.getAndIncrement())
-                        .nickname(user.getNickname())
-                        .point(user.getPoints())
-                        .profileMessage(user.getProfileMessage())
-                        .build())
-                .collect(Collectors.toList());
+                Comparator.comparing(User::getPoints).reversed())
+            .map(user -> Main.builder()
+                .rank(rankPoint.getAndIncrement())
+                .nickname(user.getNickname())
+                .point(user.getPoints())
+                .profileMessage(user.getProfileMessage())
+                .build())
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/sopt/app/application/rank/RankService.java
+++ b/src/main/java/org/sopt/app/application/rank/RankService.java
@@ -31,7 +31,7 @@ public class RankService {
     }
 
     public List<RankInfo.Main> findCurrentRanks(ActiveUserIds activeUserIds) {
-        val userList = userRepository.findAllByPlaygroundIdIn(activeUserIds.getMemberIds());
+        val userList = userRepository.findAllByPlaygroundIdIn(activeUserIds.getUserIds());
         return this.getRanking(userList);
     }
 

--- a/src/main/java/org/sopt/app/application/rank/RankService.java
+++ b/src/main/java/org/sopt/app/application/rank/RankService.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.sopt.app.application.auth.PlaygroundAuthInfo.ActiveUserIds;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.User;
@@ -36,4 +37,19 @@ public class RankService {
         return userRepository.findUserByNickname(nickname)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND.getMessage()));
     }
+
+    public List<RankInfo.Main> findCurrentRanks(ActiveUserIds activeUserIds) {
+        val userList = userRepository.findAllById(activeUserIds.getMemberIds());
+        val rankPoint = new AtomicInteger(1);
+        return userList.stream().sorted(
+                        Comparator.comparing(User::getPoints).reversed())
+                .map(user -> RankInfo.Main.builder()
+                        .rank(rankPoint.getAndIncrement())
+                        .nickname(user.getNickname())
+                        .point(user.getPoints())
+                        .profileMessage(user.getProfileMessage())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/org/sopt/app/application/rank/RankService.java
+++ b/src/main/java/org/sopt/app/application/rank/RankService.java
@@ -31,7 +31,7 @@ public class RankService {
     }
 
     public List<RankInfo.Main> findCurrentRanks(ActiveUserIds activeUserIds) {
-        val userList = userRepository.findAllById(activeUserIds.getMemberIds());
+        val userList = userRepository.findAllByPlaygroundIdIn(activeUserIds.getMemberIds());
         return this.getRanking(userList);
     }
 

--- a/src/main/java/org/sopt/app/interfaces/postgres/UserRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/UserRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.app.interfaces.postgres;
 
+import java.util.List;
 import java.util.Optional;
 import org.sopt.app.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findUserById(Long userId);
 
     Optional<User> findUserByPlaygroundId(Long playgroundId);
+
+    List<User> findAllByPlaygroundIdIn(List<Long> playgroundIds);
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
@@ -49,4 +49,20 @@ public class UserOriginalController {
         val response = userResponseMapper.ofMainView(mainViewUser, dummyOperation, mainViewNotification);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @Operation(summary = "유저 기수 정보 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "400", description = "no playground, operation profile", content = @Content),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping(value = "/generation")
+    public ResponseEntity<UserResponse.Generation> getGenerationInfo(
+            @AuthenticationPrincipal User user
+    ) {
+        val generationUser = playgroundAuthService.getPlaygroundUserActiveInfo(
+            user.getPlaygroundToken());
+        val response = userResponseMapper.ofGeneration(generationUser);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -117,4 +117,13 @@ public class UserResponse {
         private Boolean newsOptIn;
     }
 
+    @Getter
+    @Builder
+    @ToString
+    public static class Generation {
+        @Schema(description = "현재 솝트 기수", example = "33")
+        private Long currentGeneration;
+        @Schema(description = "활동/비활동/비회원 분기 처리", example = "ACTIVE")
+        private String status;
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
@@ -27,4 +27,6 @@ public interface UserResponseMapper {
     UserResponse.ProfileMessage of(UserInfo.ProfileMessage profileMessage);
 
     UserResponse.OptIn ofOptIn(User user);
+
+    UserResponse.Generation ofGeneration(PlaygroundAuthInfo.UserActiveInfo userActiveInfo);
 }


### PR DESCRIPTION
## 📝 PR Summary
pg internal api를 호출하여 받아온 현재 기수의 멤버 id를 이용해 현재 기수 활동 중인 멤버의 랭킹을 가져오는 api를 추가했습니다.
- PlaygroundAuthService에 현재 기수 멤버 id를 받아오는 restTemplate 통신 메소드를 추가해 놨습니다. -> 향후 통신만 따로 뺄 수도 있습니다.
- RankingService에 현기수 유저 id를 이용해 랭킹을 제공하는 메소드와 모든 멤버 랭킹을 제공하는 메소드에 공통 로직이 있어 분리 했습니다.
```java
    private List<Main> getRanking(List<User> userList) {
        val rankPoint = new AtomicInteger(1);
        return userList.stream().sorted(
                Comparator.comparing(User::getPoints).reversed())
            .map(user -> Main.builder()
                .rank(rankPoint.getAndIncrement())
                .nickname(user.getNickname())
                .point(user.getPoints())
                .profileMessage(user.getProfileMessage())
                .build())
            .collect(Collectors.toList());
    }
```

#### 🌵 Working Branch
feature/#80-active-user-ranking

#### 🌴 Works
- [x] pg internal api 호출 메소드 추가 (현재 활동 기수 멤버 id 리스트)
- [x] 현재 활동 기수 멤버 랭킹 리스트 api 추가


#### 🌱 Related Issue
#80 
