### PR TITLE
[FIX] 솝탬프 닉네임 설정 오류 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/friend/FriendRecommender.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendRecommender.java
@@ -71,7 +71,7 @@ public class FriendRecommender {
                     playgroundProfile.getProfileImage(),
                     userProfile.getName(),
                     playgroundProfile.getLatestActivity().getGeneration(),
-                    playgroundProfile.getLatestActivity().getPart()
+                    playgroundProfile.getLatestActivity().getPlaygroundPart().getPartName()
             );
         }).toList();
     }

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -154,4 +154,8 @@ public class PlaygroundAuthService {
     private String convertPlaygroundWebPageUrl(Long postId) {
         return playgroundWebPageUrl + "/?feed=" + postId;
     }
+
+    public boolean isCurrentGeneration(Long generation) {
+        return generation.equals(currentGeneration);
+    }
 }

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
@@ -1,6 +1,6 @@
 package org.sopt.app.application.playground.dto;
 
-import static org.sopt.app.domain.enums.PlaygroundPart.findPlaygroundPart;
+import static org.sopt.app.domain.enums.PlaygroundPart.findPlaygroundPartByPartName;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
@@ -114,7 +114,7 @@ public class PlaygroundProfileInfo {
         }
 
         public PlaygroundPart getPlaygroundPart() {
-            return findPlaygroundPart(cardinalInfo.split(",")[1]);
+            return findPlaygroundPartByPartName(cardinalInfo.split(",")[1]);
         }
     }
 

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
@@ -1,11 +1,14 @@
 package org.sopt.app.application.playground.dto;
 
+import static org.sopt.app.domain.enums.PlaygroundPart.findPlaygroundPart;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import java.util.*;
 import lombok.*;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
+import org.sopt.app.domain.enums.PlaygroundPart;
 import org.sopt.app.domain.enums.UserStatus;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -99,7 +102,8 @@ public class PlaygroundProfileInfo {
     @AllArgsConstructor(access = AccessLevel.PUBLIC)
     public static class ActivityCardinalInfo {
 
-        private String cardinalInfo;
+        private String cardinalInfo; // "{generation},{part}"
+        // part = 기획, 디자인, 서버, 안드로이드, iOS, 웹 / 회장, 부회장, 총무, {team} 팀장, {part} 파트장,
 
         public Long getGeneration() {
             try {
@@ -109,8 +113,8 @@ public class PlaygroundProfileInfo {
             }
         }
 
-        public String getPart() {
-            return cardinalInfo.split(",")[1];
+        public PlaygroundPart getPlaygroundPart() {
+            return findPlaygroundPart(cardinalInfo.split(",")[1]);
         }
     }
 

--- a/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
+++ b/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
@@ -10,6 +10,10 @@ public enum PlaygroundPart {
     PRESIDENT("회장", "회장"),
     VICE_PRESIDENT("부회장", "부회장"),
     GENERAL_AFFAIR("총무", "총무"),
+    MEDIA_TEAM_LEADER("미디어 팀장", "미팀장"),
+    OPERATIONS_TEAM_LEADER("운영 팀장", "운팀장"),
+    MAKERS_TEAM_LEADER("메이커스 팀장", "메팀장"),
+
     PLAN("기획", "기획"),
     PLAN_PART_LEADER("기획 파트장", "기획파트장"),
     DESIGN("디자인", "디자인"),

--- a/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
+++ b/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
@@ -34,11 +34,4 @@ public enum PlaygroundPart {
                 .findAny()
                 .orElse(PlaygroundPart.NONE);
     }
-
-    public static PlaygroundPart findPlaygroundPartByShortedPartName(String shortedPartName) {
-        return Arrays.stream(PlaygroundPart.values())
-                .filter(playgroundPart -> playgroundPart.shortedPartName.equals(shortedPartName))
-                .findAny()
-                .orElse(PlaygroundPart.NONE);
-    }
 }

--- a/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
+++ b/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum PlaygroundPart {
+    PRESIDENT("회장", "회장"),
+    VICE_PRESIDENT("부회장", "부회장"),
+    GENERAL_AFFAIR("총무", "총무"),
     PLAN("기획", "기획"),
     PLAN_PART_LEADER("기획 파트장", "기획파트장"),
     DESIGN("디자인", "디자인"),
@@ -19,16 +22,22 @@ public enum PlaygroundPart {
     WEB_PART_LEADER("웹 파트장", "웹파트장"),
     SERVER("서버", "서버"),
     SERVER_PART_LEADER("서버 파트장", "서버파트장"),
-    PRESIDENT("회장", "회장"),
-    VICE_PRESIDENT("부회장", "부회장"),
+
     NONE("미상", "선배"),
     ;
     final String partName;
-    final String soptampNickname;
+    final String shortedPartName;
 
-    public static PlaygroundPart findPlaygroundPart(String partName) {
+    public static PlaygroundPart findPlaygroundPartByPartName(String partName) {
         return Arrays.stream(PlaygroundPart.values())
-                .filter(playgroundPart -> playgroundPart.soptampNickname.equals(partName))
+                .filter(playgroundPart -> playgroundPart.partName.equals(partName))
+                .findAny()
+                .orElse(PlaygroundPart.NONE);
+    }
+
+    public static PlaygroundPart findPlaygroundPartByShortedPartName(String shortedPartName) {
+        return Arrays.stream(PlaygroundPart.values())
+                .filter(playgroundPart -> playgroundPart.shortedPartName.equals(shortedPartName))
                 .findAny()
                 .orElse(PlaygroundPart.NONE);
     }

--- a/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
+++ b/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
@@ -26,6 +26,7 @@ public enum PlaygroundPart {
     WEB_PART_LEADER("웹 파트장", "웹파트장"),
     SERVER("서버", "서버"),
     SERVER_PART_LEADER("서버 파트장", "서버파트장"),
+    // 파트장이 솝탬프 파트별 랭킹에 관여할 수 있으려면 각 파트의 shortedPartName이 접두사로 필요하다
 
     NONE("미상", "선배"),
     ;

--- a/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
+++ b/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
@@ -8,11 +8,19 @@ import lombok.Getter;
 @Getter
 public enum PlaygroundPart {
     PLAN("기획", "기획"),
+    PLAN_PART_LEADER("기획 파트장", "기획파트장"),
     DESIGN("디자인", "디자인"),
+    DESIGN_PART_LEADER("디자인 파트장", "디자인파트장"),
     ANDROID("안드로이드", "안드"),
+    ANDROID_PART_LEADER("안드로이드 파트장", "안드파트장"),
     IOS("iOS", "아요"),
+    IOS_PART_LEADER("iOS 파트장", "아요파트장"),
     WEB("웹", "웹"),
+    WEB_PART_LEADER("웹 파트장", "웹파트장"),
     SERVER("서버", "서버"),
+    SERVER_PART_LEADER("서버 파트장", "서버파트장"),
+    PRESIDENT("회장", "회장"),
+    VICE_PRESIDENT("부회장", "부회장"),
     NONE("미상", "선배"),
     ;
     final String partName;

--- a/src/main/java/org/sopt/app/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/app/facade/AuthFacade.java
@@ -28,16 +28,19 @@ public class AuthFacade {
         PlaygroundProfile playgroundProfile = playgroundAuthService.getPlaygroundMemberProfile(
                 playgroundToken, playgroundInfo.getId()
         );
+        Long latestGeneration = playgroundProfile.getLatestActivity().getGeneration();
 
         Long userId = userService.upsertUser(LoginInfo.of(playgroundInfo, playgroundToken));
-        soptampUserService.upsertSoptampUser(playgroundProfile, userId);
+        if(playgroundAuthService.isCurrentGeneration(latestGeneration)){
+            soptampUserService.upsertSoptampUser(playgroundProfile, userId);
+        }
 
         AppToken appToken = jwtTokenService.issueNewTokens(userId, playgroundInfo.getId());
         return AppAuthResponse.builder()
                 .playgroundToken(playgroundToken)
                 .accessToken(appToken.getAccessToken())
                 .refreshToken(appToken.getRefreshToken())
-                .status(playgroundAuthService.getStatus(playgroundProfile.getLatestActivity().getGeneration()))
+                .status(playgroundAuthService.getStatus(latestGeneration))
                 .build();
     }
 

--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -131,8 +131,8 @@ public class PokeFacade {
                         friendProfile.getProfileImage(),
                         friendProfile.getName(),
                         "",
-                        friendProfile.getActivities().get(0).getGeneration(),
-                        friendProfile.getActivities().get(0).getPart(),
+                        friendProfile.getActivities().getFirst().getGeneration(),
+                        friendProfile.getActivities().getFirst().getPlaygroundPart().getPartName(),
                         friendRelationInfo.getPokeNum(),
                         friendRelationInfo.getRelationName(),
                         createMutualFriendNames(user.getId(), friendId),
@@ -245,7 +245,7 @@ public class PokeFacade {
                 .name(pokedUserPlaygroundProfile.getName())
                 .profileImage(pokedUserPlaygroundProfile.getProfileImage())
                 .generation(latestActivity.getGeneration())
-                .part(latestActivity.getPart())
+                .part(latestActivity.getPlaygroundPart().getPartName())
                 .relation(relationInfo)
                 .mutualFriendNames(mutualFriendNames)
                 .build();

--- a/src/test/java/org/sopt/app/application/SoptampUserServiceTest.java
+++ b/src/test/java/org/sopt/app/application/SoptampUserServiceTest.java
@@ -28,7 +28,6 @@ import org.sopt.app.application.soptamp.SoptampUserInfo;
 import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.domain.entity.soptamp.SoptampUser;
-import org.sopt.app.domain.enums.PlaygroundPart;
 import org.sopt.app.interfaces.postgres.SoptampUserRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -124,7 +123,7 @@ class SoptampUserServiceTest {
         Long userId = 1L;
         //when
         soptampUserService.upsertSoptampUser(profile, userId);
-        String expectedNickname = profile.getLatestActivity().getPart() + profile.getName();
+        String expectedNickname = profile.getLatestActivity().getPlaygroundPart().getShortedPartName()+ profile.getName();
 
         //then
         ArgumentCaptor<SoptampUser> captor = ArgumentCaptor.forClass(SoptampUser.class);
@@ -132,7 +131,8 @@ class SoptampUserServiceTest {
         verify(soptampUserRepository, times(1)).save(captor.capture());
         assertThat(captor.getValue().getUserId()).isEqualTo(userId);
         assertThat(captor.getValue().getNickname()).isEqualTo(expectedNickname);
-        assertThat(captor.getValue().getPart().getPartName()).isEqualTo(profile.getLatestActivity().getPart());
+        assertThat(captor.getValue().getPart().getPartName())
+                .isEqualTo(profile.getLatestActivity().getPlaygroundPart().getPartName());
         assertThat(captor.getValue().getGeneration()).isEqualTo(profile.getLatestActivity().getGeneration());
     }
 
@@ -145,14 +145,17 @@ class SoptampUserServiceTest {
                 .activities(List.of(new ActivityCardinalInfo("35,서버")))
                 .build();
         given(soptampUserRepository.findByUserId(anyLong())).willReturn(Optional.empty());
-        given(soptampUserRepository.existsByNickname(profile.getLatestActivity().getPart() + profile.getName()))
+        given(soptampUserRepository.existsByNickname(
+                profile.getLatestActivity().getPlaygroundPart().getShortedPartName() + profile.getName()))
                 .willReturn(true);
-        given(soptampUserRepository.existsByNickname(profile.getLatestActivity().getPart() + profile.getName() + 'A'))
+        given(soptampUserRepository.existsByNickname(
+                profile.getLatestActivity().getPlaygroundPart().getShortedPartName() + profile.getName() + 'A'))
                 .willReturn(true);
 
         //when
         soptampUserService.upsertSoptampUser(profile, userId);
-        String expectedNickname = profile.getLatestActivity().getPart() + profile.getName() + 'B';
+        String expectedNickname =
+                profile.getLatestActivity().getPlaygroundPart().getShortedPartName() + profile.getName() + 'B';
 
         //then
         ArgumentCaptor<SoptampUser> captor = ArgumentCaptor.forClass(SoptampUser.class);
@@ -160,7 +163,8 @@ class SoptampUserServiceTest {
         verify(soptampUserRepository, times(1)).save(captor.capture());
         assertThat(captor.getValue().getUserId()).isEqualTo(userId);
         assertThat(captor.getValue().getNickname()).isEqualTo(expectedNickname);
-        assertThat(captor.getValue().getPart().getPartName()).isEqualTo(profile.getLatestActivity().getPart());
+        assertThat(captor.getValue().getPart().getPartName())
+                .isEqualTo(profile.getLatestActivity().getPlaygroundPart().getPartName());
         assertThat(captor.getValue().getGeneration()).isEqualTo(profile.getLatestActivity().getGeneration());
     }
 


### PR DESCRIPTION
## 📝 PR Summary
솝탬프 닉네임 생성에 오류가 있는 부분을 수정하였습니다.

#### 🌴 Works
- [x] PlaygroundPart에서 운영진들도 정확한 파트를 받을 수 있도록 했습니다.
- [x] 기존 soptampNickname이라는 실제 사용과 혼란이 있을 가능성이 있는 이름을 shortedPartName으로 변경하였습니다.
- [x] 현재 기수만 soptampUser를 upsert할 수 있도록 하였습니다. (불필요한 soptamp user 생성 방지)

#### 🌱 Related Issue
closed #421 

#### 🌵 PR 참고사항
- postman 테스트 완료했습니다.
- 이렇다면 회장, 부회장, 총무, 운팀장, 미팀장, 메팀장은 솝탬프에 참여하더라도 파트별 랭킹에 관여가 불가합니다 (원래 불가능했어요)
- "~~파트장"이 나을까요 "~~팟장"이 나을까요? 
