### PR TITLE
Fix/#123 timezone difference

### DIFF
--- a/src/main/java/org/sopt/app/AppApplication.java
+++ b/src/main/java/org/sopt/app/AppApplication.java
@@ -5,6 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @EnableJpaAuditing // JPA Auditing(감시, 감사) 기능을 활성화 하는 어노테이션 createdDate, modifiedDate 저장 활성화
 @EnableAsync
 @SpringBootApplication
@@ -14,4 +17,8 @@ public class AppApplication {
         SpringApplication.run(AppApplication.class, args);
     }
 
+    @PostConstruct
+    void setApplicationTimeZone(){
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }

--- a/src/main/java/org/sopt/app/domain/entity/BaseEntity.java
+++ b/src/main/java/org/sopt/app/domain/entity/BaseEntity.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
@@ -20,13 +21,15 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
-    @JsonFormat(pattern ="yyyy-MM-dd")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern ="yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
 
     @LastModifiedDate
     @Column(name = "updated_at")
-    @JsonFormat(pattern = "yyyy-MM-dd")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/org/sopt/app/domain/entity/Notification.java
+++ b/src/main/java/org/sopt/app/domain/entity/Notification.java
@@ -1,8 +1,5 @@
 package org.sopt.app.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
-import java.time.LocalDateTime;
 import javax.persistence.*;
 
 import lombok.AllArgsConstructor;
@@ -12,10 +9,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.sopt.app.domain.enums.NotificationCategory;
 import org.sopt.app.domain.enums.NotificationType;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Table(name = "notifications", schema = "app_dev")
@@ -23,8 +16,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class Notification{
+public class Notification extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,17 +49,6 @@ public class Notification{
     @Column(nullable = false, name = "is_read")
     @ColumnDefault("false")
     private Boolean isRead;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+9")
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    @DateTimeFormat()
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+9")
-    private LocalDateTime updatedAt;
 
 
     public void updateIsRead() {


### PR DESCRIPTION
## 📝 PR Summary
알림 저장이 계속해서 UTC 시간대로 저장되어
앱 내에서 방금 보낸 알림도 9시간 전으로 표시되는 것을 해결하기 위해
Application 자체 Timezone을 수정했습니다.

#### 🌵 Working Branch
fix/#123-timezone-difference

#### 🌴 Works
- SpringApplication class에서 `@PostConstruct` 로 시간대 직접 지정
- `@EntityListeners(AuditingEntityListener.class)`를 등록한 인터페이스 내 `@JsonFormat`에 timezone 지정
- 직렬화 대비 `@DateTimeFormat`도 등록

```text
// 로그 중
2023-10-04 20:33:46.800 DEBUG 87173 --- [           main] o.hibernate.internal.SessionFactoryImpl  : Instantiating session factory with properties: {hibernate.format_sql=true, hibernate.id.new_generator_mappings=true, java.specification.version=17, hibernate.resource.beans.container=org.springframework.orm.hibernate5.SpringBeanContainer@1425e531, hibernate.connection.handling_mode=DELAYED_ACQUISITION_AND_HOLD, sun.jnu.encoding=UTF-8, 
...
...
...
user.timezone=Asia/Seoul, 
...
sql.init=, hibernate.default_batch_fetch_size=600}
```
> 로컬 테스트 잘들어감
![스크린샷 2023-10-04 오후 8 48 45](https://github.com/sopt-makers/sopt-backend/assets/86935274/007ae12e-17e9-4192-a3fd-8dfce5e0fb4c)


#### 🌱 Related Issue
#123 
