### PR TITLE
[FEAT] 전체 모임 확인 dummy api 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/meeting/MeetingCategory.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingCategory.java
@@ -1,0 +1,6 @@
+package org.sopt.app.application.meeting;
+
+public enum MeetingCategory {
+    STUDY,
+    EVENT
+}

--- a/src/main/java/org/sopt/app/application/meeting/MeetingResponse.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingResponse.java
@@ -11,9 +11,10 @@ public record MeetingResponse(
     String imageUrl,
     Boolean canJoinOnlyActiveGeneration
 ) {
-    public static MeetingResponse eventActiveDummy() {
+    @Deprecated
+    public static MeetingResponse eventActiveDummy(Long id) {
         return MeetingResponse.builder()
-                .meetingId(1L)
+                .meetingId(id)
                 .title("[35기 솝커톤] 서버 파트 신청")
                 .category(MeetingCategory.EVENT)
                 .status(MeetingStatus.ACTIVE)
@@ -22,9 +23,10 @@ public record MeetingResponse(
                 .build();
     }
 
-    public static MeetingResponse studyRecruitingDummy() {
+    @Deprecated
+    public static MeetingResponse studyRecruitingDummy(Long id) {
         return MeetingResponse.builder()
-                .meetingId(2L)
+                .meetingId(id)
                 .title("모집중이고 활동 기수만 참여하는 스터디")
                 .category(MeetingCategory.STUDY)
                 .status(MeetingStatus.RECRUITING)
@@ -33,9 +35,10 @@ public record MeetingResponse(
                 .build();
     }
 
-    public static MeetingResponse studyPreRecruitingDummy() {
+    @Deprecated
+    public static MeetingResponse studyPreRecruitingDummy(Long id) {
         return MeetingResponse.builder()
-                .meetingId(3L)
+                .meetingId(id)
                 .title("모집 이전이고 모든 기수가 참여하는 스터디")
                 .category(MeetingCategory.STUDY)
                 .status(MeetingStatus.PRE_RECRUITING)
@@ -44,9 +47,10 @@ public record MeetingResponse(
                 .build();
     }
 
-    public static MeetingResponse studyClosedDummy() {
+    @Deprecated
+    public static MeetingResponse studyClosedDummy(Long id) {
         return MeetingResponse.builder()
-                .meetingId(4L)
+                .meetingId(id)
                 .title("모집이 끝나고 모든 기수가 참여하는 스터디")
                 .category(MeetingCategory.STUDY)
                 .status(MeetingStatus.CLOSED)
@@ -55,9 +59,10 @@ public record MeetingResponse(
                 .build();
     }
 
-    public static MeetingResponse studyActiveDummy() {
+    @Deprecated
+    public static MeetingResponse studyActiveDummy(Long id) {
         return MeetingResponse.builder()
-                .meetingId(5L)
+                .meetingId(id)
                 .title("활동중이고 활동 기수만 참여하는 스터디")
                 .category(MeetingCategory.STUDY)
                 .status(MeetingStatus.ACTIVE)

--- a/src/main/java/org/sopt/app/application/meeting/MeetingResponse.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingResponse.java
@@ -1,0 +1,68 @@
+package org.sopt.app.application.meeting;
+
+import lombok.Builder;
+
+@Builder
+public record MeetingResponse(
+    Long meetingId,
+    String title,
+    MeetingCategory category,
+    MeetingStatus status,
+    String imageUrl,
+    Boolean canJoinOnlyActiveGeneration
+) {
+    public static MeetingResponse eventActiveDummy() {
+        return MeetingResponse.builder()
+                .meetingId(1L)
+                .title("[35기 솝커톤] 서버 파트 신청")
+                .category(MeetingCategory.EVENT)
+                .status(MeetingStatus.ACTIVE)
+                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
+                .canJoinOnlyActiveGeneration(false)
+                .build();
+    }
+
+    public static MeetingResponse studyRecruitingDummy() {
+        return MeetingResponse.builder()
+                .meetingId(2L)
+                .title("모집중이고 활동 기수만 참여하는 스터디")
+                .category(MeetingCategory.STUDY)
+                .status(MeetingStatus.RECRUITING)
+                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
+                .canJoinOnlyActiveGeneration(true)
+                .build();
+    }
+
+    public static MeetingResponse studyPreRecruitingDummy() {
+        return MeetingResponse.builder()
+                .meetingId(3L)
+                .title("모집 이전이고 모든 기수가 참여하는 스터디")
+                .category(MeetingCategory.STUDY)
+                .status(MeetingStatus.PRE_RECRUITING)
+                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
+                .canJoinOnlyActiveGeneration(false)
+                .build();
+    }
+
+    public static MeetingResponse studyClosedDummy() {
+        return MeetingResponse.builder()
+                .meetingId(4L)
+                .title("모집이 끝나고 모든 기수가 참여하는 스터디")
+                .category(MeetingCategory.STUDY)
+                .status(MeetingStatus.CLOSED)
+                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
+                .canJoinOnlyActiveGeneration(false)
+                .build();
+    }
+
+    public static MeetingResponse studyActiveDummy() {
+        return MeetingResponse.builder()
+                .meetingId(5L)
+                .title("활동중이고 활동 기수만 참여하는 스터디")
+                .category(MeetingCategory.STUDY)
+                .status(MeetingStatus.ACTIVE)
+                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
+                .canJoinOnlyActiveGeneration(true)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/app/application/meeting/MeetingStatus.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingStatus.java
@@ -1,0 +1,8 @@
+package org.sopt.app.application.meeting;
+
+public enum MeetingStatus {
+    RECRUITING,
+    PRE_RECRUITING,
+    CLOSED,
+    ACTIVE
+}

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.app_service.dto.AppServiceEntryStatusResponse;
+import org.sopt.app.application.meeting.MeetingResponse;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.facade.HomeFacade;
 import org.springframework.http.ResponseEntity;
@@ -49,6 +50,35 @@ public class HomeController {
     ) {
         return ResponseEntity.ok(
                 homeFacade.checkAppServiceEntryStatus(user)
+        );
+    }
+
+    @Operation(summary = "전체 모임 확인")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "401", description = "token error", content = @Content),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping("/meeting/all")
+    public ResponseEntity<List<MeetingResponse>> getAllMeeting(
+            @AuthenticationPrincipal User user,
+            @RequestParam(value = "page") final int page,
+            @RequestParam(value = "take") final int take,
+            @RequestParam(value = "category") final String category
+    ) {
+        return ResponseEntity.ok(
+                List.of(
+                        MeetingResponse.eventActiveDummy(1L),
+                        MeetingResponse.studyRecruitingDummy(2L),
+                        MeetingResponse.studyPreRecruitingDummy(3L),
+                        MeetingResponse.studyClosedDummy(4L),
+                        MeetingResponse.studyActiveDummy(5L),
+                        MeetingResponse.eventActiveDummy(6L),
+                        MeetingResponse.studyRecruitingDummy(7L),
+                        MeetingResponse.studyPreRecruitingDummy(8L),
+                        MeetingResponse.studyClosedDummy(9L),
+                        MeetingResponse.studyActiveDummy(10L)
+                )
         );
     }
 }


### PR DESCRIPTION
## 📝 PR Summary
전체 모임 확인 dummy api를 추가하였습니다.
크루에게 internal api 전달받으면 작업 시작하도록 하겠습니다.

#### 🌴 Works
- [x] 전체 모임 확인 dummy api 추가

#### 🌱 Related Issue
closed #431 
