### PR TITLE
fix: pg memberProfile dto json 매핑 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
+++ b/src/main/java/org/sopt/app/application/auth/PlaygroundAuthInfo.java
@@ -133,6 +133,7 @@ public class PlaygroundAuthInfo {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class MemberProfile {
+        @JsonProperty("memberId")
         private Long id;
         private String profileImage;
         private String name;


### PR DESCRIPTION
## 📝 PR Summary
memberProfile에 jsonMapping이 빠져있어 null이 되는 현상 수정

#### 🌵 Working Branch
fix/playground-memberprofile

#### 🌴 Works
- [ ] MemberProfile class id 필드에 jsonProperty 추가


#### 🌱 Related Issue

