### PR TITLE
fix: 콕찌르기 메인화면과 친구리스트에서 실명 여부가 다르게 나오는 이슈 해결

### DIFF
--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -272,7 +272,8 @@ public class PokeFacade {
                 user.getPlaygroundToken(), List.of(friendUserProfile.getPlaygroundId())).get(0);
         val friendRelationInfo = friendService.getRelationInfo(userId, friendId);
 
-        val pokeHistoryList = pokeHistoryService.getAllOfPokeBetween(userId, friendId);
+        List<PokeHistoryInfo> pokeHistoryListIsReplyFalse = pokeHistoryService.getAllOfPokeBetween(userId, friendId);
+        List<PokeHistoryInfo> pokeHistoryListAll = pokeHistoryService.getAllPokeHistoryByUsers(userId, friendId);
 
         return List.of(
                 SimplePokeProfile.of(
@@ -287,8 +288,8 @@ public class PokeFacade {
                         friendRelationInfo.getRelationName(),
                         createMutualFriendNames(user.getId(), friendId),
                         false,
-                        getIsAlreadyPoke(pokeHistoryList, userId),
-                        getIsAnonymous(pokeHistoryList, userId),
+                        getIsAlreadyPoke(pokeHistoryListIsReplyFalse, userId),
+                        getIsAnonymous(pokeHistoryListAll, userId),
                         friendRelationInfo.getAnonymousName()
                 )
         );


### PR DESCRIPTION
## 📝 PR Summary
콕찌르기 메인화면과 친구리스트에서 실명 여부가 다르게 나오는 이슈 해결
getIsAnonymous랑 getIsAlreadyPoke를 userId와 friendId만 받아서 할 수 있도록 하려 했는데 잘 안되네요.. 일단 PR 올리고 수정해보겠습니다!

#### 🌵 Working Branch
#307 

#### 🌴 Works
- [x] 콕찌르기 메인화면과 친구리스트에서 실명 여부가 다르게 나오는 이슈 해결


#### 🌱 Related Issue
#307
