### PR TITLE
fix: 온보딩 유저 추천 - 찌르기 여부 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
@@ -2,6 +2,7 @@ package org.sopt.app.application.poke;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.HashMap;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -66,5 +67,14 @@ public class PokeHistoryService {
         if (pokeHistory.size() >= 1) {
             throw new BadRequestException(ErrorCode.DUPLICATE_POKE.getMessage());
         }
+    }
+
+    public HashMap<Long, Boolean> getAllPokeHistoryMap(Long userId) {
+        val pokeHistories = pokeHistoryRepository.findAllByPokerIdAndIsReply(userId, false);
+        HashMap<Long, Boolean> pokeHistoryMap = new HashMap<>();
+        for (PokeHistory pokeHistory : pokeHistories) {
+            pokeHistoryMap.put(pokeHistory.getPokedId(), pokeHistory.getIsReply());
+        }
+        return pokeHistoryMap;
     }
 }

--- a/src/main/java/org/sopt/app/presentation/poke/PokeController.java
+++ b/src/main/java/org/sopt/app/presentation/poke/PokeController.java
@@ -42,7 +42,8 @@ public class PokeController {
     ) {
         val result = pokeFacade.getRecommendUserForNew(
             user.getPlaygroundToken(),
-            user.getPlaygroundId()
+            user.getPlaygroundId(),
+            user.getId()
         );
         return ResponseEntity.ok(result);
     }


### PR DESCRIPTION
## 📝 PR Summary
온보딩 뷰에서 랜덤 유저를 추천할 때 이미 찌른 경우를 나타낼 수 있도록 로직을 수정했습니다.
단순 반복보다 해시 맵이 더 접근성이 좋을 거 같아 해시 맵을 사용했습니다.
#### 🌵 Working Branch

fix/random-user-isAlreadyPoke

#### 🌴 Works
- [ ]
- [ ]


#### 🌱 Related Issue

