### PR TITLE
[FIX] 콕찌르기 무한반복 에러 수정 - #366

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
@@ -1,19 +1,21 @@
 package org.sopt.app.application.playground;
 
+
 import feign.HeaderMap;
 import feign.Param;
 import feign.RequestLine;
+import java.util.List;
+import java.util.Map;
 import org.sopt.app.application.auth.dto.PlaygroundAuthTokenInfo.RefreshedToken;
 import org.sopt.app.application.playground.dto.PlaygroundPostInfo.PlaygroundPostResponse;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.*;
 import org.sopt.app.application.playground.dto.PlaygroundUserFindCondition;
 import org.sopt.app.application.playground.dto.RecommendedFriendInfo.PlaygroundUserIds;
 import org.sopt.app.presentation.auth.AppAuthRequest;
-
-import java.util.List;
-import java.util.Map;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@EnableFeignClients
 public interface PlaygroundClient {
 
     @RequestLine("POST /api/v1/idp/sso/auth")

--- a/src/main/java/org/sopt/app/application/poke/PokeService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeService.java
@@ -51,16 +51,14 @@ public class PokeService {
         );
 
         if (!latestPokeFromPokedIsReplyFalse.isEmpty()) {
-            latestPokeFromPokedIsReplyFalse.get(0).activateReply();
+            latestPokeFromPokedIsReplyFalse.getFirst().activateReply();
         }
-
-        PokeHistory createdPoke = PokeHistory.builder()
+        return historyRepository.save(PokeHistory.builder()
                 .pokerId(pokerUserId)
                 .pokedId(pokedUserId)
                 .message(pokeMessage)
                 .isReply(false)
                 .isAnonymous(isAnonymous)
-                .build();
-        return historyRepository.save(createdPoke);
+                .build());
     }
 }

--- a/src/main/java/org/sopt/app/domain/entity/Friend.java
+++ b/src/main/java/org/sopt/app/domain/entity/Friend.java
@@ -13,7 +13,6 @@ import org.hibernate.annotations.ColumnDefault;
 public class Friend extends BaseEntity {
 
     @Id
-    @NotNull
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/org/sopt/app/domain/entity/poke/PokeHistory.java
+++ b/src/main/java/org/sopt/app/domain/entity/poke/PokeHistory.java
@@ -1,6 +1,10 @@
 package org.sopt.app.domain.entity.poke;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +22,6 @@ public class PokeHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @NotNull
     private Long id;
 
     @NotNull

--- a/src/main/java/org/sopt/app/domain/entity/poke/PokeMessage.java
+++ b/src/main/java/org/sopt/app/domain/entity/poke/PokeMessage.java
@@ -20,7 +20,6 @@ public class PokeMessage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @NotNull
     private Long id;
 
     @NotNull

--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -98,7 +98,7 @@ public class PokeFacade {
         pokeHistoryService.checkDuplicate(pokerUserId, pokedUserId);
         PokeHistory newPoke = pokeService.poke(pokerUserId, pokedUserId, pokeMessage, isAnonymous);
 
-        this.applyFriendship(pokerUserId, pokedUserId);
+        applyFriendship(pokerUserId, pokedUserId);
         return newPoke.getId();
     }
 


### PR DESCRIPTION
## 📝 PR Summary

#### 🌴 Works
- [x] 콕찌르기 무한반복 에러 수정
- 다음과 같은 문제점 
- 1. entity 영속화 되지 않은 시점에서 id값 호출
- 2. null check인 @NotNull 사용 
   - @NotNull을 붙인채로 builder로 생성시에 객체 자체에 id값이 없어 어플리케이션단에서 오류 발생 
#### 🌱 Related Issue
closed #366 

#### 🌵 PR 참고사항
- 
