### PR TITLE
[FEAT] 친구 추천 테스트 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/friend/FriendFilter.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendFilter.java
@@ -1,18 +1,19 @@
 package org.sopt.app.application.friend;
 
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.user.UserInfo.UserProfile;
 
 @RequiredArgsConstructor
 public class FriendFilter {
-    private final Set<Long> friendIds;
-    private final Long userId;
+    private final Set<Long> friendUserIds;
+    private final Long ownUserId;
 
-    public Set<Long> excludeAlreadyFriendIds(Set<Long> userIds) {
-        userIds = new HashSet<>(userIds);
-        userIds.removeAll(friendIds);
-        userIds.remove(userId);
-        return userIds;
+    public List<UserProfile> excludeAlreadyFriendUserIds(List<UserProfile> userProfiles) {
+        return userProfiles.stream()
+                .filter(userProfile -> ownUserId.equals(userProfile.getUserId()))
+                .filter(userProfile -> friendUserIds.contains(userProfile.getUserId()))
+                .toList();
     }
 }

--- a/src/main/java/org/sopt/app/application/friend/FriendFilter.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendFilter.java
@@ -12,8 +12,8 @@ public class FriendFilter {
 
     public List<UserProfile> excludeAlreadyFriendUserIds(List<UserProfile> userProfiles) {
         return userProfiles.stream()
-                .filter(userProfile -> ownUserId.equals(userProfile.getUserId()))
-                .filter(userProfile -> friendUserIds.contains(userProfile.getUserId()))
+                .filter(userProfile -> !ownUserId.equals(userProfile.getUserId()))
+                .filter(userProfile -> !friendUserIds.contains(userProfile.getUserId()))
                 .toList();
     }
 }

--- a/src/main/java/org/sopt/app/application/friend/FriendRecommender.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendRecommender.java
@@ -1,0 +1,105 @@
+package org.sopt.app.application.friend;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.playground.PlaygroundAuthService;
+import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.OwnPlaygroundProfile;
+import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
+import org.sopt.app.application.playground.user_finder.PlaygroundUserIdsProvider;
+import org.sopt.app.application.user.UserInfo.UserProfile;
+import org.sopt.app.application.user.UserService;
+import org.sopt.app.common.utils.RandomPicker;
+import org.sopt.app.domain.entity.User;
+import org.sopt.app.domain.enums.FriendRecommendType;
+import org.sopt.app.presentation.poke.PokeResponse.RecommendedFriendsByType;
+import org.sopt.app.presentation.poke.PokeResponse.RecommendedFriendsRequest;
+import org.sopt.app.presentation.poke.PokeResponse.SimplePokeProfile;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FriendRecommender {
+
+    private final PlaygroundAuthService playgroundAuthService;
+    private final UserService userService;
+    private final FriendService friendService;
+    private final PlaygroundUserIdsProvider playgroundUserIdsProvider;
+
+    public RecommendedFriendsRequest recommendFriendsByTypeList(
+            List<FriendRecommendType> typeList, int size, User user) {
+        typeList = this.adjustTypeList(typeList);
+
+        OwnPlaygroundProfile ownProfile = playgroundAuthService.getOwnPlaygroundProfile(user.getPlaygroundToken());
+        FriendFilter friendFilter =
+                new FriendFilter(friendService.findAllFriendIdsByUserId(user.getId()), user.getId());
+        List<RecommendedFriendsByType> recommendedFriends = new ArrayList<>();
+        for (FriendRecommendType type : typeList) {
+            List<UserProfile> recommendableUserProfiles =
+                    this.getRecommendableUserProfiles(type, ownProfile, friendFilter);
+            if (!recommendableUserProfiles.isEmpty()) {
+                List<UserProfile> pickedUserProfiles = RandomPicker.pickRandom(recommendableUserProfiles, size);
+                List<SimplePokeProfile> simplePokeProfiles =
+                        this.convertUserProfilesToSimplePokeProfiles(pickedUserProfiles, user);
+
+                recommendedFriends.add(RecommendedFriendsByType.builder()
+                        .randomType(type)
+                        .randomTitle(type.getRecommendTitle())
+                        .userInfoList(simplePokeProfiles)
+                        .build());
+            }
+        }
+        return new RecommendedFriendsRequest(recommendedFriends);
+    }
+
+    private List<SimplePokeProfile> convertUserProfilesToSimplePokeProfiles(
+            List<UserProfile> pickedUserProfiles, User user) {
+        List<Long> pickedPlaygroundIds = pickedUserProfiles.stream().map(UserProfile::getPlaygroundId).toList();
+        List<PlaygroundProfile> pickedPlaygroundProfiles = playgroundAuthService.getPlaygroundMemberProfiles(
+                user.getPlaygroundToken(), pickedPlaygroundIds);
+        return this.makeSimplePokeProfilesForNotFriend(pickedPlaygroundProfiles, pickedUserProfiles);
+    }
+
+    private List<SimplePokeProfile> makeSimplePokeProfilesForNotFriend(
+            List<PlaygroundProfile> playgroundProfiles, List<UserProfile> userProfiles) {
+
+        return userProfiles.stream().map(userProfile -> {
+            PlaygroundProfile playgroundProfile = playgroundProfiles.stream()
+                    .filter(profile -> profile.getMemberId().equals(userProfile.getPlaygroundId()))
+                    .findFirst().orElseThrow();
+
+            return SimplePokeProfile.createNonFriendPokeProfile(
+                    userProfile.getUserId(),
+                    userProfile.getPlaygroundId(),
+                    playgroundProfile.getProfileImage(),
+                    userProfile.getName(),
+                    playgroundProfile.getLatestActivity().getGeneration(),
+                    playgroundProfile.getLatestActivity().getPart()
+            );
+        }).toList();
+    }
+
+    private List<UserProfile> getRecommendableUserProfiles(
+            FriendRecommendType type, OwnPlaygroundProfile ownProfile, FriendFilter friendFilter) {
+        Set<Long> playgroundIds;
+        if (type == FriendRecommendType.ALL_USER) {
+            playgroundIds = Set.copyOf(userService.getAllPlaygroundIds());
+        } else {
+            playgroundIds = playgroundUserIdsProvider.findPlaygroundIdsByType(ownProfile, type);
+        }
+        List<UserProfile> unFilteredUserProfiles = userService.getUserProfilesByPlaygroundIds(List.copyOf(playgroundIds));
+        return friendFilter.excludeAlreadyFriendUserIds(unFilteredUserProfiles);
+    }
+
+    private List<FriendRecommendType> adjustTypeList(List<FriendRecommendType> typeList) {
+        if (typeList == null || typeList.isEmpty()) {
+            return List.of(FriendRecommendType.ALL_USER);
+        }
+
+        if (typeList.contains(FriendRecommendType.ALL)) {
+            return List.of(FriendRecommendType.GENERATION, FriendRecommendType.MBTI, FriendRecommendType.UNIVERSITY);
+        }
+        return typeList;
+    }
+}

--- a/src/main/java/org/sopt/app/application/friend/FriendService.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendService.java
@@ -3,8 +3,6 @@ package org.sopt.app.application.friend;
 import lombok.*;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.sopt.app.application.poke.PokeInfo.Relationship;
 import org.sopt.app.common.exception.NotFoundException;
@@ -170,14 +168,5 @@ public class FriendService {
 
     public Set<Long> findAllFriendIdsByUserId(Long userId) {
         return friendRepository.findAllOfFriendIdsByUserId(userId);
-    }
-
-    public List<Long> findUserIdsLinkedFriends(Long userId) {
-        return Stream.concat(
-                        friendRepository.findAllOfFriendIdsByUserId(userId).stream(),
-                        friendRepository.findAllIfUserIdsByFriendId(userId).stream()
-                )
-                .distinct()
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/sopt/app/application/playground/user_finder/PlaygroundUserFindConditionCreatorFactory.java
+++ b/src/main/java/org/sopt/app/application/playground/user_finder/PlaygroundUserFindConditionCreatorFactory.java
@@ -1,7 +1,9 @@
 package org.sopt.app.application.playground.user_finder;
 
 import org.sopt.app.domain.enums.FriendRecommendType;
+import org.springframework.stereotype.Component;
 
+@Component
 public class PlaygroundUserFindConditionCreatorFactory {
 
     public PlaygroundUserFindConditionCreator create(final FriendRecommendType recommendType) {

--- a/src/main/java/org/sopt/app/application/playground/user_finder/PlaygroundUserIdsProvider.java
+++ b/src/main/java/org/sopt/app/application/playground/user_finder/PlaygroundUserIdsProvider.java
@@ -13,11 +13,10 @@ import org.springframework.stereotype.Service;
 public class PlaygroundUserIdsProvider {
 
     private final PlaygroundUserFinder finder;
+    private final PlaygroundUserFindConditionCreatorFactory factory;
 
     public Set<Long> findPlaygroundIdsByType(OwnPlaygroundProfile profile, FriendRecommendType type) {
-        PlaygroundUserFindConditionCreatorFactory factory = new PlaygroundUserFindConditionCreatorFactory();
         PlaygroundUserFindConditionCreator conditionCreator = factory.create(type);
-
         Optional<PlaygroundUserFindCondition> condition = conditionCreator.createCondition(profile);
         if (condition.isPresent()){
             return finder.findByCondition(condition.get());

--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -321,8 +321,8 @@ public class PokeFacade {
         } else {
             playgroundIds = playgroundUserIdsProvider.findPlaygroundIdsByType(ownProfile, type);
         }
-        Set<Long> notFriendPlaygroundIds = friendFilter.excludeAlreadyFriendIds(playgroundIds);
-        return userService.getUserProfilesByPlaygroundIds(List.copyOf(notFriendPlaygroundIds));
+        List<UserProfile> unFilteredUserProfiles = userService.getUserProfilesByPlaygroundIds(List.copyOf(playgroundIds));
+        return friendFilter.excludeAlreadyFriendUserIds(unFilteredUserProfiles);
     }
 
     private List<FriendRecommendType> adjustTypeList(List<FriendRecommendType> typeList) {

--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -294,6 +294,25 @@ public class PokeFacade {
         return this.makeSimplePokeProfilesForNotFriend(pickedPlaygroundProfiles, pickedUserProfiles);
     }
 
+    private List<SimplePokeProfile> makeSimplePokeProfilesForNotFriend(
+            List<PlaygroundProfile> playgroundProfiles, List<UserProfile> userProfiles) {
+
+        return userProfiles.stream().map(userProfile -> {
+            PlaygroundProfile playgroundProfile = playgroundProfiles.stream()
+                    .filter(profile -> profile.getMemberId().equals(userProfile.getPlaygroundId()))
+                    .findFirst().orElseThrow();
+
+            return SimplePokeProfile.createNonFriendPokeProfile(
+                    userProfile.getUserId(),
+                    userProfile.getPlaygroundId(),
+                    playgroundProfile.getProfileImage(),
+                    userProfile.getName(),
+                    playgroundProfile.getLatestActivity().getGeneration(),
+                    playgroundProfile.getLatestActivity().getPart()
+            );
+        }).toList();
+    }
+
     private List<UserProfile> getRecommendableUserProfiles(
             FriendRecommendType type, OwnPlaygroundProfile ownProfile, FriendFilter friendFilter) {
         Set<Long> playgroundIds;
@@ -315,25 +334,6 @@ public class PokeFacade {
             return List.of(FriendRecommendType.GENERATION, FriendRecommendType.MBTI, FriendRecommendType.UNIVERSITY);
         }
         return typeList;
-    }
-
-    private List<SimplePokeProfile> makeSimplePokeProfilesForNotFriend(
-            List<PlaygroundProfile> playgroundProfiles, List<UserProfile> userProfiles) {
-
-        return userProfiles.stream().map(userProfile -> {
-            PlaygroundProfile playgroundProfile = playgroundProfiles.stream()
-                    .filter(profile -> profile.getMemberId().equals(userProfile.getPlaygroundId()))
-                    .findFirst().orElseThrow();
-
-            return SimplePokeProfile.createNonFriendPokeProfile(
-                    userProfile.getUserId(),
-                    userProfile.getPlaygroundId(),
-                    playgroundProfile.getProfileImage(),
-                    userProfile.getName(),
-                    playgroundProfile.getLatestActivity().getGeneration(),
-                    playgroundProfile.getLatestActivity().getPart()
-            );
-        }).toList();
     }
 
     public boolean getIsNewUser(Long userId) {

--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -7,17 +7,12 @@ import static org.sopt.app.application.poke.PokeInfo.NEW_FRIEND_ONE_MUTUAL;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.sopt.app.application.friend.FriendFilter;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.OwnPlaygroundProfile;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
+import org.sopt.app.application.friend.FriendRecommender;
 import org.sopt.app.application.playground.PlaygroundAuthService;
-import org.sopt.app.application.playground.user_finder.PlaygroundUserIdsProvider;
 import org.sopt.app.application.friend.FriendService;
 import org.sopt.app.application.poke.*;
 import org.sopt.app.application.poke.PokeInfo.PokeHistoryInfo;
-import org.sopt.app.application.user.UserInfo.UserProfile;
 import org.sopt.app.application.user.UserService;
-import org.sopt.app.common.utils.RandomPicker;
 import org.sopt.app.domain.entity.poke.PokeHistory;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.domain.enums.FriendRecommendType;
@@ -35,10 +30,10 @@ public class PokeFacade {
     private final PlaygroundAuthService playgroundAuthService;
     private final UserService userService;
     private final FriendService friendService;
+    private final FriendRecommender friendRecommender;
     private final PokeService pokeService;
     private final PokeHistoryService pokeHistoryService;
     private final PokeMessageService pokeMessageService;
-    private final PlaygroundUserIdsProvider playgroundUserIdsProvider;
 
     @Transactional(readOnly = true)
     public List<PokeMessage> getPokingMessages(String type) {
@@ -225,7 +220,7 @@ public class PokeFacade {
     }
 
     public SimplePokeProfile getPokeHistoryProfile(User user, Long friendId, Long pokeId) {
-        PokeInfo.PokeDetail pokeDetail = getPokeInfo(pokeId);
+        PokeInfo.PokeDetail pokeDetail = pokeService.getPokeDetail(pokeId);
         PokeInfo.PokedUserInfo friendUserInfo = getFriendUserInfo(user, friendId);
 
         return SimplePokeProfile.from(
@@ -234,10 +229,6 @@ public class PokeFacade {
                 getIsAlreadyPoke(pokeDetail.getPokerId(), pokeDetail.getPokedId(), user.getId()),
                 getIsAnonymous(pokeDetail.getPokerId(), pokeDetail.getPokedId(), user.getId())
         );
-    }
-
-    private PokeInfo.PokeDetail getPokeInfo(Long pokeHistoryId) {
-        return pokeService.getPokeDetail(pokeHistoryId);
     }
 
     private PokeInfo.PokedUserInfo getFriendUserInfo(User user, Long friendUserId) {
@@ -261,79 +252,8 @@ public class PokeFacade {
     }
 
     public RecommendedFriendsRequest getRecommendedFriendsByTypeList(
-            List<FriendRecommendType> typeList, int size, User user) {
-        typeList = this.adjustTypeList(typeList);
-
-        OwnPlaygroundProfile ownProfile = playgroundAuthService.getOwnPlaygroundProfile(user.getPlaygroundToken());
-        FriendFilter friendFilter =
-                new FriendFilter(friendService.findAllFriendIdsByUserId(user.getId()), user.getId());
-        List<RecommendedFriendsByType> recommendedFriends = new ArrayList<>();
-        for (FriendRecommendType type : typeList) {
-            List<UserProfile> recommendableUserProfiles =
-                    this.getRecommendableUserProfiles(type, ownProfile, friendFilter);
-            if (!recommendableUserProfiles.isEmpty()) {
-                List<UserProfile> pickedUserProfiles = RandomPicker.pickRandom(recommendableUserProfiles, size);
-                List<SimplePokeProfile> simplePokeProfiles =
-                        this.convertUserProfilesToSimplePokeProfiles(pickedUserProfiles, user);
-
-                recommendedFriends.add(RecommendedFriendsByType.builder()
-                        .randomType(type)
-                        .randomTitle(type.getRecommendTitle())
-                        .userInfoList(simplePokeProfiles)
-                        .build());
-            }
-        }
-        return new RecommendedFriendsRequest(recommendedFriends);
-    }
-
-    private List<SimplePokeProfile> convertUserProfilesToSimplePokeProfiles(
-            List<UserProfile> pickedUserProfiles, User user) {
-        List<Long> pickedPlaygroundIds = pickedUserProfiles.stream().map(UserProfile::getPlaygroundId).toList();
-        List<PlaygroundProfile> pickedPlaygroundProfiles = playgroundAuthService.getPlaygroundMemberProfiles(
-                user.getPlaygroundToken(), pickedPlaygroundIds);
-        return this.makeSimplePokeProfilesForNotFriend(pickedPlaygroundProfiles, pickedUserProfiles);
-    }
-
-    private List<SimplePokeProfile> makeSimplePokeProfilesForNotFriend(
-            List<PlaygroundProfile> playgroundProfiles, List<UserProfile> userProfiles) {
-
-        return userProfiles.stream().map(userProfile -> {
-            PlaygroundProfile playgroundProfile = playgroundProfiles.stream()
-                    .filter(profile -> profile.getMemberId().equals(userProfile.getPlaygroundId()))
-                    .findFirst().orElseThrow();
-
-            return SimplePokeProfile.createNonFriendPokeProfile(
-                    userProfile.getUserId(),
-                    userProfile.getPlaygroundId(),
-                    playgroundProfile.getProfileImage(),
-                    userProfile.getName(),
-                    playgroundProfile.getLatestActivity().getGeneration(),
-                    playgroundProfile.getLatestActivity().getPart()
-            );
-        }).toList();
-    }
-
-    private List<UserProfile> getRecommendableUserProfiles(
-            FriendRecommendType type, OwnPlaygroundProfile ownProfile, FriendFilter friendFilter) {
-        Set<Long> playgroundIds;
-        if (type == FriendRecommendType.ALL_USER) {
-            playgroundIds = Set.copyOf(userService.getAllPlaygroundIds());
-        } else {
-            playgroundIds = playgroundUserIdsProvider.findPlaygroundIdsByType(ownProfile, type);
-        }
-        List<UserProfile> unFilteredUserProfiles = userService.getUserProfilesByPlaygroundIds(List.copyOf(playgroundIds));
-        return friendFilter.excludeAlreadyFriendUserIds(unFilteredUserProfiles);
-    }
-
-    private List<FriendRecommendType> adjustTypeList(List<FriendRecommendType> typeList) {
-        if (typeList == null || typeList.isEmpty()) {
-            return List.of(FriendRecommendType.ALL_USER);
-        }
-
-        if (typeList.contains(FriendRecommendType.ALL)) {
-            return List.of(FriendRecommendType.GENERATION, FriendRecommendType.MBTI, FriendRecommendType.UNIVERSITY);
-        }
-        return typeList;
+            List<FriendRecommendType> typeList, int size, User user){
+        return friendRecommender.recommendFriendsByTypeList(typeList, size, user);
     }
 
     public boolean getIsNewUser(Long userId) {

--- a/src/test/java/org/sopt/app/application/FriendRecommenderTest.java
+++ b/src/test/java/org/sopt/app/application/FriendRecommenderTest.java
@@ -13,9 +13,11 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.app.application.friend.FriendRecommender;
 import org.sopt.app.application.friend.FriendService;
 import org.sopt.app.application.playground.PlaygroundAuthService;
@@ -24,10 +26,10 @@ import org.sopt.app.application.user.UserService;
 import org.sopt.app.common.fixtures.PokeFixture;
 import org.sopt.app.common.fixtures.UserFixture;
 import org.sopt.app.domain.enums.FriendRecommendType;
-import org.sopt.app.facade.PokeFacade;
 import org.sopt.app.presentation.poke.PokeResponse.RecommendedFriendsRequest;
 import org.sopt.app.presentation.poke.PokeResponse.SimplePokeProfile;
 
+@ExtendWith(MockitoExtension.class)
 class FriendRecommenderTest {
 
     @Mock
@@ -191,13 +193,6 @@ class FriendRecommenderTest {
         // then
         assertEquals(2L, ac.getValue().get(0));
         assertEquals(22L, result.getRandomInfoList().get(0).getUserInfoList().get(0).getUserId());
-    }
-
-    // TODO: 자신의 유형 값이 null이면 객체를 반환하지 않아야 하는 테스트 다른 객체로 책임 전달
-    @Test
-    @DisplayName("SUCCESS_요구사항5_자신의 유형 값이 null이면 객체를 반환하지 않음")
-    void SUCCESS_getRecommendedFriendsByAllType_Requirement5() {
-
     }
 
 }

--- a/src/test/java/org/sopt/app/application/FriendRecommenderTest.java
+++ b/src/test/java/org/sopt/app/application/FriendRecommenderTest.java
@@ -1,0 +1,203 @@
+package org.sopt.app.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.sopt.app.application.friend.FriendRecommender;
+import org.sopt.app.application.friend.FriendService;
+import org.sopt.app.application.playground.PlaygroundAuthService;
+import org.sopt.app.application.playground.user_finder.PlaygroundUserIdsProvider;
+import org.sopt.app.application.user.UserService;
+import org.sopt.app.common.fixtures.PokeFixture;
+import org.sopt.app.common.fixtures.UserFixture;
+import org.sopt.app.domain.enums.FriendRecommendType;
+import org.sopt.app.facade.PokeFacade;
+import org.sopt.app.presentation.poke.PokeResponse.RecommendedFriendsRequest;
+import org.sopt.app.presentation.poke.PokeResponse.SimplePokeProfile;
+
+class FriendRecommenderTest {
+
+    @Mock
+    private PlaygroundAuthService playgroundAuthService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private FriendService friendService;
+    @Mock
+    private PlaygroundUserIdsProvider playgroundUserIdsProvider;
+    @InjectMocks
+    private FriendRecommender friendRecommender;
+
+    @Test
+    @DisplayName("SUCCESS_모든 유형의 추천 친구 조회")
+    void SUCCESS_getRecommendedFriendsByAllType() {
+        // given
+        final Set<Long> sameMbtiPlaygroundIds = Set.of(1L);
+        final List<Long> sameMbtiUserIds = List.of(11L);
+        final Set<Long> sameUniversityPlaygroundIds = Set.of(2L);
+        final List<Long> sameUniversityUserIds = List.of(22L);
+        final Set<Long> sameGenerationPlaygroundIds = Set.of(3L);
+        final List<Long> sameGenerationUserIds = List.of(33L);
+
+        given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
+                .willReturn(PokeFixture.createOwnPlaygroundProfile());
+        given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
+
+        //== MBTI, UNIVERSITY, GENERATION별 playgroundIds를 찾는 로직 ==//
+        given(playgroundUserIdsProvider.findPlaygroundIdsByType(any(), eq(FriendRecommendType.MBTI)))
+                .willReturn(sameMbtiPlaygroundIds);
+        given(playgroundUserIdsProvider.findPlaygroundIdsByType(any(), eq(FriendRecommendType.UNIVERSITY)))
+                .willReturn(sameUniversityPlaygroundIds);
+        given(playgroundUserIdsProvider.findPlaygroundIdsByType(any(), eq(FriendRecommendType.GENERATION)))
+                .willReturn(sameGenerationPlaygroundIds);
+
+        //== MBTI, UNIVERSITY, GENERATION별 playground profile을 찾는 로직 ==//
+        given(playgroundAuthService.getPlaygroundMemberProfiles(anyString(), eq(List.copyOf(sameMbtiPlaygroundIds))))
+                .willReturn(PokeFixture.createPlaygroundProfileList(List.copyOf(sameMbtiPlaygroundIds)));
+        given(playgroundAuthService.getPlaygroundMemberProfiles(anyString(), eq(List.copyOf(sameUniversityPlaygroundIds))))
+                .willReturn(PokeFixture.createPlaygroundProfileList(List.copyOf(sameUniversityPlaygroundIds)));
+        given(playgroundAuthService.getPlaygroundMemberProfiles(anyString(), eq(List.copyOf(sameGenerationPlaygroundIds))))
+                .willReturn(PokeFixture.createPlaygroundProfileList(List.copyOf(sameGenerationPlaygroundIds)));
+
+        //== MBTI, UNIVERSITY, GENERATION별 user profile을 찾는 로직 ==//
+        given(userService.getUserProfilesByPlaygroundIds(List.copyOf(sameMbtiPlaygroundIds)))
+                .willReturn(PokeFixture.createUserProfileList(sameMbtiUserIds ,List.copyOf(sameMbtiPlaygroundIds)));
+        given(userService.getUserProfilesByPlaygroundIds(List.copyOf(sameUniversityPlaygroundIds)))
+                .willReturn(PokeFixture.createUserProfileList(sameUniversityUserIds ,List.copyOf(sameUniversityPlaygroundIds)));
+        given(userService.getUserProfilesByPlaygroundIds(List.copyOf(sameGenerationPlaygroundIds)))
+                .willReturn(PokeFixture.createUserProfileList(sameGenerationUserIds ,List.copyOf(sameGenerationPlaygroundIds)));
+
+        // when
+        RecommendedFriendsRequest result = friendRecommender.recommendFriendsByTypeList(
+                List.of(FriendRecommendType.ALL), 6, UserFixture.createMyAppUser());
+        List<Long> resultSameMbtiPlaygroundIds = result.getRandomInfoList().stream()
+                .filter(info -> info.getRandomType() == FriendRecommendType.MBTI)
+                .findFirst().get().getUserInfoList().stream().map(SimplePokeProfile::getPlaygroundId).toList();
+        List<Long> resultSameUniversityPlaygroundIds = result.getRandomInfoList().stream()
+                .filter(info -> info.getRandomType() == FriendRecommendType.UNIVERSITY)
+                .findFirst().get().getUserInfoList().stream().map(SimplePokeProfile::getPlaygroundId).toList();
+        List<Long> resultSameGenerationPlaygroundIds = result.getRandomInfoList().stream()
+                .filter(info -> info.getRandomType() == FriendRecommendType.GENERATION)
+                .findFirst().get().getUserInfoList().stream().map(SimplePokeProfile::getPlaygroundId).toList();
+
+        // then
+        assertEquals(3, result.getRandomInfoList().size());
+        assertEquals(List.copyOf(sameMbtiPlaygroundIds), resultSameMbtiPlaygroundIds);
+        assertEquals(List.copyOf(sameUniversityPlaygroundIds), resultSameUniversityPlaygroundIds);
+        assertEquals(List.copyOf(sameGenerationPlaygroundIds), resultSameGenerationPlaygroundIds);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_요구사항1_추천할 친구가 없다면 객체를 반환하지 않음")
+    void SUCCESS_getRecommendedFriendsByAllType_Requirement1() {
+        // given
+        final List<Long> emptyPlaygroundIds = List.of();
+        final List<Long> emptyUserIds = List.of();
+
+        given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
+                .willReturn(PokeFixture.createOwnPlaygroundProfile());
+        given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
+        given(userService.getAllPlaygroundIds()).willReturn(emptyPlaygroundIds); // 추천된 playground id 없음
+        given(userService.getUserProfilesByPlaygroundIds(emptyPlaygroundIds))
+                .willReturn(PokeFixture.createUserProfileList(emptyUserIds ,List.copyOf(emptyPlaygroundIds)));
+
+        // when
+        RecommendedFriendsRequest result = friendRecommender.recommendFriendsByTypeList(
+                List.of(FriendRecommendType.ALL_USER), 6, UserFixture.createMyAppUser());
+
+        // then
+        assertTrue(result.getRandomInfoList().isEmpty());
+    }
+
+    @Test
+    @DisplayName("SUCCESS_요구사항2_자기 자신은 추천 친구에서 제외되어야 함")
+    void SUCCESS_getRecommendedFriendsByAllType_Requirement2() {
+        // given
+        final List<Long> playgroundIds = List.of(UserFixture.myPlaygroundId);
+        final List<Long> userIds = List.of(UserFixture.myAppUserId);
+
+        given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
+                .willReturn(PokeFixture.createOwnPlaygroundProfile());
+        given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
+
+        //== playgroundIds에 자신의 playgroundId만 포함됨 ==//
+        given(userService.getAllPlaygroundIds()).willReturn(playgroundIds);
+        given(userService.getUserProfilesByPlaygroundIds(playgroundIds)).willReturn(
+                PokeFixture.createUserProfileList(userIds, playgroundIds));
+
+        // when
+        RecommendedFriendsRequest result = friendRecommender.recommendFriendsByTypeList(
+                List.of(FriendRecommendType.ALL_USER), 6, UserFixture.createMyAppUser());
+
+        // then
+        assertTrue(result.getRandomInfoList().isEmpty());
+    }
+
+    @Test
+    @DisplayName("SUCCESS_요구사항3_플그 아이디는 있지만 앱 아이디가 없는 유저는 추천하지 않도록 필터링")
+    void SUCCESS_getRecommendedFriendsByAllType_Requirement3() {
+        // given
+        final List<Long> playgroundIds = List.of(1L);
+
+        given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
+                .willReturn(PokeFixture.createOwnPlaygroundProfile());
+        given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
+        given(userService.getAllPlaygroundIds()).willReturn(playgroundIds); // playgroundId 존재
+        given(userService.getUserProfilesByPlaygroundIds(playgroundIds)).willReturn(List.of());// 앱 아이디가 없어 userProfile을 반환하지 않음
+
+        // when
+        RecommendedFriendsRequest result = friendRecommender.recommendFriendsByTypeList(
+                List.of(FriendRecommendType.ALL_USER), 6, UserFixture.createMyAppUser());
+
+        // then
+        assertTrue(result.getRandomInfoList().isEmpty());
+    }
+
+    @Test
+    @DisplayName("SUCCESS_요구사항4_이미 친구인 유저는 추천 친구에서 제외함 ")
+    void SUCCESS_getRecommendedFriendsByAllType_Requirement4() {
+        // given
+        final List<Long> playgroundIds = List.of(1L, 2L);
+        final List<Long> userIds = List.of(11L, 22L);
+
+        given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
+                .willReturn(PokeFixture.createOwnPlaygroundProfile());
+        given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of(11L)); // 11번 유저는 이미 친구
+
+        given(userService.getAllPlaygroundIds()).willReturn(playgroundIds);
+        given(userService.getUserProfilesByPlaygroundIds(any())).willReturn(
+                PokeFixture.createUserProfileList(userIds, playgroundIds));
+
+        // when
+        ArgumentCaptor<List<Long>> ac = ArgumentCaptor.forClass(List.class);
+        when(playgroundAuthService.getPlaygroundMemberProfiles(anyString(), ac.capture())).
+                thenReturn(PokeFixture.createPlaygroundProfileList(List.of(2L)));
+        RecommendedFriendsRequest result = friendRecommender.recommendFriendsByTypeList(
+                List.of(FriendRecommendType.ALL_USER), 6, UserFixture.createMyAppUser());
+
+        // then
+        assertEquals(2L, ac.getValue().get(0));
+        assertEquals(22L, result.getRandomInfoList().get(0).getUserInfoList().get(0).getUserId());
+    }
+
+    // TODO: 자신의 유형 값이 null이면 객체를 반환하지 않아야 하는 테스트 다른 객체로 책임 전달
+    @Test
+    @DisplayName("SUCCESS_요구사항5_자신의 유형 값이 null이면 객체를 반환하지 않음")
+    void SUCCESS_getRecommendedFriendsByAllType_Requirement5() {
+
+    }
+
+}

--- a/src/test/java/org/sopt/app/application/PlaygroundUserIdsProviderTest.java
+++ b/src/test/java/org/sopt/app/application/PlaygroundUserIdsProviderTest.java
@@ -1,0 +1,68 @@
+package org.sopt.app.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.OwnPlaygroundProfile;
+import org.sopt.app.application.playground.dto.PlaygroundUserFindCondition;
+import org.sopt.app.application.playground.dto.RecommendedFriendInfo.PlaygroundUserFindFilter;
+import org.sopt.app.application.playground.user_finder.PlaygroundUserFindConditionCreatorFactory;
+import org.sopt.app.application.playground.user_finder.PlaygroundUserFinder;
+import org.sopt.app.application.playground.user_finder.PlaygroundUserIdsProvider;
+import org.sopt.app.common.fixtures.PokeFixture;
+import org.sopt.app.domain.enums.FriendRecommendType;
+
+@ExtendWith(MockitoExtension.class)
+class PlaygroundUserIdsProviderTest {
+
+    @Spy
+    private PlaygroundUserFindConditionCreatorFactory factory;
+    @Mock
+    private PlaygroundUserFinder finder;
+    @InjectMocks
+    private PlaygroundUserIdsProvider playgroundUserIdsProvider;
+
+    @Test
+    @DisplayName("SUCCESS_자신의 유형 값과 같은 플레이그라운드 아이디 찾기")
+    void SUCCESS_findPlaygroundIdsByType() {
+        // given
+        OwnPlaygroundProfile profile = PokeFixture.createOwnPlaygroundProfile();
+
+        // when
+        ArgumentCaptor<PlaygroundUserFindCondition> ac = ArgumentCaptor.forClass(PlaygroundUserFindCondition.class);
+        when(finder.findByCondition(ac.capture())).thenReturn(Set.of(1L, 2L, 3L));
+        Set<Long> result = playgroundUserIdsProvider.findPlaygroundIdsByType(profile, FriendRecommendType.MBTI);
+        PlaygroundUserFindFilter expectedFilter = PlaygroundUserFindFilter.builder()
+                .key(String.valueOf(FriendRecommendType.MBTI))
+                .value(profile.getMbti())
+                .build();
+        // then
+        assertEquals(ac.getValue(), new PlaygroundUserFindCondition(profile.getAllGenerations(), List.of(expectedFilter)));
+        assertEquals(3, result.size());
+    }
+
+    @Test
+    @DisplayName("SUCCESS_자신의 유형 값이 null이면 빈 Set 반환")
+    void SUCCESS_findPlaygroundIdsByType_requirement_1() {
+        // given
+        OwnPlaygroundProfile profile = PokeFixture.createMbtiNullPlaygroundProfile();
+
+        // when
+        Set<Long> result = playgroundUserIdsProvider.findPlaygroundIdsByType(profile, FriendRecommendType.MBTI);
+
+        // then
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/src/test/java/org/sopt/app/facade/PokeFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/PokeFacadeTest.java
@@ -479,16 +479,15 @@ class PokeFacadeTest {
     @DisplayName("SUCCESS_요구사항1_추천할 친구가 없다면 객체를 반환하지 않음")
     void SUCCESS_getRecommendedFriendsByAllType_Requirement1() {
         // given
-        final Set<Long> emptyPlaygroundIds = Set.of();
+        final List<Long> emptyPlaygroundIds = List.of();
         final List<Long> emptyUserIds = List.of();
 
         given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
                 .willReturn(PokeFixture.createOwnPlaygroundProfile());
         given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
 
-        given(playgroundUserIdsProvider.findPlaygroundIdsByType(any(), eq(FriendRecommendType.ALL_USER)))
-                .willReturn(emptyPlaygroundIds); // 추천된 playground id 없음
-        given(userService.getUserProfilesByPlaygroundIds(List.copyOf(emptyPlaygroundIds)))
+        given(userService.getAllPlaygroundIds()).willReturn(emptyPlaygroundIds); // 추천된 playground id 없음
+        given(userService.getUserProfilesByPlaygroundIds(emptyPlaygroundIds))
                 .willReturn(PokeFixture.createUserProfileList(emptyUserIds ,List.copyOf(emptyPlaygroundIds)));
 
         // when

--- a/src/test/java/org/sopt/app/facade/PokeFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/PokeFacadeTest.java
@@ -485,7 +485,6 @@ class PokeFacadeTest {
         given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
                 .willReturn(PokeFixture.createOwnPlaygroundProfile());
         given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
-
         given(userService.getAllPlaygroundIds()).willReturn(emptyPlaygroundIds); // 추천된 playground id 없음
         given(userService.getUserProfilesByPlaygroundIds(emptyPlaygroundIds))
                 .willReturn(PokeFixture.createUserProfileList(emptyUserIds ,List.copyOf(emptyPlaygroundIds)));
@@ -522,36 +521,27 @@ class PokeFacadeTest {
         assertTrue(result.getRandomInfoList().isEmpty());
     }
 
-    /**
     @Test
     @DisplayName("SUCCESS_요구사항3_플그 아이디는 있지만 앱 아이디가 없는 유저는 추천하지 않도록 필터링")
     void SUCCESS_getRecommendedFriendsByAllType_Requirement3() {
         // given
+        final List<Long> playgroundIds = List.of(1L);
+
         given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
                 .willReturn(PokeFixture.createOwnPlaygroundProfile());
-        given(playgroundAuthService.getPlaygroundIdsForSameGeneration(List.of(GENERATION)))
-                .willReturn(List.of(1L));
-        given(playgroundAuthService.getPlaygroundIdsForSameMbti(GENERATION, MBTI))
-                .willReturn(List.of(2L));
-        given(playgroundAuthService.getPlaygroundIdsForSameUniversity(GENERATION, UNIVERSITY))
-                .willReturn(List.of(3L));
-        given(friendService.findUserIdsLinkedFriends(anyLong())).willReturn(new ArrayList<>());
-
-        given(userService.getUserProfilesByPlaygroundIds(anyList())).willReturn(
-                PokeFixture.createUserProfileList(
-                        List.of(44L, 55L, 66L, 77L, 88L),
-                        List.of(4L, 5L, 6L, 7L, 8L)
-                )); // playgroundId가 1, 2, 3인 유저는 앱 아이디가 없음
-        User myAppUser = UserFixture.createMyAppUser();
+        given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
+        given(userService.getAllPlaygroundIds()).willReturn(playgroundIds); // playgroundId 존재
+        given(userService.getUserProfilesByPlaygroundIds(playgroundIds)).willReturn(List.of());// 앱 아이디가 없어 userProfile을 반환하지 않음
 
         // when
-        RecommendedFriendsRequest result =
-                pokeFacade.getRecommendedFriendsByTypeList(List.of(FriendRecommendType.ALL), 6, myAppUser);
+        RecommendedFriendsRequest result = pokeFacade.getRecommendedFriendsByTypeList(
+                List.of(FriendRecommendType.ALL_USER), 6, UserFixture.createMyAppUser());
 
         // then
         assertTrue(result.getRandomInfoList().isEmpty());
     }
 
+    /**
     @Test
     @DisplayName("SUCCESS_요구사항4_이미 친구인 유저는 추천 친구에서 제외함 ")
     void SUCCESS_getRecommendedFriendsByAllType_Requirement4() {

--- a/src/test/java/org/sopt/app/facade/PokeFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/PokeFacadeTest.java
@@ -472,35 +472,31 @@ class PokeFacadeTest {
         assertEquals(List.copyOf(sameGenerationPlaygroundIds), resultSameGenerationPlaygroundIds);
     }
 
-    /**
     @Test
     @DisplayName("SUCCESS_요구사항1_추천할 친구가 없다면 객체를 반환하지 않음")
     void SUCCESS_getRecommendedFriendsByAllType_Requirement1() {
         // given
+        final Set<Long> sameMbtiPlaygroundIds = Set.of();
+        final List<Long> sameMbtiUserIds = List.of();
+
         given(playgroundAuthService.getOwnPlaygroundProfile(anyString()))
                 .willReturn(PokeFixture.createOwnPlaygroundProfile());
-        given(playgroundAuthService.getPlaygroundIdsForSameGeneration(List.of(GENERATION))).willReturn(List.of());
-        given(playgroundAuthService.getPlaygroundIdsForSameMbti(GENERATION, MBTI))
-                .willReturn(List.of(4L,5L,6L));
-        given(playgroundAuthService.getPlaygroundIdsForSameUniversity(GENERATION, UNIVERSITY)).willReturn(List.of());
-        given(friendService.findUserIdsLinkedFriends(anyLong()))
-                .willReturn(new ArrayList<>(Arrays.asList(44L, 55L, 66L)));
+        given(friendService.findAllFriendIdsByUserId(anyLong())).willReturn(Set.of()); // 현재 친구인 유저 없음
 
-        // 추천 친구가 있어도 이미 친구인 프로필이라서 제외되어 추천 친구가 0명이 되면 객체를 반환하지 않아야 한다.
-        given(userService.getUserProfilesByPlaygroundIds(anyList())).willReturn(
-                PokeFixture.createUserProfileList(
-                        List.of(11L, 22L, 33L, 44L, 55L, 66L, 77L, 88L, 99L),
-                        List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
-                ));
-        User myAppUser = UserFixture.createMyAppUser();
+        given(playgroundUserIdsProvider.findPlaygroundIdsByType(any(), eq(FriendRecommendType.MBTI)))
+                .willReturn(sameMbtiPlaygroundIds);
+        given(userService.getUserProfilesByPlaygroundIds(List.copyOf(sameMbtiPlaygroundIds)))
+                .willReturn(PokeFixture.createUserProfileList(sameMbtiUserIds ,List.copyOf(sameMbtiPlaygroundIds)));
 
         // when
-        RecommendedFriendsRequest result = pokeFacade.getRecommendedFriendsByTypeList(List.of(FriendRecommendType.ALL), 6, myAppUser);
+        RecommendedFriendsRequest result = pokeFacade.getRecommendedFriendsByTypeList(
+                List.of(FriendRecommendType.MBTI), 6, UserFixture.createMyAppUser());
 
         // then
         assertTrue(result.getRandomInfoList().isEmpty());
     }
 
+    /**
     @Test
     @DisplayName("SUCCESS_요구사항2_자기 자신은 추천 친구에서 제외되어야 함")
     void SUCCESS_getRecommendedFriendsByAllType_Requirement2() {
@@ -529,6 +525,7 @@ class PokeFacadeTest {
         // then
         assertTrue(result.getRandomInfoList().isEmpty());
     }
+
 
     @Test
     @DisplayName("SUCCESS_요구사항3_플그 아이디는 있지만 앱 아이디가 없는 유저는 추천하지 않도록 필터링")


### PR DESCRIPTION
## 📝 PR Summary
친구 추천에 대한 테스트를 추가하였습니다.
친구 추천에 대한 책임을 PokeFacade에서 새로운 객체를 만들어 위임했습니다.
기존 Friend filter에서 userId를 필터링 해야하지만, playground id를 필터링하고 있던 오류를 해결했습니다.

#### 🌴 Works
- [x] 친구 추천 테스트 추가

#### 🌱 Related Issue
closed #346 
