### PR TITLE
fix: FriendList size 정상적으로 수정

### DIFF
--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -221,6 +221,13 @@ public class PokeFacade {
                 .limit(2)
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public int getFriendSizeByFriendship(Long userId, Friendship friendship) {
+        return friendService.findAllFriendsByFriendship(
+            userId, friendship.getLowerLimit(), friendship.getUpperLimit()).size();
+    }
+
     @Transactional(readOnly = true)
     public EachRelationFriendList getAllFriendByFriendship(User user, Friendship friendship, Pageable pageable) {
         val friends = friendService.findAllFriendsByFriendship(

--- a/src/main/java/org/sopt/app/presentation/poke/PokeController.java
+++ b/src/main/java/org/sopt/app/presentation/poke/PokeController.java
@@ -156,13 +156,17 @@ public class PokeController {
     ) {
         if (Objects.isNull(type)) {
             val newFriends = pokeFacade.getTwoFriendByFriendship(user, Friendship.NEW_FRIEND);
+            val newFriendsSize = pokeFacade.getFriendSizeByFriendship(user.getId(), Friendship.NEW_FRIEND);
             val bestFriends = pokeFacade.getTwoFriendByFriendship(user, Friendship.BEST_FRIEND);
+            val bestFriendsSize = pokeFacade.getFriendSizeByFriendship(user.getId(), Friendship.BEST_FRIEND);
             val soulMates = pokeFacade.getTwoFriendByFriendship(user, Friendship.SOULMATE);
+            val soulMatesSize = pokeFacade.getFriendSizeByFriendship(user.getId(), Friendship.SOULMATE);
+
             val response = AllRelationFriendList.of(
-                    newFriends, newFriends.size(),
-                    bestFriends, bestFriends.size(),
-                    soulMates, soulMates.size(),
-                newFriends.size() + bestFriends.size() + soulMates.size()
+                    newFriends, newFriendsSize,
+                    bestFriends, bestFriendsSize,
+                    soulMates, soulMatesSize,
+                    newFriendsSize + bestFriendsSize + soulMatesSize
             );
             return ResponseEntity.ok(response);
         }


### PR DESCRIPTION
## 📝 PR Summary
friendList response에 들어가는 각 친구 목록 당 size가 단순하게 2개로 자른 사이즈로 들어가던 문제 수정.

#### 🌵 Working Branch


#### 🌴 Works
- [ ]
- [ ]


#### 🌱 Related Issue

