### PR TITLE
[FEAT] 알림 목록 카테고리 별 조회 기능 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/notification/NotificationService.java
+++ b/src/main/java/org/sopt/app/application/notification/NotificationService.java
@@ -10,6 +10,7 @@ import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.Notification;
 import org.sopt.app.domain.entity.User;
+import org.sopt.app.domain.enums.NotificationCategory;
 import org.sopt.app.domain.enums.NotificationType;
 import org.sopt.app.interfaces.postgres.NotificationRepository;
 import org.sopt.app.interfaces.postgres.UserRepository;
@@ -33,8 +34,15 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<Notification> findNotificationList(User user, Pageable pageable) {
-        return notificationRepository.findAllByUserId(user.getId(), pageable);
+    public List<Notification> findNotificationList(Long userId, Pageable pageable) {
+        return notificationRepository.findAllByUserId(userId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Notification> findNotificationListByCategory(
+            Long userId, Pageable pageable, NotificationCategory category
+    ) {
+        return notificationRepository.findAllByUserIdAndCategory(userId, pageable, category);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/app/interfaces/postgres/NotificationRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/NotificationRepository.java
@@ -3,6 +3,7 @@ package org.sopt.app.interfaces.postgres;
 import java.util.List;
 import java.util.Optional;
 import org.sopt.app.domain.entity.Notification;
+import org.sopt.app.domain.enums.NotificationCategory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +14,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findAllByUserId(Long userId);
 
     List<Notification> findAllByUserId(Long userId, Pageable pageable);
+
+    List<Notification> findAllByUserIdAndCategory(Long userId, Pageable pageable, NotificationCategory category);
 
     Optional<Notification> findByNotificationIdAndUserId(String notificationId, Long userId);
 

--- a/src/main/java/org/sopt/app/presentation/notification/NotificationController.java
+++ b/src/main/java/org/sopt/app/presentation/notification/NotificationController.java
@@ -6,9 +6,11 @@ import io.swagger.v3.oas.annotations.responses.*;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.util.List;
 import jakarta.validation.Valid;
+import java.util.Objects;
 import lombok.*;
 import org.sopt.app.application.notification.NotificationService;
 import org.sopt.app.domain.entity.User;
+import org.sopt.app.domain.enums.NotificationCategory;
 import org.sopt.app.presentation.notification.NotificationResponse.NotificationSimple;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -33,10 +35,16 @@ public class NotificationController {
     @GetMapping(value = "/all")
     public ResponseEntity<List<NotificationResponse.NotificationSimple>> findNotificationList(
             @AuthenticationPrincipal User user,
+            @RequestParam(name = "category", required = false) NotificationCategory category,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        val result = notificationService.findNotificationList(user, pageable);
-        return ResponseEntity.ok(result.stream().map(NotificationSimple::of).toList());
+        if(Objects.isNull(category)) {
+            val result = notificationService.findNotificationList(user.getId(), pageable);
+            return ResponseEntity.ok(result.stream().map(NotificationSimple::of).toList());
+        } else {
+            val result = notificationService.findNotificationListByCategory(user.getId(), pageable, category);
+            return ResponseEntity.ok(result.stream().map(NotificationSimple::of).toList());
+        }
     }
     @Operation(summary = "알림 상세 조회")
     @ApiResponses({


### PR DESCRIPTION
## 📝 PR Summary
알림 목록의 카테고리 별 조회 기능을 추가하였습니다.
param에 category 필드를 추가하여 category 필드가 없다면 전체 알림 목록 조회, category 필드가 있다면 카테고리 별 알림 목록 조회가 가능하도록 기능을 구현했습니다.

#### 🌴 Works
- [x] 알림 목록 카테고리 별 조회 기능 추가

#### 🌱 Related Issue
closed #430 

#### 🌵 PR 참고사항
- Postman 테스트 완료했습니다.
