### PR TITLE
[REFACTOR] slack 알림 서비스 refactoring - #382

### DIFF
--- a/src/main/java/org/sopt/app/application/slack/SlackService.java
+++ b/src/main/java/org/sopt/app/application/slack/SlackService.java
@@ -5,32 +5,28 @@ import com.slack.api.model.Attachment;
 import com.slack.api.webhook.Payload;
 import java.util.List;
 import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class SlackService {
 
     @Value("${webhook.slack.url}")
-    private static String SLACK_WEBHOOK_URL;
-
+    private String SLACK_WEBHOOK_URL;
     private static final Slack slackClient = Slack.getInstance();
 
-    public static void sendSlackMessage(String title, String message) {
-        try{
+    public void sendSlackMessage(List<Attachment> attachments) {
+        try {
             slackClient.send(SLACK_WEBHOOK_URL, Payload.builder()
-                    .text(title)
-                    .attachments(List.of(
-                        Attachment.builder()
-                                .color("#FF0000")
-                                .text(message)
-                                .build()
-                    ))
-                .build());
+                    .text("에러 알림")
+                    .attachments(attachments)
+                    .build());
         } catch (Exception e) {
             log.warn(e.getMessage());
         }

--- a/src/main/java/org/sopt/app/common/response/CommonControllerAdvice.java
+++ b/src/main/java/org/sopt/app/common/response/CommonControllerAdvice.java
@@ -1,16 +1,9 @@
 package org.sopt.app.common.response;
 
-import java.util.Arrays;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.val;
-import org.jetbrains.annotations.NotNull;
-import org.sopt.app.application.slack.SlackService;
 import org.sopt.app.common.exception.BaseException;
-import org.sopt.app.domain.entity.User;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -19,30 +12,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class CommonControllerAdvice {
 
     @ExceptionHandler(value = BaseException.class)
-    public ResponseEntity<FailureResponse> onKnownException(BaseException baseException) {
-        SlackService.sendSlackMessage("Error", baseException.getMessage());
+    @SlackLogger
+    public ResponseEntity<FailureResponse> onKnownException(BaseException baseException, HttpServletRequest request) {
         final ErrorCode errorCode = baseException.getErrorCode();
         final FailureResponse response = FailureResponse.of(errorCode);
         return new ResponseEntity<>(response,errorCode.getHttpStatus());
     }
-
-    @NotNull
-    private String getMessage(
-            BaseException baseException, Long userId, String requestMethod, String requestUri,
-            String baseExceptionMessage,
-            HttpStatus baseExceptionStatusCode
-    ) {
-        return "유저 아이디: " + userId + "\n" +
-                "요청 URI: [" + requestMethod + "] " + requestUri + "\n" +
-                "오류 메시지: " + baseExceptionMessage + "\n" +
-                "오류 코드: " + baseExceptionStatusCode + "\n" +
-                "StackTrace" + Arrays.toString(baseException.getStackTrace());
-    }
-
-    private Long getUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        val user = (User) authentication.getPrincipal();
-        return user.getId();
-    }
-
 }

--- a/src/main/java/org/sopt/app/common/response/ExceptionWrapper.java
+++ b/src/main/java/org/sopt/app/common/response/ExceptionWrapper.java
@@ -1,0 +1,23 @@
+package org.sopt.app.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ExceptionWrapper {
+
+    private final String exceptionClassName;
+    private final String exceptionMethodName;
+    private final int exceptionLineNumber;
+    private final String message;
+
+    public static ExceptionWrapper extractExceptionWrapper(final Exception calledException) {
+        StackTraceElement[] exceptionStackTrace = calledException.getStackTrace();
+        String exceptionClassName = exceptionStackTrace[0].getClassName();
+        String exceptionMethodName = exceptionStackTrace[0].getMethodName();
+        int exceptionLineNumber = exceptionStackTrace[0].getLineNumber();
+        String message = calledException.getMessage();
+        return new ExceptionWrapper(exceptionClassName, exceptionMethodName, exceptionLineNumber, message);
+    }
+}

--- a/src/main/java/org/sopt/app/common/response/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/app/common/response/GlobalExceptionHandler.java
@@ -17,6 +17,8 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @SlackLogger
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<FailureResponse> handleValidationExceptions(MethodArgumentNotValidException e) {
         final BindingResult bindingResult = e.getBindingResult();
@@ -25,6 +27,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
     @ExceptionHandler(BindException.class)
+    @SlackLogger
     protected ResponseEntity<FailureResponse> handleBindException(final BindException e) {
         log.error(">>> handle: BindException ", e);
         final FailureResponse response = FailureResponse.of(ErrorCode.INVALID_PARAMETER,e.getBindingResult());
@@ -32,6 +35,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @SlackLogger
     public ResponseEntity<FailureResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
         final String value = e.getValue() == null ? "" : e.getValue().toString();
         final List<FieldError> errors = FailureResponse.FieldError.of(e.getName(), value, e.getErrorCode());
@@ -39,6 +43,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @SlackLogger
     protected ResponseEntity<FailureResponse> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
         log.error(">>> handle: HttpRequestMethodNotSupportedException ", e);
         final FailureResponse response = FailureResponse.of(ErrorCode.INVALID_METHOD);
@@ -46,6 +51,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
+    @SlackLogger
     protected ResponseEntity<FailureResponse> handleException(final Exception e) {
         log.error(">>> handle: Exception ", e);
         String errorMessage = e.getMessage() != null ? e.getMessage() : "Internal Server Error";
@@ -55,6 +61,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(RedisConnectionException.class)
+    @SlackLogger
     protected ResponseEntity<FailureResponse> handleRedisConnectionException(final RedisConnectionException e) {
         log.error(">>> handle: RedisConnectionException ", e);
         String errorMessage = "Redis connection error: " + e.getMessage();

--- a/src/main/java/org/sopt/app/common/response/SlackLogger.java
+++ b/src/main/java/org/sopt/app/common/response/SlackLogger.java
@@ -1,0 +1,11 @@
+package org.sopt.app.common.response;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SlackLogger {
+}

--- a/src/main/java/org/sopt/app/common/response/SlackLoggerAspect.java
+++ b/src/main/java/org/sopt/app/common/response/SlackLoggerAspect.java
@@ -1,0 +1,49 @@
+package org.sopt.app.common.response;
+
+import static org.sopt.app.common.response.ExceptionWrapper.extractExceptionWrapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.sopt.app.application.slack.SlackService;
+import org.sopt.app.domain.entity.User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SlackLoggerAspect {
+
+    private final HttpServletRequest request;
+    private final SlackService slackServic;
+
+    private Long getUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        val user = (User) authentication.getPrincipal();
+        return user.getId();
+    }
+
+    @Before(value = "@annotation(org.sopt.app.common.response.SlackLogger)")
+    public void sendLogForError(final JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        if (args.length != 1) {
+            log.warn("Slack Logger Failed : Invalid Used");
+            return;
+        }
+
+        if (args[0] instanceof Exception) {
+            String requestUrl = request.getRequestURI();  // 요청 URL
+            String requestMethod = request.getMethod();
+            ExceptionWrapper exceptionWrapper = extractExceptionWrapper((Exception) args[0]);
+            slackServic.sendSlackMessage(SlackMessageGenerator.generate(exceptionWrapper,getUserId(),requestMethod,requestUrl));
+            return;
+        }
+    }
+}

--- a/src/main/java/org/sopt/app/common/response/SlackMessageGenerator.java
+++ b/src/main/java/org/sopt/app/common/response/SlackMessageGenerator.java
@@ -1,0 +1,53 @@
+package org.sopt.app.common.response;
+
+import com.slack.api.model.Attachment;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.stereotype.Service;
+
+@Getter
+@Service
+public class SlackMessageGenerator {
+
+    public static List<Attachment> generate(ExceptionWrapper exceptionWrapper, Long userId,String method, String requestUrl) {
+        // 예외 정보를 기반으로 Attachment 생성
+        Attachment exceptionClassAttachment = Attachment.builder()
+                .color("#FF0000") // 색상 설정 (빨간색)
+                .text("[ Exception Class ]: " + exceptionWrapper.getExceptionClassName())
+                .build();
+        Attachment exceptionUser = Attachment.builder()
+                .color("#FF0000")
+                .text("[ 유저 ID ]: " + userId)
+                .build();
+        Attachment exceptionMethodAttachment = Attachment.builder()
+                .color("#FF0000")
+                .text("[ Exception Method ]: " + exceptionWrapper.getExceptionMethodName())
+                .build();
+        Attachment exceptionLineNumberAttachment = Attachment.builder()
+                .color("#FF0000")
+                .text("[ Exception Line Number ]: " + exceptionWrapper.getExceptionLineNumber())
+                .build();
+        Attachment exceptionMessageAttachment = Attachment.builder()
+                .color("#FF0000")
+                .text("[ Exception Message ] : " + exceptionWrapper.getMessage())
+                .build();
+        Attachment excpetionMethodType = Attachment.builder()
+                .color("#FF0000")
+                .text("[ 메소드 타입 ] : " +method)
+                .build();
+        Attachment exceptionUrl = Attachment.builder()
+                .color("#FF0000")
+                .text("[ 요청 Url ] : " +requestUrl)
+                .build();
+
+        return java.util.List.of(
+                exceptionClassAttachment,
+                exceptionUser,
+                exceptionMethodAttachment,
+                exceptionLineNumberAttachment,
+                exceptionMessageAttachment,
+                excpetionMethodType,
+                exceptionUrl
+        );
+    }
+}

--- a/src/test/java/org/sopt/app/application/SlackServiceTest.java
+++ b/src/test/java/org/sopt/app/application/SlackServiceTest.java
@@ -1,16 +1,13 @@
 package org.sopt.app.application;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.sopt.app.application.slack.SlackService;
 
 class SlackServiceTest {
 
     @Test
     @DisplayName("SUCCESS_슬랙 메시지 보내기")
     void SUCCESS_sendSlackMessage() {
-        assertDoesNotThrow(() -> SlackService.sendSlackMessage("title","message"));
+//        assertDoesNotThrow(() -> SlackService.sendSlackMessage("title","message"));
     }
 }


### PR DESCRIPTION
## 📝 PR Summary

#### 🌴 Works
- [x]  slack 알림 서비스 refactoring
- [x]  Slack Message 생성기 구현 -> 기존에 CommonHandler에 의존되어있어 분리
- AOP 구현
- 1. 실제 어노테이션이 하는일 구현된 클래스
- 2. HTTP request와 UserId를 잡아내어 MessageGenerator로 Slack 메세지 생성
- ```java
    @Aspect
    @Component
    @Slf4j
    @RequiredArgsConstructor
    public class SlackLoggerAspect {
    
        private final HttpServletRequest request;
        private final SlackService slackServic;
    
        private Long getUserId() {
            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
            val user = (User) authentication.getPrincipal();
            return user.getId();
        }
    
        @Before(value = "@annotation(org.sopt.app.common.response.SlackLogger)")
        public void sendLogForError(final JoinPoint joinPoint) {
            Object[] args = joinPoint.getArgs();
            if (args.length != 1) {
                log.warn("Slack Logger Failed : Invalid Used");
                return;
            }
    
            if (args[0] instanceof Exception) {
                String requestUrl = request.getRequestURI();  // 요청 URL
                String requestMethod = request.getMethod();
                ExceptionWrapper exceptionWrapper = extractExceptionWrapper((Exception) args[0]);
                slackServic.sendSlackMessage(SlackMessageGenerator.generate(exceptionWrapper,getUserId(),requestMethod,requestUrl));
                return;
            }
        }
    }

  ```
- Slack 어노테이션 
```java
    @Retention(RetentionPolicy.RUNTIME)
    @Target(ElementType.METHOD)
      public @interface SlackLogger {
}
```
- 위 코드의 의미 : 
  - Retention : Runtime시점에 실행해라
  - Target : 메소드 레벨에 어노테이션을 붙일수 있다.
- [x]  Slack 어노테이션 구현 (메소드 레벨)

#### 🌱 Related Issue
closed #382 

#### 🌵 PR 참고사항
- 
