### PR TITLE
[MODIFY] 일정이 끝났을 때, 일정 관련 api에서 가장 마지막 일정을 반환하도록 수정

### DIFF
--- a/src/main/java/org/sopt/app/presentation/calendar/CalendarResponse.java
+++ b/src/main/java/org/sopt/app/presentation/calendar/CalendarResponse.java
@@ -13,14 +13,16 @@ public class CalendarResponse {
     private final LocalDate endDate;
     private final Boolean isOneDaySchedule;
     private final Boolean isOnlyActiveGeneration;
+    private final Boolean isRecentSchedule;
 
-    public static CalendarResponse of(Calendar calendar) {
+    public static CalendarResponse of(Calendar calendar, Boolean isRecentSchedule) {
         return CalendarResponse.builder()
                 .startDate(calendar.getStartDate())
                 .endDate(calendar.getEndDate())
                 .title(calendar.getTitle())
                 .isOneDaySchedule(calendar.getIsOneDaySchedule())
                 .isOnlyActiveGeneration(calendar.getIsOnlyActiveGeneration())
+                .isRecentSchedule(isRecentSchedule)
                 .build();
     }
 }


### PR DESCRIPTION
## 📝 PR Summary
일정이 끝났을 때, 일정 관련 api에서 가장 마지막 일정을 반환하도록 수정합니다.

#### 🌴 Works
- [x] 일정 단일 조회 api에서 일정이 끝나면 가장 마지막 일정을 반환하도록 수정
- [x]  일정 목록 전체 조회 api에서 일정이 끝나면 모든 isRecentSchedule을 false로 반환하도록 수정


#### 🌱 Related Issue
closed #444 

#### 🌵 PR 참고사항
- postman 테스트도 완료했습니다.
