### PR TITLE
[FEAT] 오늘의 솝마디 스케쥴러 구현 - #344

### DIFF
--- a/src/main/java/org/sopt/app/AppApplication.java
+++ b/src/main/java/org/sopt/app/AppApplication.java
@@ -7,9 +7,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing // JPA Auditing(감시, 감사) 기능을 활성화 하는 어노테이션 createdDate, modifiedDate 저장 활성화
 @EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class AppApplication {
 

--- a/src/main/java/org/sopt/app/application/fortune/FortuneEvent.java
+++ b/src/main/java/org/sopt/app/application/fortune/FortuneEvent.java
@@ -1,0 +1,17 @@
+package org.sopt.app.application.fortune;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.app.common.event.Event;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FortuneEvent extends Event {
+
+    private Long userId;
+
+    public static FortuneEvent of(Long userId) {
+        return new FortuneEvent(userId);
+    }
+}

--- a/src/main/java/org/sopt/app/application/fortune/FortuneEventListener.java
+++ b/src/main/java/org/sopt/app/application/fortune/FortuneEventListener.java
@@ -1,0 +1,78 @@
+package org.sopt.app.application.fortune;
+
+import org.sopt.app.domain.enums.NotificationCategory;
+import org.sopt.app.presentation.fortune.FortuneAlarmRequest;
+import org.sopt.app.presentation.poke.PokeRequest;
+import org.sopt.app.presentation.poke.PokeResponse;
+
+import org.springframework.http.MediaType;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@Component
+@RequiredArgsConstructor
+public class FortuneEventListener {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${makers.push.server}")
+    private String baseURI;
+
+    @Value("${makers.push.x-api-key}")
+    private String apiKey;
+
+    @Async
+    @Transactional(value = Transactional.TxType.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendFortuneAlarm(FortuneEvent fortuneEvent) {
+        HttpEntity<FortuneAlarmRequest> entity = new HttpEntity<>(
+                createBodyFor(fortuneEvent.getUserId()),
+                createHeadersForSend()
+        );
+        sendRequestToAlarmServer(entity);
+    }
+
+    private HttpHeaders createHeadersForSend() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("action", "send");
+        headers.add("x-api-key", apiKey);
+        headers.add("service", "app");
+        headers.add("transactionId", UUID.randomUUID().toString());
+        return headers;
+    }
+
+    private FortuneAlarmRequest createBodyFor(Long userId) {
+        return FortuneAlarmRequest.of(
+                List.of(String.valueOf(userId)),
+                "오늘의 솝마디",  // 메시지 제목
+                "오늘의 솝마디를 확인해보세요!",  // 메시지 내용
+                NotificationCategory.NEWS.name(),
+                "https://app.dev.sopt.org/api/v2/fortune/word"  // Fortune API로 연결되는 URL
+        );
+    }
+
+    private ResponseEntity<FortuneAlarmRequest> sendRequestToAlarmServer(HttpEntity<FortuneAlarmRequest> requestEntity) {
+        return restTemplate.exchange(
+                baseURI,
+                HttpMethod.POST,
+                requestEntity,
+                FortuneAlarmRequest.class
+        );
+    }
+}

--- a/src/main/java/org/sopt/app/application/fortune/FortuneScheduler.java
+++ b/src/main/java/org/sopt/app/application/fortune/FortuneScheduler.java
@@ -1,0 +1,34 @@
+package org.sopt.app.application.fortune;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.notification.NotificationService;
+import org.sopt.app.domain.enums.NotificationCategory;
+import org.sopt.app.domain.enums.NotificationType;
+import org.sopt.app.presentation.notification.NotificationRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FortuneScheduler {
+    private final NotificationService notificationService;
+    // 매일 아침 9시에 실행되는 스케줄러
+    @Scheduled(cron = "0 0 9 * * ?")
+    public void runDailyFortuneCreation() {
+        NotificationRequest.RegisterNotificationRequest registerNotificationRequest = createFortuneNotificationRequest();
+        notificationService.registerNotification(registerNotificationRequest);
+    }
+
+    private NotificationRequest.RegisterNotificationRequest createFortuneNotificationRequest() {
+        return NotificationRequest.RegisterNotificationRequest.builder()
+                .notificationId(UUID.randomUUID().toString())  // 고유한 알림 ID
+                .title("오늘의 솝마디")  // 알림 제목
+                .content("오늘의 솝마디를 확인해보세요!")  // 알림 내용
+                .type(NotificationType.SEND_ALL)  // 모든 사용자에게 보낼 경우
+                .category(NotificationCategory.NEWS)  // 알림 카테고리
+                .deepLink("https://app.dev.sopt.org/api/v2/fortune/word")  // Fortune API URL
+                .webLink("https://app.dev.sopt.org/api/v2/fortune/word")  // 웹 링크
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/app/application/fortune/FortuneScheduler.java
+++ b/src/main/java/org/sopt/app/application/fortune/FortuneScheduler.java
@@ -1,11 +1,14 @@
 package org.sopt.app.application.fortune;
 
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.notification.NotificationService;
+import org.sopt.app.common.event.Events;
 import org.sopt.app.domain.enums.NotificationCategory;
 import org.sopt.app.domain.enums.NotificationType;
-import org.sopt.app.presentation.notification.NotificationRequest;
+import org.sopt.app.presentation.notification.NotificationRequest.RegisterNotificationRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -13,22 +16,27 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FortuneScheduler {
     private final NotificationService notificationService;
+    @Value("${app.base.url}")
+    private String baseUrl;
+
     // 매일 아침 9시에 실행되는 스케줄러
     @Scheduled(cron = "0 0 9 * * ?")
     public void runDailyFortuneCreation() {
-        NotificationRequest.RegisterNotificationRequest registerNotificationRequest = createFortuneNotificationRequest();
-        notificationService.registerNotification(registerNotificationRequest);
+        RegisterNotificationRequest registerNotificationRequest = createFortuneNotificationRequest();
+        List<Long> playgroundIds = notificationService.registerNotification(registerNotificationRequest);
+        playgroundIds
+                .forEach(userId -> Events.raise(FortuneEvent.of(userId)));
     }
 
-    private NotificationRequest.RegisterNotificationRequest createFortuneNotificationRequest() {
-        return NotificationRequest.RegisterNotificationRequest.builder()
-                .notificationId(UUID.randomUUID().toString())  // 고유한 알림 ID
-                .title("오늘의 솝마디")  // 알림 제목
-                .content("오늘의 솝마디를 확인해보세요!")  // 알림 내용
-                .type(NotificationType.SEND_ALL)  // 모든 사용자에게 보낼 경우
-                .category(NotificationCategory.NEWS)  // 알림 카테고리
-                .deepLink("https://app.dev.sopt.org/api/v2/fortune/word")  // Fortune API URL
-                .webLink("https://app.dev.sopt.org/api/v2/fortune/word")  // 웹 링크
+    private RegisterNotificationRequest createFortuneNotificationRequest() {
+        return RegisterNotificationRequest.builder()
+                .notificationId(UUID.randomUUID().toString())
+                .title("오늘의 솝마디")
+                .content("오늘의 솝마디를 확인해보세요!")
+                .type(NotificationType.SEND_ALL)
+                .category(NotificationCategory.NEWS)
+                .deepLink(baseUrl + "/api/v2/fortune/word")
+                .webLink(baseUrl + "/api/v2/fortune/word")
                 .build();
     }
 }

--- a/src/main/java/org/sopt/app/application/notification/NotificationService.java
+++ b/src/main/java/org/sopt/app/application/notification/NotificationService.java
@@ -15,6 +15,7 @@ import org.sopt.app.domain.enums.NotificationType;
 import org.sopt.app.interfaces.postgres.NotificationRepository;
 import org.sopt.app.interfaces.postgres.UserRepository;
 import org.sopt.app.presentation.notification.NotificationRequest;
+import org.sopt.app.presentation.notification.NotificationRequest.RegisterNotificationRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,8 +45,8 @@ public class NotificationService {
     }
 
     @Transactional
-    public void registerNotification(
-            NotificationRequest.RegisterNotificationRequest registerNotificationRequest
+    public List<Long> registerNotification(
+            RegisterNotificationRequest registerNotificationRequest
     ) {
         List<Long> playgroundIds = new ArrayList<>();
         if (registerNotificationRequest.getType().equals(NotificationType.SEND_ALL)) {
@@ -56,6 +57,7 @@ public class NotificationService {
                     .toList();
         }
         registerTo(playgroundIds, registerNotificationRequest);
+        return playgroundIds;
     }
     private void registerTo(List<Long> playgroundIds, NotificationRequest.RegisterNotificationRequest registerNotificationRequest) {
         val targetUserIds = userRepository.findAllIdByPlaygroundIdIn(playgroundIds);

--- a/src/main/java/org/sopt/app/application/poke/PokeEventListener.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeEventListener.java
@@ -1,5 +1,6 @@
 package org.sopt.app.application.poke;
 
+import org.sopt.app.common.utils.HttpHeadersUtils;
 import org.sopt.app.domain.enums.NotificationCategory;
 import org.sopt.app.presentation.poke.PokeRequest;
 import org.sopt.app.presentation.poke.PokeResponse;
@@ -26,12 +27,10 @@ import lombok.val;
 @RequiredArgsConstructor
 public class PokeEventListener {
     private final RestTemplate restTemplate = new RestTemplate();
+    private final HttpHeadersUtils headersUtils;
 
     @Value("${makers.push.server}")
     private String baseURI;
-
-    @Value("${makers.push.x-api-key}")
-    private String apiKey;
 
     @Async
     @Transactional(value = Transactional.TxType.REQUIRES_NEW)
@@ -39,20 +38,11 @@ public class PokeEventListener {
     public void sendPokeAlarm(PokeEvent pokeEvent) {
             val entity = new HttpEntity(
                     createBodyFor(pokeEvent.getPokedUserId()),
-                    createHeadersForSend()
+                    headersUtils.createHeadersForSend()
             );
             sendRequestToAlarmServer(entity);
     }
 
-    private HttpHeaders createHeadersForSend() {
-        val headers = new HttpHeaders();
-        headers.add("Content-Type", "application/json");
-        headers.add("action", "send");
-        headers.add("x-api-key", apiKey);
-        headers.add("service", "app");
-        headers.add("transactionId", UUID.randomUUID().toString());
-        return headers;
-    }
     private PokeRequest.PokeAlarmRequest createBodyFor(Long pokedUserId) {
         return PokeRequest.PokeAlarmRequest.of(
                 List.of(String.valueOf(pokedUserId)),
@@ -70,5 +60,4 @@ public class PokeEventListener {
                 PokeResponse.PokeAlarmStatusResponse.class
         );
     }
-
 }

--- a/src/main/java/org/sopt/app/common/utils/HttpHeadersUtils.java
+++ b/src/main/java/org/sopt/app/common/utils/HttpHeadersUtils.java
@@ -1,0 +1,26 @@
+package org.sopt.app.common.utils;
+
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpHeadersUtils {
+
+    @Value("${makers.push.x-api-key}")
+    private String apiKey;
+
+    @Bean
+    public HttpHeaders createHeadersForSend() {
+        HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("action", "send");
+        headers.add("x-api-key", apiKey);
+        headers.add("service", "app");
+        headers.add("transactionId", UUID.randomUUID().toString());
+        return headers;
+    }
+}

--- a/src/main/java/org/sopt/app/presentation/fortune/FortuneAlarmRequest.java
+++ b/src/main/java/org/sopt/app/presentation/fortune/FortuneAlarmRequest.java
@@ -5,36 +5,44 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
 public class FortuneAlarmRequest {
 
-    @Schema(description = "유저 아이디", example = "['1']")
+    @Schema(description = "유저 아이디", example = "[1]")
     @NotNull(message = "target user Id may not be null")
     private List<String> userIds;
 
-    @Schema(description = "알림 제목", example = "['1']")
+    @Schema(description = "알림 제목")
     @NotNull(message = "Alarm Title may not be null")
     private String title;
 
-    @Schema(description = "알림 내용", example = "['1']")
+    @Schema(description = "알림 내용")
     @NotNull(message = "Alarm Content may not be null")
     private String content;
 
-    @Schema(description = "알림 카테고리", example = "NEWS")
+    @Schema(description = "알림 카테고리")
     @NotNull(message = "Alarm Category may not be null")
     private String category;
 
-    @Schema(description = "오늘의 솝마디 알림 딥링크", example = "/home/fortune")
+    @Schema(description = "오늘의 솝마디 알림 딥링크")
     private String deepLink;
 
     public static FortuneAlarmRequest of(List<String> userIds, String title, String content,
                                          String category, String deepLink) {
-        return new FortuneAlarmRequest(userIds, title, content, category, deepLink);
+        return FortuneAlarmRequest.builder()
+                .category(category)
+                .content(content)
+                .deepLink(deepLink)
+                .title(title)
+                .userIds(userIds)
+                .build();
     }
 }

--- a/src/main/java/org/sopt/app/presentation/fortune/FortuneAlarmRequest.java
+++ b/src/main/java/org/sopt/app/presentation/fortune/FortuneAlarmRequest.java
@@ -1,0 +1,40 @@
+package org.sopt.app.presentation.fortune;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FortuneAlarmRequest {
+
+    @Schema(description = "유저 아이디", example = "['1']")
+    @NotNull(message = "target user Id may not be null")
+    private List<String> userIds;
+
+    @Schema(description = "알림 제목", example = "['1']")
+    @NotNull(message = "Alarm Title may not be null")
+    private String title;
+
+    @Schema(description = "알림 내용", example = "['1']")
+    @NotNull(message = "Alarm Content may not be null")
+    private String content;
+
+    @Schema(description = "알림 카테고리", example = "NEWS")
+    @NotNull(message = "Alarm Category may not be null")
+    private String category;
+
+    @Schema(description = "오늘의 솝마디 알림 딥링크", example = "/home/fortune")
+    private String deepLink;
+
+    public static FortuneAlarmRequest of(List<String> userIds, String title, String content,
+                                         String category, String deepLink) {
+        return new FortuneAlarmRequest(userIds, title, content, category, deepLink);
+    }
+}

--- a/src/main/java/org/sopt/app/presentation/notification/NotificationRequest.java
+++ b/src/main/java/org/sopt/app/presentation/notification/NotificationRequest.java
@@ -15,8 +15,7 @@ import java.util.List;
 public class NotificationRequest {
 
     @Getter
-    @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    @AllArgsConstructor(access = AccessLevel.PUBLIC)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @Builder
     public static class RegisterNotificationRequest {
 

--- a/src/main/java/org/sopt/app/presentation/notification/NotificationRequest.java
+++ b/src/main/java/org/sopt/app/presentation/notification/NotificationRequest.java
@@ -17,6 +17,7 @@ public class NotificationRequest {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PUBLIC)
+    @Builder
     public static class RegisterNotificationRequest {
 
         @Schema(description = "알림 대상 유저 플레이그라운드 ID 리스트", example = "['1', '2']")
@@ -54,5 +55,4 @@ public class NotificationRequest {
         @JsonProperty(value = "id")
         private String notificationId;
     }
-
 }


### PR DESCRIPTION
## 📝 PR Summary

#### 🌴 Works
- [x] 오늘의 솝마디 스케쥴러 구현
- 로직을 천천히 살펴보다가 FCM 기반 작동이 event로 이루어지는것인지 notification service를 통해 이루어지는 것인지 확인이 불가능하여 일단 확인해본 notification service를 통해서 전체 알림 생성만 해두는 크론탭 기반 scheduler로 구현하였습니다! 
```java
public class FortuneScheduler {
    private final NotificationService notificationService;
    // 매일 아침 9시에 실행되는 스케줄러
    @Scheduled(cron = "0 0 9 * * ?")
    public void runDailyFortuneCreation() {
        NotificationRequest.RegisterNotificationRequest registerNotificationRequest = createFortuneNotificationRequest();
        notificationService.registerNotification(registerNotificationRequest);
    }

    private NotificationRequest.RegisterNotificationRequest createFortuneNotificationRequest() {
        return NotificationRequest.RegisterNotificationRequest.builder()
                .notificationId(UUID.randomUUID().toString())  // 고유한 알림 ID
                .title("오늘의 솝마디")  // 알림 제목
                .content("오늘의 솝마디를 확인해보세요!")  // 알림 내용
                .type(NotificationType.SEND_ALL)  // 모든 사용자에게 보낼 경우
                .category(NotificationCategory.NEWS)  // 알림 카테고리
                .deepLink("https://app.dev.sopt.org/api/v2/fortune/word")  // Fortune API URL
                .webLink("https://app.dev.sopt.org/api/v2/fortune/word")  // 웹 링크
                .build();
    }
}

```
- poke 서비스가 Fcm 알림이 설정되어있다고 알고 있어 기존에 poke 서비스와 유사하게 event기반으로 미리 FortuneAlarm 서비스를 만들어 놓았습니다!
```java
@Component
@RequiredArgsConstructor
public class FortuneEventListener {

    private final RestTemplate restTemplate;

    @Value("${makers.push.server}")
    private String baseURI;

    @Value("${makers.push.x-api-key}")
    private String apiKey;

    @Async
    @Transactional(value = Transactional.TxType.REQUIRES_NEW)
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
    public void sendFortuneAlarm(FortuneEvent fortuneEvent) {
        HttpEntity<FortuneAlarmRequest> entity = new HttpEntity<>(
                createBodyFor(fortuneEvent.getUserId()),
                createHeadersForSend()
        );
        sendRequestToAlarmServer(entity);
    }

    private HttpHeaders createHeadersForSend() {
        HttpHeaders headers = new HttpHeaders();
        headers.setContentType(MediaType.APPLICATION_JSON);
        headers.add("action", "send");
        headers.add("x-api-key", apiKey);
        headers.add("service", "app");
        headers.add("transactionId", UUID.randomUUID().toString());
        return headers;
    }

    private FortuneAlarmRequest createBodyFor(Long userId) {
        return FortuneAlarmRequest.of(
                List.of(String.valueOf(userId)),
                "오늘의 솝마디",  // 메시지 제목
                "오늘의 솝마디를 확인해보세요!",  // 메시지 내용
                NotificationCategory.NEWS.name(),
                "https://app.dev.sopt.org/api/v2/fortune/word"  // Fortune API로 연결되는 URL
        );
    }

    private ResponseEntity<FortuneAlarmRequest> sendRequestToAlarmServer(HttpEntity<FortuneAlarmRequest> requestEntity) {
        return restTemplate.exchange(
                baseURI,
                HttpMethod.POST,
                requestEntity,
                FortuneAlarmRequest.class
        );
    }
}
```

#### 🌱 Related Issue
closed #344 

#### 🌵 PR 참고사항
- 
