### PR TITLE
[MODIFY] 기획 변경으로 인한 앱 서비스 반환 API 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/app_service/AppServiceBadgeService.java
+++ b/src/main/java/org/sopt/app/application/app_service/AppServiceBadgeService.java
@@ -16,6 +16,12 @@ public class AppServiceBadgeService {
     public AppServiceEntryStatusResponse getAppServiceEntryStatusResponse(
             final AppServiceInfo appServiceInfo, final Long userId
     ) {
+        AppServiceBadgeManager badgeManager = getAppServiceBadgeManager(appServiceInfo);
+        AppServiceBadgeInfo badgeInfo = badgeManager.acquireAppServiceBadgeInfo(userId);
+        return AppServiceEntryStatusResponse.createAppServiceEntryStatus(appServiceInfo, badgeInfo);
+    }
+
+    private AppServiceBadgeManager getAppServiceBadgeManager(AppServiceInfo appServiceInfo) {
         AppServiceBadgeManager badgeManager = badgeManagerMap.get(
                 AppServiceName.of(appServiceInfo.getServiceName()).getBadgeManagerName()
         );
@@ -23,8 +29,6 @@ public class AppServiceBadgeService {
         if(badgeManager == null) {
             badgeManager = badgeManagerMap.get("defaultBadgeManager");
         }
-
-        AppServiceBadgeInfo badgeInfo = badgeManager.acquireAppServiceBadgeInfo(userId);
-        return AppServiceEntryStatusResponse.createAppServiceEntryStatus(appServiceInfo, badgeInfo);
+        return badgeManager;
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/AppServiceName.java
+++ b/src/main/java/org/sopt/app/application/app_service/AppServiceName.java
@@ -6,11 +6,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AppServiceName {
-    POKE("POKE","pokeBadgeManager"),
-    SOPTAMP("SOPTAMP","soptampBadgeManager"),
-    FORTUNE("FORTUNE","fortuneBadgeManager"),
-    OTHERS("OTHERS","defaultBadgeManager");
+    POKE("콕찌르기", "POKE","pokeBadgeManager"),
+    SOPTAMP("솝탬프", "SOPTAMP","soptampBadgeManager"),
+    FORTUNE("솝마디", "FORTUNE","fortuneBadgeManager"),
+    OTHERS("", "OTHERS","defaultBadgeManager");
 
+    private final String exposedName;
     private final String serviceName;
     private final String badgeManagerName;
 

--- a/src/main/java/org/sopt/app/application/app_service/FortuneBadgeManager.java
+++ b/src/main/java/org/sopt/app/application/app_service/FortuneBadgeManager.java
@@ -18,6 +18,6 @@ public class FortuneBadgeManager implements AppServiceBadgeManager {
         if(fortuneService.isExistTodayFortune(userId)){
             return AppServiceBadgeInfo.createWithAllDisabled();
         }
-        return AppServiceBadgeInfo.createWithEnabledDisPlayMessage();
+        return AppServiceBadgeInfo.createWithEnabledDisPlayAlarmBadge("N");
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/PokeBadgeManager.java
+++ b/src/main/java/org/sopt/app/application/app_service/PokeBadgeManager.java
@@ -17,8 +17,12 @@ public class PokeBadgeManager implements AppServiceBadgeManager {
     public AppServiceBadgeInfo acquireAppServiceBadgeInfo(final Long userId) {
         Long unRepliedPokeMeSize = pokeHistoryService.getUnRepliedPokeMeSize(userId);
         if(unRepliedPokeMeSize > 0) {
-            return AppServiceBadgeInfo.createWithEnabledDisPlayAlarmBadge(unRepliedPokeMeSize.toString());
+            return AppServiceBadgeInfo.createWithEnabledDisPlayAlarmBadge(limitLessThanTwoNumbers(unRepliedPokeMeSize));
         }
         return AppServiceBadgeInfo.createWithAllDisabled();
+    }
+
+    private String limitLessThanTwoNumbers(final Long number) {
+        return number > 9 ? "9+" : number.toString();
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/SoptampBadgeManager.java
+++ b/src/main/java/org/sopt/app/application/app_service/SoptampBadgeManager.java
@@ -24,7 +24,7 @@ public class SoptampBadgeManager implements AppServiceBadgeManager {
             return AppServiceBadgeInfo.createWithAllDisabled();
         }
         return AppServiceBadgeInfo.createWithEnabledDisPlayAlarmBadge(
-                rankFacade.findPartRank(part).getRank().toString()
+                rankFacade.findPartRank(part).getRank().toString() + "위"
         );
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/dto/AppServiceBadgeInfo.java
+++ b/src/main/java/org/sopt/app/application/app_service/dto/AppServiceBadgeInfo.java
@@ -7,29 +7,18 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AppServiceBadgeInfo {
 
-    private Boolean displayMessage;
     private Boolean displayAlarmBadge;
     private String alarmBadge;
 
     public static AppServiceBadgeInfo createWithEnabledDisPlayAlarmBadge(String alarmBadge) {
         return AppServiceBadgeInfo.builder()
-                .displayMessage(false)
                 .displayAlarmBadge(true)
                 .alarmBadge(alarmBadge)
                 .build();
     }
 
-    public static AppServiceBadgeInfo createWithEnabledDisPlayMessage() {
-        return AppServiceBadgeInfo.builder()
-                .displayMessage(true)
-                .displayAlarmBadge(false)
-                .alarmBadge("")
-                .build();
-    }
-
     public static AppServiceBadgeInfo createWithAllDisabled() {
         return AppServiceBadgeInfo.builder()
-                .displayMessage(false)
                 .displayAlarmBadge(false)
                 .alarmBadge("")
                 .build();

--- a/src/main/java/org/sopt/app/application/app_service/dto/AppServiceEntryStatusResponse.java
+++ b/src/main/java/org/sopt/app/application/app_service/dto/AppServiceEntryStatusResponse.java
@@ -11,6 +11,8 @@ public class AppServiceEntryStatusResponse {
     private final String serviceName;
     private final Boolean displayAlarmBadge;
     private final String alarmBadge;
+    private final String iconUrl;
+    private final String deepLink;
 
     public static AppServiceEntryStatusResponse createAppServiceEntryStatus (
             AppServiceInfo appServiceInfo, AppServiceBadgeInfo badgeInfo
@@ -19,6 +21,8 @@ public class AppServiceEntryStatusResponse {
                 .serviceName(AppServiceName.of(appServiceInfo.getServiceName()).getExposedName())
                 .displayAlarmBadge(badgeInfo.getDisplayAlarmBadge())
                 .alarmBadge(badgeInfo.getAlarmBadge())
+                .iconUrl(appServiceInfo.getIconUrl())
+                .deepLink(appServiceInfo.getDeepLink())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/dto/AppServiceEntryStatusResponse.java
+++ b/src/main/java/org/sopt/app/application/app_service/dto/AppServiceEntryStatusResponse.java
@@ -1,6 +1,5 @@
 package org.sopt.app.application.app_service.dto;
 
-import java.util.List;
 import lombok.*;
 
 @Builder
@@ -11,33 +10,14 @@ public class AppServiceEntryStatusResponse {
     private final String serviceName;
     private final Boolean displayAlarmBadge;
     private final String alarmBadge;
-    private final Boolean displayMessage;
-    private final List<String> messages;
-    private final List<String> messageColors;
 
     public static AppServiceEntryStatusResponse createAppServiceEntryStatus (
             AppServiceInfo appServiceInfo, AppServiceBadgeInfo badgeInfo
     ) {
-        if (badgeInfo.getDisplayMessage().equals(Boolean.TRUE)){
-            return createAppServiceEntryStatusByDisPlayMessage(appServiceInfo);
-        }
         if(badgeInfo.getDisplayAlarmBadge().equals(Boolean.TRUE)){
             return createAppServiceEntryStatusByDisPlayAlarmBadge(appServiceInfo, badgeInfo.getAlarmBadge());
         }
         return createDefaultAppServiceEntryStatus(appServiceInfo);
-    }
-
-    private static AppServiceEntryStatusResponse createAppServiceEntryStatusByDisPlayMessage(
-            AppServiceInfo appServiceInfo
-    ) {
-        return AppServiceEntryStatusResponse.builder()
-                .serviceName(appServiceInfo.getServiceName())
-                .displayAlarmBadge(false)
-                .alarmBadge("")
-                .displayMessage(true)
-                .messages(appServiceInfo.getMessages())
-                .messageColors(appServiceInfo.getMessageColors())
-                .build();
     }
 
     private static AppServiceEntryStatusResponse createAppServiceEntryStatusByDisPlayAlarmBadge(
@@ -47,9 +27,6 @@ public class AppServiceEntryStatusResponse {
                 .serviceName(appServiceInfo.getServiceName())
                 .displayAlarmBadge(true)
                 .alarmBadge(alarmBadge)
-                .displayMessage(false)
-                .messages(List.of())
-                .messageColors(List.of())
                 .build();
     }
 
@@ -60,9 +37,6 @@ public class AppServiceEntryStatusResponse {
                 .serviceName(appServiceInfo.getServiceName())
                 .displayAlarmBadge(false)
                 .alarmBadge("")
-                .displayMessage(false)
-                .messages(List.of())
-                .messageColors(List.of())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/dto/AppServiceEntryStatusResponse.java
+++ b/src/main/java/org/sopt/app/application/app_service/dto/AppServiceEntryStatusResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.app.application.app_service.dto;
 
 import lombok.*;
+import org.sopt.app.application.app_service.AppServiceName;
 
 @Builder
 @Getter
@@ -14,29 +15,10 @@ public class AppServiceEntryStatusResponse {
     public static AppServiceEntryStatusResponse createAppServiceEntryStatus (
             AppServiceInfo appServiceInfo, AppServiceBadgeInfo badgeInfo
     ) {
-        if(badgeInfo.getDisplayAlarmBadge().equals(Boolean.TRUE)){
-            return createAppServiceEntryStatusByDisPlayAlarmBadge(appServiceInfo, badgeInfo.getAlarmBadge());
-        }
-        return createDefaultAppServiceEntryStatus(appServiceInfo);
-    }
-
-    private static AppServiceEntryStatusResponse createAppServiceEntryStatusByDisPlayAlarmBadge(
-            AppServiceInfo appServiceInfo, String alarmBadge
-    ) {
         return AppServiceEntryStatusResponse.builder()
-                .serviceName(appServiceInfo.getServiceName())
-                .displayAlarmBadge(true)
-                .alarmBadge(alarmBadge)
-                .build();
-    }
-
-    private static AppServiceEntryStatusResponse createDefaultAppServiceEntryStatus(
-            AppServiceInfo appServiceInfo
-    ) {
-        return AppServiceEntryStatusResponse.builder()
-                .serviceName(appServiceInfo.getServiceName())
-                .displayAlarmBadge(false)
-                .alarmBadge("")
+                .serviceName(AppServiceName.of(appServiceInfo.getServiceName()).getExposedName())
+                .displayAlarmBadge(badgeInfo.getDisplayAlarmBadge())
+                .alarmBadge(badgeInfo.getAlarmBadge())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/dto/AppServiceInfo.java
+++ b/src/main/java/org/sopt/app/application/app_service/dto/AppServiceInfo.java
@@ -12,12 +12,16 @@ public class AppServiceInfo {
     private final String serviceName;
     private final Boolean activeUser;
     private final Boolean inactiveUser;
+    private final String iconUrl;
+    private final String deepLink;
 
     public static AppServiceInfo of(final AppService appService) {
         return AppServiceInfo.builder()
                 .serviceName(appService.getServiceName())
                 .activeUser(appService.getActiveUser())
                 .inactiveUser(appService.getInactiveUser())
+                .iconUrl(appService.getIconUrl())
+                .deepLink(appService.getDeepLink())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/app/application/app_service/dto/AppServiceInfo.java
+++ b/src/main/java/org/sopt/app/application/app_service/dto/AppServiceInfo.java
@@ -1,6 +1,5 @@
 package org.sopt.app.application.app_service.dto;
 
-import java.util.List;
 import lombok.*;
 import org.sopt.app.domain.entity.AppService;
 
@@ -13,16 +12,12 @@ public class AppServiceInfo {
     private final String serviceName;
     private final Boolean activeUser;
     private final Boolean inactiveUser;
-    private final List<String> messages;
-    private final List<String> messageColors;
 
     public static AppServiceInfo of(final AppService appService) {
         return AppServiceInfo.builder()
                 .serviceName(appService.getServiceName())
                 .activeUser(appService.getActiveUser())
                 .inactiveUser(appService.getInactiveUser())
-                .messages(appService.getMessages())
-                .messageColors(appService.getMessageColors())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/app/domain/entity/AppService.java
+++ b/src/main/java/org/sopt/app/domain/entity/AppService.java
@@ -1,12 +1,8 @@
 package org.sopt.app.domain.entity;
 
-import io.hypersistence.utils.hibernate.type.array.ListArrayType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.Type;
 
 @Getter
 @Entity
@@ -28,15 +24,4 @@ public class AppService extends BaseEntity {
     @NotNull
     private Boolean inactiveUser;
 
-    @NotNull
-    @Column(columnDefinition = "text[]")
-    @ColumnDefault("'{}'::text[]")
-    @Type(value= ListArrayType.class)
-    private List<String> messages;
-
-    @NotNull
-    @Column(columnDefinition = "text[]")
-    @ColumnDefault("'{}'::text[]")
-    @Type(value= ListArrayType.class)
-    private List<String> messageColors;
 }

--- a/src/main/java/org/sopt/app/domain/entity/AppService.java
+++ b/src/main/java/org/sopt/app/domain/entity/AppService.java
@@ -24,4 +24,8 @@ public class AppService extends BaseEntity {
     @NotNull
     private Boolean inactiveUser;
 
+    private String iconUrl;
+
+    private String deepLink;
+
 }


### PR DESCRIPTION
## 📝 PR Summary
기획 변경으로 인해 앱 서비스 반환 API를 수정하였습니다.

#### 🌴 Works
- [x] 앱 서비스 메시지 삭제
 - [x] 앱 서비스 반환에 서비스 이미지와 해당 서비스의 딥링크 값 반환
 - [x] 콕찌르기 알림 배지에서 숫자가 10 이상일 경우 9+로 반환하도록 통일
 - [x] 솝탬프 알림 배지에서 등수 뒤에 ~위 붙이기 (ex) 1 -> 1위)
- [x] 서비스 이름 영어 -> 한글 변경

#### 🌱 Related Issue
closed #456 

#### 🌵 PR 참고사항
- App Service 엔티티 변경으로 인한 App Service에 컬럼 추가해두었습니다.
