### PR TITLE
[HOTFIX] FortuneWord가 아닌 FortuneCard id를 가져오는 로직 수정

### DIFF
--- a/src/main/java/org/sopt/app/interfaces/postgres/fortune/FortuneCardRepositoryImpl.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/fortune/FortuneCardRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.domain.entity.fortune.FortuneCard;
 import org.sopt.app.domain.entity.fortune.QFortuneCard;
+import org.sopt.app.domain.entity.fortune.QFortuneWord;
 import org.sopt.app.domain.entity.fortune.QUserFortune;
 import org.springframework.stereotype.Repository;
 
@@ -18,12 +19,15 @@ public class FortuneCardRepositoryImpl implements FortuneCardRepository {
     public Optional<FortuneCard> findByRelatedUserId(final Long userId) {
         QUserFortune userFortune = QUserFortune.userFortune;
         QFortuneCard fortuneCard = QFortuneCard.fortuneCard;
+        QFortuneWord fortuneWord = QFortuneWord.fortuneWord;
 
         return Optional.ofNullable(
                 queryFactory.select(fortuneCard)
                         .from(userFortune)
+                        .join(fortuneWord)
+                        .on(userFortune.fortuneId.eq(fortuneWord.id))
                         .join(fortuneCard)
-                        .on(userFortune.fortuneId.eq(fortuneCard.id))
+                        .on(fortuneWord.fortuneCardId.eq(fortuneCard.id))
                         .where(userFortune.userId.eq(userId))
                         .fetchOne()
         );


### PR DESCRIPTION
## 📝 PR Summary
FortuneWord가 아닌 FortuneCard id를 가져오는 로직을 수정했습니다.