### PR TITLE
[FEAT] 모든 모임 조회 api 크루 api와 연결

### DIFF
--- a/src/main/java/org/sopt/app/application/meeting/CrewClient.java
+++ b/src/main/java/org/sopt/app/application/meeting/CrewClient.java
@@ -6,11 +6,12 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableFeignClients
 public interface CrewClient {
-    @RequestLine("GET /internal/meetings")
+
+    @RequestLine("GET /internal/meetings?orgId={playgroundId}&page={page}&take={take}&category={category}&isOnlyActiveGeneration={isOnlyActiveGeneration}")
     CrewMeetingResponse getAllMeetings(@HeaderMap Map<String, String> headers,
-            @Param("orgId") Long playgroundId,
-            @Param("page") Long page,
-            @Param("take") Long take,
+            @Param("playgroundId") Long playgroundId,
+            @Param("page") int page,
+            @Param("take") int take,
             @Param("category") String category,
             @Param("isOnlyActiveGeneration") Boolean isOnlyActiveGeneration
     );

--- a/src/main/java/org/sopt/app/application/meeting/CrewClient.java
+++ b/src/main/java/org/sopt/app/application/meeting/CrewClient.java
@@ -1,0 +1,17 @@
+package org.sopt.app.application.meeting;
+
+import feign.*;
+import java.util.Map;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@EnableFeignClients
+public interface CrewClient {
+    @RequestLine("GET /internal/meetings")
+    CrewMeetingResponse getAllMeetings(@HeaderMap Map<String, String> headers,
+            @Param("orgId") Long playgroundId,
+            @Param("page") Long page,
+            @Param("take") Long take,
+            @Param("category") String category,
+            @Param("isOnlyActiveGeneration") Boolean isOnlyActiveGeneration
+    );
+}

--- a/src/main/java/org/sopt/app/application/meeting/CrewMeetingResponse.java
+++ b/src/main/java/org/sopt/app/application/meeting/CrewMeetingResponse.java
@@ -3,9 +3,9 @@ package org.sopt.app.application.meeting;
 import java.util.List;
 
 public record CrewMeetingResponse(
-        List<Meeting> meetings
+        List<CrewMeeting> meetings
 ) {
-    public record Meeting(
+    public record CrewMeeting(
         Long id,
         String title,
         Boolean canJoinOnlyActiveGeneration,

--- a/src/main/java/org/sopt/app/application/meeting/CrewMeetingResponse.java
+++ b/src/main/java/org/sopt/app/application/meeting/CrewMeetingResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.app.application.meeting;
+
+import java.util.List;
+
+public record CrewMeetingResponse(
+        List<Meeting> meetings
+) {
+    public record Meeting(
+        Long id,
+        String title,
+        Boolean canJoinOnlyActiveGeneration,
+        MeetingStatus status,
+        String imageUrl,
+        String category,
+        List<String> joinableParts,
+        Boolean isBlockedMeeting
+    ){
+
+    }
+}

--- a/src/main/java/org/sopt/app/application/meeting/MeetingCategory.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingCategory.java
@@ -1,6 +1,0 @@
-package org.sopt.app.application.meeting;
-
-public enum MeetingCategory {
-    STUDY,
-    EVENT
-}

--- a/src/main/java/org/sopt/app/application/meeting/MeetingResponse.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingResponse.java
@@ -1,73 +1,31 @@
 package org.sopt.app.application.meeting;
 
+import java.util.List;
 import lombok.Builder;
+import org.sopt.app.application.meeting.CrewMeetingResponse.CrewMeeting;
+import org.sopt.app.domain.enums.Part;
 
 @Builder
 public record MeetingResponse(
-    Long meetingId,
+    Long id,
     String title,
-    MeetingCategory category,
+    String category,
+    Boolean canJoinOnlyActiveGeneration,
+    List<String> joinableParts,
+    Boolean canJoinAllParts,
     MeetingStatus status,
-    String imageUrl,
-    Boolean canJoinOnlyActiveGeneration
+    String imageUrl
 ) {
-    @Deprecated
-    public static MeetingResponse eventActiveDummy(Long id) {
+    public static MeetingResponse of(final CrewMeeting crewMeeting) {
         return MeetingResponse.builder()
-                .meetingId(id)
-                .title("[35기 솝커톤] 서버 파트 신청")
-                .category(MeetingCategory.EVENT)
-                .status(MeetingStatus.ACTIVE)
-                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
-                .canJoinOnlyActiveGeneration(false)
-                .build();
-    }
-
-    @Deprecated
-    public static MeetingResponse studyRecruitingDummy(Long id) {
-        return MeetingResponse.builder()
-                .meetingId(id)
-                .title("모집중이고 활동 기수만 참여하는 스터디")
-                .category(MeetingCategory.STUDY)
-                .status(MeetingStatus.RECRUITING)
-                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
-                .canJoinOnlyActiveGeneration(true)
-                .build();
-    }
-
-    @Deprecated
-    public static MeetingResponse studyPreRecruitingDummy(Long id) {
-        return MeetingResponse.builder()
-                .meetingId(id)
-                .title("모집 이전이고 모든 기수가 참여하는 스터디")
-                .category(MeetingCategory.STUDY)
-                .status(MeetingStatus.PRE_RECRUITING)
-                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
-                .canJoinOnlyActiveGeneration(false)
-                .build();
-    }
-
-    @Deprecated
-    public static MeetingResponse studyClosedDummy(Long id) {
-        return MeetingResponse.builder()
-                .meetingId(id)
-                .title("모집이 끝나고 모든 기수가 참여하는 스터디")
-                .category(MeetingCategory.STUDY)
-                .status(MeetingStatus.CLOSED)
-                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
-                .canJoinOnlyActiveGeneration(false)
-                .build();
-    }
-
-    @Deprecated
-    public static MeetingResponse studyActiveDummy(Long id) {
-        return MeetingResponse.builder()
-                .meetingId(id)
-                .title("활동중이고 활동 기수만 참여하는 스터디")
-                .category(MeetingCategory.STUDY)
-                .status(MeetingStatus.ACTIVE)
-                .imageUrl("https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/11/14/78d48e33-f1d7-474f-a357-117b75a8cb90.png")
-                .canJoinOnlyActiveGeneration(true)
+                .id(crewMeeting.id())
+                .title(crewMeeting.title())
+                .category(crewMeeting.category())
+                .canJoinOnlyActiveGeneration(crewMeeting.canJoinOnlyActiveGeneration())
+                .joinableParts(crewMeeting.joinableParts())
+                .canJoinAllParts(crewMeeting.joinableParts().size() == Part.values().length)
+                .status(crewMeeting.status())
+                .imageUrl(crewMeeting.imageUrl())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/app/application/meeting/MeetingService.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingService.java
@@ -1,0 +1,24 @@
+package org.sopt.app.application.meeting;
+
+import static org.sopt.app.application.playground.PlaygroundHeaderCreator.createAuthorizationHeaderByInternalPlaygroundToken;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.presentation.home.MeetingParamRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingService {
+    private final CrewClient crewClient;
+
+    public CrewMeetingResponse getAllMeetings(MeetingParamRequest request) {
+        return crewClient.getAllMeetings(
+                createAuthorizationHeaderByInternalPlaygroundToken(),
+                request.playgroundId(),
+                request.page(),
+                request.take(),
+                request.category(),
+                false
+        );
+    }
+}

--- a/src/main/java/org/sopt/app/application/meeting/MeetingStatus.java
+++ b/src/main/java/org/sopt/app/application/meeting/MeetingStatus.java
@@ -1,8 +1,7 @@
 package org.sopt.app.application.meeting;
 
 public enum MeetingStatus {
-    RECRUITING,
-    PRE_RECRUITING,
-    CLOSED,
-    ACTIVE
+    APPLY_ABLE,
+    BEFORE_START,
+    RECRUITMENT_COMPLETE
 }

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
@@ -1,19 +1,13 @@
 package org.sopt.app.application.playground;
 
 
-import feign.HeaderMap;
-import feign.Param;
-import feign.RequestLine;
-import java.util.List;
-import java.util.Map;
-import org.sopt.app.application.auth.dto.PlaygroundAuthTokenInfo.RefreshedToken;
+import feign.*;
+import java.util.*;
+import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.*;
 import org.sopt.app.application.playground.dto.PlayGroundEmploymentResponse;
 import org.sopt.app.application.playground.dto.PlaygroundPostInfo.PlaygroundPostResponse;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.ActiveUserIds;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.OwnPlaygroundProfile;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundMain;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
 import org.sopt.app.application.playground.dto.PlaygroundUserFindCondition;
+import org.sopt.app.application.auth.dto.PlaygroundAuthTokenInfo.RefreshedToken;
 import org.sopt.app.application.playground.dto.RecommendedFriendInfo.PlaygroundUserIds;
 import org.sopt.app.presentation.auth.AppAuthRequest.*;
 import org.sopt.app.presentation.home.response.RecentPostsResponse;

--- a/src/main/java/org/sopt/app/common/config/ClientConfig.java
+++ b/src/main/java/org/sopt/app/common/config/ClientConfig.java
@@ -5,6 +5,7 @@ import feign.codec.*;
 import feign.jackson.*;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
+import org.sopt.app.application.meeting.CrewClient;
 import org.springframework.context.annotation.*;
 import org.sopt.app.application.playground.PlaygroundClient;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,8 +14,12 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @Configuration
 @EnableFeignClients
 public class ClientConfig {
+
     @Value("${makers.playground.server}")
     private String playgroundEndPoint;
+
+    @Value("${makers.playground.server}")
+    private String crewEndPoint;
 
     @Bean
     public PlaygroundClient playgroundClient() {
@@ -25,6 +30,17 @@ public class ClientConfig {
                 .logger(new Slf4jLogger(PlaygroundClient.class))
                 .logLevel(feignLoggerLevel())
                 .target(PlaygroundClient.class, playgroundEndPoint);
+    }
+
+    @Bean
+    public CrewClient crewClient() {
+        return Feign.builder()
+                .client(okHttpClient())
+                .encoder(encoder())
+                .decoder(decoder())
+                .logger(new Slf4jLogger(CrewClient.class))
+                .logLevel(feignLoggerLevel())
+                .target(CrewClient.class, crewEndPoint);
     }
 
     @Bean

--- a/src/main/java/org/sopt/app/common/config/ClientConfig.java
+++ b/src/main/java/org/sopt/app/common/config/ClientConfig.java
@@ -18,7 +18,7 @@ public class ClientConfig {
     @Value("${makers.playground.server}")
     private String playgroundEndPoint;
 
-    @Value("${makers.playground.server}")
+    @Value("${makers.crew.server}")
     private String crewEndPoint;
 
     @Bean

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -90,6 +90,7 @@ public class HomeFacade {
     public List<MeetingResponse> getAllMeetings(MeetingParamRequest request) {
         return meetingService.getAllMeetings(request)
                 .meetings().stream()
+                .filter(crewMeeting -> !crewMeeting.isBlockedMeeting())
                 .map(MeetingResponse::of)
                 .toList();
     }

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -4,15 +4,16 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.application.app_service.*;
-import org.sopt.app.application.app_service.dto.AppServiceEntryStatusResponse;
-import org.sopt.app.application.app_service.dto.AppServiceInfo;
+import org.sopt.app.application.app_service.dto.*;
 import org.sopt.app.application.home.ActivityDurationCalculator;
+import org.sopt.app.application.meeting.*;
 import org.sopt.app.application.playground.PlaygroundAuthService;
 import org.sopt.app.application.description.DescriptionInfo.MainDescription;
 import org.sopt.app.application.description.DescriptionService;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.domain.enums.UserStatus;
-import org.sopt.app.presentation.home.HomeDescriptionResponse;
+import org.sopt.app.presentation.home.response.HomeDescriptionResponse;
+import org.sopt.app.presentation.home.MeetingParamRequest;
 import org.sopt.app.presentation.home.response.RecentPostsResponse;
 import org.sopt.app.presentation.home.response.EmploymentPostResponse;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ public class HomeFacade {
     private final PlaygroundAuthService playgroundAuthService;
     private final AppServiceService appServiceService;
     private final AppServiceBadgeService appServiceBadgeService;
+    private final MeetingService meetingService;
 
     @Transactional(readOnly = true)
     @Deprecated
@@ -85,4 +87,10 @@ public class HomeFacade {
         return playgroundAuthService.getPlaygroundEmploymentPost(user.getPlaygroundToken());
     }
 
+    public List<MeetingResponse> getAllMeetings(MeetingParamRequest request) {
+        return meetingService.getAllMeetings(request)
+                .meetings().stream()
+                .map(MeetingResponse::of)
+                .toList();
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -11,8 +11,7 @@ import org.sopt.app.application.app_service.dto.AppServiceEntryStatusResponse;
 import org.sopt.app.application.meeting.MeetingResponse;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.facade.HomeFacade;
-import org.sopt.app.presentation.home.response.RecentPostsResponse;
-import org.sopt.app.presentation.home.response.EmploymentPostResponse;
+import org.sopt.app.presentation.home.response.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -98,18 +97,7 @@ public class HomeController {
             @RequestParam(value = "category") final String category
     ) {
         return ResponseEntity.ok(
-                List.of(
-                        MeetingResponse.eventActiveDummy(1L),
-                        MeetingResponse.studyRecruitingDummy(2L),
-                        MeetingResponse.studyPreRecruitingDummy(3L),
-                        MeetingResponse.studyClosedDummy(4L),
-                        MeetingResponse.studyActiveDummy(5L),
-                        MeetingResponse.eventActiveDummy(6L),
-                        MeetingResponse.studyRecruitingDummy(7L),
-                        MeetingResponse.studyPreRecruitingDummy(8L),
-                        MeetingResponse.studyClosedDummy(9L),
-                        MeetingResponse.studyActiveDummy(10L)
-                )
+                homeFacade.getAllMeetings(new MeetingParamRequest(user.getPlaygroundId(), page, take, category))
         );
     }
 }

--- a/src/main/java/org/sopt/app/presentation/home/MeetingParamRequest.java
+++ b/src/main/java/org/sopt/app/presentation/home/MeetingParamRequest.java
@@ -1,0 +1,10 @@
+package org.sopt.app.presentation.home;
+
+public record MeetingParamRequest(
+        Long playgroundId,
+        int page,
+        int take,
+        String category
+) {
+
+}

--- a/src/main/java/org/sopt/app/presentation/home/response/HomeDescriptionResponse.java
+++ b/src/main/java/org/sopt/app/presentation/home/response/HomeDescriptionResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.app.presentation.home;
+package org.sopt.app.presentation.home.response;
 
 import lombok.*;
 


### PR DESCRIPTION
## 📝 PR Summary
기존 Dummy api로 구현되어 있던 모든 모임 조회 api를 크루 api와 연결하였습니다.

#### 🌴 Works
- [x] 모임 조회 api 연결

#### 🌱 Related Issue
closed #431 

#### 🌵 PR 참고사항
- yml 파일에서 makers.crew.server를 추가해두었습니다! notion 설정 파일에 업데이트하고 github secret에도 dev, prod 업데이트 해두었습니다.
