### PR TITLE
feat: PokeResponse에 isAnonymous 필드 추가 (#275)

### DIFF
--- a/src/main/java/org/sopt/app/presentation/poke/PokeResponse.java
+++ b/src/main/java/org/sopt/app/presentation/poke/PokeResponse.java
@@ -171,7 +171,7 @@ public class PokeResponse {
 
         //TODO: dummy data 콕 찌르기 개발 이후 정상화 하기
         @Schema(description = "익명 여부", example = "true")
-        private Boolean isPrivate = true;
+        private Boolean isAnonymous = true;
 
         @Schema(description = "함께 아는 친구관계 문구", example = "제갈송현 외 1명과 친구")
         private String mutualRelationMessage;


### PR DESCRIPTION
## 📝 PR Summary
아래 4가지 api에 isPrivate 필드를 추가하고 4가지 api 모두 테스트 완료하였습니다.

- 내 친구를 찔러보세요
- 내 친구 리스트
- 나를 찌른 사람
- 나를 찌른 사람 리스트

Q. isPrivate 필드를 boolean 값으로 설정하면 자꾸 필드 네이밍이 isPrivate가 아닌 private로 나가던데 이유를 아실까요...??

#### 🌵 Working Branch
feat/#275-set-dummy-field

#### 🌴 Works
- 아래 api에 isPrivate 필드를 추가하였습니다.
- [x] 내 친구를 찔러보세요
- [x] 내 친구 리스트
- [x] 나를 찌른 사람
- [x] 나를 찌른 사람 리스트

#### 🌱 Related Issue
closed #275 

