### PR TITLE
FIX : 이전 버전 알림 API 재생성 및 Deprecated 처리

### DIFF
--- a/src/main/java/org/sopt/app/application/notification/NotificationService.java
+++ b/src/main/java/org/sopt/app/application/notification/NotificationService.java
@@ -31,6 +31,12 @@ public class NotificationService {
         return notificationRepository.findByNotificationIdAndUserId(notificationId, user.getId())
                 .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
     }
+    @Transactional(readOnly = true)
+    @Deprecated
+    public Notification findNotificationDeprecated(User user, Long notificationId) {
+        return notificationRepository.findByIdAndUserId(notificationId, user.getId())
+                .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
+    }
 
     @Transactional(readOnly = true)
     public List<Notification> findNotificationList(User user, Pageable pageable) {
@@ -78,6 +84,15 @@ public class NotificationService {
             updateSingleNotificationIsRead(user, notificationId);
         }
     }
+    @Transactional
+    @Deprecated
+    public void updateNotificationIsReadDeprecated(User user, Long notificationId) {
+        if (Objects.isNull(notificationId)) {
+            updateAllNotificationIsRead(user);
+        } else {
+            updateSingleNotificationIsReadDeprecated(user, notificationId);
+        }
+    }
 
     private void updateAllNotificationIsRead(User user) {
         val notificationList = notificationRepository.findAllByUserId(user.getId());
@@ -92,6 +107,12 @@ public class NotificationService {
 
     private void updateSingleNotificationIsRead(User user, String notificationId) {
         val notification = notificationRepository.findByNotificationIdAndUserId(notificationId, user.getId())
+                .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
+        notification.updateIsRead();
+        notificationRepository.save(notification);
+    }
+    private void updateSingleNotificationIsReadDeprecated(User user, Long notificationId) {
+        val notification = notificationRepository.findByIdAndUserId(notificationId, user.getId())
                 .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
         notification.updateIsRead();
         notificationRepository.save(notification);

--- a/src/main/java/org/sopt/app/application/notification/NotificationService.java
+++ b/src/main/java/org/sopt/app/application/notification/NotificationService.java
@@ -94,6 +94,21 @@ public class NotificationService {
         }
     }
 
+    private void updateSingleNotificationIsRead(User user, String notificationId) {
+        val notification = notificationRepository.findByNotificationIdAndUserId(notificationId, user.getId())
+                .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
+        notification.updateIsRead();
+        notificationRepository.save(notification);
+    }
+
+    @Deprecated
+    private void updateSingleNotificationIsReadDeprecated(User user, Long notificationId) {
+        val notification = notificationRepository.findByIdAndUserId(notificationId, user.getId())
+                .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
+        notification.updateIsRead();
+        notificationRepository.save(notification);
+    }
+
     private void updateAllNotificationIsRead(User user) {
         val notificationList = notificationRepository.findAllByUserId(user.getId());
         val readNotificationList = notificationList.stream()
@@ -103,19 +118,6 @@ public class NotificationService {
                     }
                 ).collect(Collectors.toList());
         notificationRepository.saveAll(readNotificationList);
-    }
-
-    private void updateSingleNotificationIsRead(User user, String notificationId) {
-        val notification = notificationRepository.findByNotificationIdAndUserId(notificationId, user.getId())
-                .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
-        notification.updateIsRead();
-        notificationRepository.save(notification);
-    }
-    private void updateSingleNotificationIsReadDeprecated(User user, Long notificationId) {
-        val notification = notificationRepository.findByIdAndUserId(notificationId, user.getId())
-                .orElseThrow(() -> new BadRequestException(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage()));
-        notification.updateIsRead();
-        notificationRepository.save(notification);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/app/interfaces/postgres/NotificationRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/NotificationRepository.java
@@ -12,5 +12,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findAllByUserId(Long userId, Pageable pageable);
 
+    Optional<Notification> findByIdAndUserId(Long id, Long userId);
     Optional<Notification> findByNotificationIdAndUserId(String notificationId, Long userId);
 }

--- a/src/main/java/org/sopt/app/presentation/notification/NotificationController.java
+++ b/src/main/java/org/sopt/app/presentation/notification/NotificationController.java
@@ -39,7 +39,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "200", description = "success"),
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    @GetMapping(value = "")
+    @GetMapping(value = "/all")
     public ResponseEntity<List<NotificationResponse.NotificationSimple>> findNotificationList(
             @AuthenticationPrincipal User user,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -62,7 +62,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "200", description = "success"),
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    @GetMapping(value = "/{notificationId}")
+    @GetMapping(value = "/detail/{notificationId}")
     public ResponseEntity<NotificationResponse.NotificationDetail> findNotificationDetail(
             @AuthenticationPrincipal User user,
             @PathVariable("notificationId") String notificationId
@@ -70,8 +70,8 @@ public class NotificationController {
         val result = notificationService.findNotification(user, notificationId);
         return ResponseEntity.status(HttpStatus.OK).body(
                 NotificationResponse.NotificationDetail.of(
-                        notificationId,
-                        user.getId(),
+                        result.getNotificationId(),
+                        result.getUserId(),
                         result.getTitle(),
                         result.getContent(),
                         result.getDeepLink(),
@@ -103,7 +103,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
     @PatchMapping(value = {
-            "/{notificationId}", ""
+            "/read/{notificationId}", "/read"
     })
     public ResponseEntity<NotificationDetail> updateNotificationIsRead(
             @AuthenticationPrincipal User user,
@@ -113,4 +113,72 @@ public class NotificationController {
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 
+
+
+    @Operation(summary = "알림 목록 조회 - DEPRECATED")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping(value = "")
+    @Deprecated
+    public ResponseEntity<List<NotificationResponse.NotificationSimpleDeprecated>> findNotificationListDeprecated(
+            @AuthenticationPrincipal User user,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        val result = notificationService.findNotificationList(user, pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                result.stream()
+                        .map((notification) -> NotificationResponse.NotificationSimpleDeprecated.of(
+                                notification.getId()
+                                , notification.getUserId()
+                                , notification.getTitle()
+                                , notification.getContent()
+                                , notification.getCategory().name()
+                                , notification.getIsRead()
+                                , notification.getCreatedAt()
+                        )).toList());
+    }
+    @Operation(summary = "알림 상세 조회 - DEPRECATED")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping(value = "/{notificationId}")
+    @Deprecated
+    public ResponseEntity<NotificationResponse.NotificationDetailDeprecated> findNotificationDetailDeprecated(
+            @AuthenticationPrincipal User user,
+            @PathVariable("notificationId") Long notificationId
+    ) {
+        val result = notificationService.findNotificationDeprecated(user, notificationId);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                NotificationResponse.NotificationDetailDeprecated.of(
+                        result.getId(),
+                        result.getUserId(),
+                        result.getTitle(),
+                        result.getContent(),
+                        result.getDeepLink(),
+                        result.getWebLink(),
+                        result.getCreatedAt(),
+                        result.getUpdatedAt()
+                )
+        );
+    }
+
+    @Operation(summary = "알림 읽음 여부 변경 - DEPRECATED")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @PatchMapping(value = {
+            "/{notificationId}", ""
+    })
+    @Deprecated
+    public ResponseEntity<NotificationDetail> updateNotificationIsReadDeprecated(
+            @AuthenticationPrincipal User user,
+            @PathVariable(name = "notificationId", required = false) Long notificationId
+    ) {
+        notificationService.updateNotificationIsReadDeprecated(user, notificationId);
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/notification/NotificationResponse.java
+++ b/src/main/java/org/sopt/app/presentation/notification/NotificationResponse.java
@@ -104,4 +104,89 @@ public class NotificationResponse {
             );
         }
     }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @ToString
+    @Deprecated
+    public static class NotificationSimpleDeprecated {
+
+        @Schema(description = "알림 아이디", example = "1")
+        private Long id;
+
+        @Schema(description = "앱 유저 아이디", example = "1")
+        private Long userId;
+
+        @Schema(description = "알림 제목", example = "공지다!")
+        private String title;
+
+        @Schema(description = "알림 내용", example = "공지 내용은 앱팀 최고입니다.")
+        private String content;
+
+        @Schema(description = "알림 카테고리", example = "NOTICE")
+        private String category;
+
+        @Schema(description = "알림 읽음 여부", example = "true")
+        private Boolean isRead;
+
+        @Schema(description = "알림 생성 일시", example = "2023-03-29T18:39:42.106369")
+        private LocalDateTime createdAt;
+
+        public static NotificationSimpleDeprecated of(
+                Long notificationId
+                , Long userId
+                , String title
+                , String content
+                , String category
+                , Boolean isRead
+                , LocalDateTime createdAt
+        ) {
+            return new NotificationSimpleDeprecated(
+                    notificationId, userId, title, content, category, isRead, createdAt
+            );
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @ToString
+    @Deprecated
+    public static class NotificationDetailDeprecated {
+
+        @Schema(description = "알림 아이디", example = "1")
+        private Long id;
+        @Schema(description = "유저 아이디", example = "1")
+        private Long userId;
+        @Schema(description = "알림 제목", example = "공지다!")
+        private String title;
+        @Schema(description = "알림 내용", example = "공지 내용은 앱팀 최고입니다.")
+        private String content;
+        @Schema(description = "알림 첨부 딥링크")
+        private String deepLink;
+        @Schema(description = "알림 첨부 웹링크")
+        private String webLink;
+        @Schema(description = "알림 생성 일시", example = "2023-03-29T18:39:42.106369")
+        private LocalDateTime createdAt;
+        @Schema(description = "알림 수정 일시", example = "2023-03-29T18:39:42.106369")
+        private LocalDateTime updatedAt;
+
+        public static NotificationDetailDeprecated of(
+                Long notificationId
+                , Long userId
+                , String title
+                , String content
+                , String deepLink
+                , String webLink
+                , LocalDateTime createdAt
+                , LocalDateTime updatedAt
+        ) {
+            return new NotificationDetailDeprecated(
+                    notificationId, userId, title, content, deepLink, webLink, createdAt, updatedAt
+            );
+        }
+    }
+
+
 }


### PR DESCRIPTION
- (신버전) 알림 상세 조회 URI : `/detail/{notificationId}` 로 변경
- (신버전) 알림 리스트 조회 URI : `/all` 로 변경
- (신버전) 알림 읽음 처리 URI : `/read` (전체), `/read/{notificationId}` (개별) 로 변경

## 📝 PR Summary


#### 🌵 Working Branch
feat/#148-create-legacy-alarm-api

#### 🌴 Works
- [x] 구버전 API 재생성 및 Deprecated 처리
  - [x] Response DTO Deprecated 처리
  - [x] Notification Entity ID 기반 Service Method Deprecated 처리
  - [x] Notification Entity ID 기반 Controller Method Deprecated 처리
- [x] 신버전 API URI 분리
  - [x] (신버전) 알림 상세 조회 URI : `/detail/{notificationId}` 로 변경
  - [x] (신버전) 알림 리스트 조회 URI : `/all` 로 변경
  - [x] (신버전) 알림 읽음 처리 URI : `/read` (전체), `/read/{notificationId}` (개별) 로 변경


#### 🌱 Related Issue
#148 
