### PR TITLE
[FIX] 솝탬프 contents가 empty이면 오류가 발생하는 에러 해결

### DIFF
--- a/src/main/java/org/sopt/app/presentation/stamp/StampRequest.java
+++ b/src/main/java/org/sopt/app/presentation/stamp/StampRequest.java
@@ -1,6 +1,7 @@
 package org.sopt.app.presentation.stamp;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -36,6 +37,7 @@ public class StampRequest {
         private String image;
         @Schema(description = "스탬프 내용", example = "스탬프 찍었다!")
         @NotNull(message = "contents may not be null")
+        @NotEmpty(message = "contents may not be empty")
         private String contents;
         @Schema(description = "활동 날짜", example = "2024.04.08")
         @NotNull(message = "activity date may not be null")


### PR DESCRIPTION
## 📝 PR Summary
스탬프 contents가 empty이면 오류가 발생하는 에러를 해결했습니다.
contents가 empty인 스탬프 확인시 에러가 아닌 로그를 남기도록 수정하였습니다.

#### 🌱 Related Issue
closed #441 