### PR TITLE
FEAT : 친구가 아닌 유저 아이디로만 Shuffle 하도록 로직 추가

### DIFF
--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -55,8 +55,13 @@ public class PokeFacade {
         Long userId
     ) {
         val playgroundUserIds = playgroundAuthService.getPlayGroundUserIds(playgroundToken);
+        // TODO : 친구가 아닌 유저 아이디로만 Shuffle 하도록
+        val notFriendUserPlaygroundIds = userService.getUserProfilesByPlaygroundIds(playgroundUserIds.getUserIds()).stream()
+                .filter(userProfile -> !userId.equals(userProfile.getUserId()) && !friendService.isFriendEachOther(userId, userProfile.getUserId()))
+                .map(UserProfile::getPlaygroundId)
+                .collect(Collectors.toList());
         int RECOMMEND_USER_NUM_FOR_NEW = 6;
-        val recommendUserIds = pickRandomUserIds(playgroundUserIds.getUserIds(), userPlaygroundId,
+        val recommendUserIds = pickRandomUserIds(notFriendUserPlaygroundIds, userPlaygroundId,
             RECOMMEND_USER_NUM_FOR_NEW
         );
         val playgroundProfiles = playgroundAuthService.getPlaygroundMemberProfiles(playgroundToken, recommendUserIds);


### PR DESCRIPTION
## 📝 PR Summary
친구가 아닌 유저 아이디로만 Shuffle 하도록 로직 추가

#### 🌵 Working Branch
`feat/onboarding-exclude-friend`

#### 🌴 Works
- [x] Filter로 나 자신과 이미 친구인 사람은 제외


#### 🌱 Related Issue

