### PR TITLE
fix: /poke/random 중복 url 엔드포인트 삭제

### DIFF
--- a/src/main/java/org/sopt/app/presentation/poke/PokeController.java
+++ b/src/main/java/org/sopt/app/presentation/poke/PokeController.java
@@ -44,34 +44,6 @@ public class PokeController {
 
     private final PokeFacade pokeFacade;
 
-    @GetMapping("/random")
-    public ResponseEntity<RandomInfoList> getRandomByRandomTypeAndSize(
-            @RequestParam("randomType") List<String> randomType,
-            @RequestParam("size") int size
-    ) {
-        SimplePokeProfile simplePokeProfile = SimplePokeProfile.of(2L, 2L, "image", "name2", "", 34, "서버", 1,
-                "새로운 친구", "새로운 친구", true, false, false, "");
-        List<SimplePokeProfile> simplePokeProfileList = List.of(simplePokeProfile, simplePokeProfile,
-                simplePokeProfile, simplePokeProfile, simplePokeProfile, simplePokeProfile);
-
-        if (randomType.get(0).equals("ALL")) {
-            val randomInfoList = List.of(
-                    RandomInfo.of("GENERATION", "나와 " + "GENERATION" + " 같은 사람들",
-                            simplePokeProfileList.subList(0, size)),
-                    RandomInfo.of("MBTI", "나와 " + "MBTI" + " 같은 사람들", simplePokeProfileList.subList(0, size)),
-                    RandomInfo.of("SOJU_CAPACITY", "나와 " + "SOJU_CAPACITY" + " 같은 사람들",
-                            simplePokeProfileList.subList(0, size))
-            );
-            return ResponseEntity.ok(RandomInfoList.of(randomInfoList));
-        } else {
-            val randomInfoList = randomType.stream()
-                    .map(type -> RandomInfo.of(type, "나와 " + type + " 같은 사람들", simplePokeProfileList.subList(0, size)))
-                    .toList();
-            val result = RandomInfoList.of(randomInfoList);
-            return ResponseEntity.ok(result);
-        }
-    }
-
     @GetMapping("/random-user")
     public ResponseEntity<List<PokeResponse.SimplePokeProfile>> getRandomUserForNew(
             @AuthenticationPrincipal User user


### PR DESCRIPTION
## 📝 PR Summary
임시로 만들어둔 /poke/random 중복 url 엔드포인트를 삭제하였습니다.

#### 🌵 Working Branch
fix/#291-poke-random-duplicate-error

#### 🌴 Works
- [x] 임시로 만들어둔 /poke/random 중복 url 엔드포인트를 삭제하였습니다.

#### 🌱 Related Issue
closed #291
