### PR TITLE
[FEAT] 카테고리별 최신 게시물 조회 API 구현 - #434

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -182,22 +182,10 @@ public class PlaygroundAuthService {
         final Map<String, String> accessToken = createAuthorizationHeaderByUserPlaygroundToken(playgroundToken);
         try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
             List<String> categories = List.of("SOPT 활동", "자유", "파트");
-
-            CompletableFuture<RecentPostsResponse> hotPostFuture = CompletableFuture.supplyAsync(() -> {
-                PlaygroundPostResponse hotpost = playgroundClient.getPlaygroundHotPost(accessToken);
-                return RecentPostsResponse.builder()
-                        .category("HOT")
-                        .isHotPost(true)
-                        .content(hotpost.content())
-                        .title(hotpost.title())
-                        .id(hotpost.postId())
-                        .build();
-            }, executor);
+            CompletableFuture<RecentPostsResponse> hotPostFuture = CompletableFuture.supplyAsync(() ->
+                    RecentPostsResponse.of(playgroundClient.getPlaygroundHotPost(accessToken)), executor);
             List<CompletableFuture<RecentPostsResponse>> categoryFutures = categories.stream()
-                    .map(category -> CompletableFuture.supplyAsync(() -> {
-                        RecentPostsResponse recentPosts = playgroundClient.getRecentPosts(accessToken, category);
-                        return recentPosts;
-                    }, executor))
+                    .map(category -> CompletableFuture.supplyAsync(() -> playgroundClient.getRecentPosts(accessToken, category), executor))
                     .toList();
             List<CompletableFuture<RecentPostsResponse>> allFutures = new ArrayList<>(categoryFutures);
             allFutures.addFirst(hotPostFuture);

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
@@ -10,6 +10,7 @@ import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.*;
 import org.sopt.app.application.playground.dto.PlaygroundUserFindCondition;
 import org.sopt.app.application.playground.dto.RecommendedFriendInfo.PlaygroundUserIds;
 import org.sopt.app.presentation.auth.AppAuthRequest.*;
+import org.sopt.app.presentation.home.response.RecentPostsResponse;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -45,4 +46,8 @@ public interface PlaygroundClient {
 
     @RequestLine("GET /api/v1/community/posts/hot")
     PlaygroundPostResponse getPlaygroundHotPost(@HeaderMap Map<String, String> headers);
+
+    @RequestLine("GET /internal/api/v1/community/post/recent?category={category}")
+    RecentPostsResponse getRecentPosts(@HeaderMap Map<String, String> headers, @Param("category") String category);
+
 }

--- a/src/main/java/org/sopt/app/application/playground/dto/PlayGroundPostCategory.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlayGroundPostCategory.java
@@ -1,0 +1,17 @@
+package org.sopt.app.application.playground.dto;
+
+public enum PlayGroundPostCategory {
+    SOPT_ACTIVITY("SOPT 활동"),
+    FREE("자유"),
+    PART("파트");
+    private final String displayName;
+
+    PlayGroundPostCategory(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}
+

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -13,6 +13,7 @@ import org.sopt.app.application.description.DescriptionService;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.domain.enums.UserStatus;
 import org.sopt.app.presentation.home.HomeDescriptionResponse;
+import org.sopt.app.presentation.home.response.RecentPostsResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,5 +67,16 @@ public class HomeFacade {
         }
 
         return false;
+    }
+
+    public List<RecentPostsResponse> getRecentPosts(User user) {
+        return playgroundAuthService.getRecentPosts(user.getPlaygroundToken()).stream()
+                .map(post -> RecentPostsResponse.builder()
+                        .id(post.getId())
+                        .title(post.getTitle())
+                        .category(post.getCategory())
+                        .isHotPost(post.isHotPost())
+                        .build()
+                ).toList();
     }
 }

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.app_service.dto.AppServiceEntryStatusResponse;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.facade.HomeFacade;
+import org.sopt.app.presentation.home.response.RecentPostsResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -49,6 +50,21 @@ public class HomeController {
     ) {
         return ResponseEntity.ok(
                 homeFacade.checkAppServiceEntryStatus(user)
+        );
+    }
+
+    @Operation(summary = "카테고리별 최신 게시물 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "401", description = "token error", content = @Content),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping("/posts")
+    public ResponseEntity<List<RecentPostsResponse>> getRecentPost(
+            @AuthenticationPrincipal User user
+    ) {
+        return ResponseEntity.ok(
+                homeFacade.getRecentPosts(user)
         );
     }
 }

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -66,9 +66,9 @@ public class HomeController {
             @AuthenticationPrincipal User user
     ) {
         return ResponseEntity.ok(
-                homeFacade.getRecentPosts(user)
+                homeFacade.getRecentPosts(user));
     }
-    
+
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "success"),
             @ApiResponse(responseCode = "401", description = "token error", content = @Content),

--- a/src/main/java/org/sopt/app/presentation/home/response/RecentPostsResponse.java
+++ b/src/main/java/org/sopt/app/presentation/home/response/RecentPostsResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.sopt.app.application.playground.dto.PlaygroundPostInfo.PlaygroundPostResponse;
 
 @Data
 @Builder
@@ -15,4 +16,14 @@ public class RecentPostsResponse {
     private String category;
     private String content;
     private boolean isHotPost;
+
+    public static RecentPostsResponse of(PlaygroundPostResponse playgroundPostResponse) {
+        return RecentPostsResponse.builder()
+                .id(playgroundPostResponse.postId())
+                .title(playgroundPostResponse.title())
+                .category("HOT")
+                .content(playgroundPostResponse.content())
+                .isHotPost(true)
+                .build();
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/home/response/RecentPostsResponse.java
+++ b/src/main/java/org/sopt/app/presentation/home/response/RecentPostsResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.app.presentation.home.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecentPostsResponse {
+    private Long id;
+    private String title;
+    private String category;
+    private String content;
+    private boolean isHotPost;
+}


### PR DESCRIPTION
## 📝 PR Summary

#### 🌴 Works
- [x] 카테고리별 최신 게시물 조회 API 구현 

#### 🌱 Related Issue
closed #434 

#### 🌵 PR 참고사항
- Playground에 content값을 추가해서 요청했습니다
- 아직 값이 없어 content는 null인 상태입니다.
![image](https://github.com/user-attachments/assets/18f78c9c-e00e-4c22-93c0-093a77e70e63)

