### PR TITLE
[REFACTOR] sorted set을 이용한 솝탬프 랭킹 캐싱

### DIFF
--- a/src/main/java/org/sopt/app/application/rank/CachedUserInfo.java
+++ b/src/main/java/org/sopt/app/application/rank/CachedUserInfo.java
@@ -1,0 +1,19 @@
+package org.sopt.app.application.rank;
+
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.app.application.soptamp.SoptampUserInfo;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CachedUserInfo implements Serializable{
+    private String name;
+    private String profileMessage;
+    private String part;
+
+    public static CachedUserInfo of(SoptampUserInfo userInfo){
+        return new CachedUserInfo(userInfo.getNickname(), userInfo.getProfileMessage(), userInfo.getPart().getPartName());
+    }
+}

--- a/src/main/java/org/sopt/app/application/rank/CachedUserInfo.java
+++ b/src/main/java/org/sopt/app/application/rank/CachedUserInfo.java
@@ -1,5 +1,7 @@
 package org.sopt.app.application.rank;
 
+import static org.sopt.app.domain.enums.PlaygroundPart.toPart;
+
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,6 +16,10 @@ public class CachedUserInfo implements Serializable{
     private String part;
 
     public static CachedUserInfo of(SoptampUserInfo userInfo){
-        return new CachedUserInfo(userInfo.getNickname(), userInfo.getProfileMessage(), userInfo.getPart().getPartName());
+        return new CachedUserInfo(
+                userInfo.getNickname(),
+                userInfo.getProfileMessage(),
+                (toPart(userInfo.getPart()) == null) ? "" : toPart(userInfo.getPart()).getPartName()
+        );
     }
 }

--- a/src/main/java/org/sopt/app/application/rank/RankCacheService.java
+++ b/src/main/java/org/sopt/app/application/rank/RankCacheService.java
@@ -1,0 +1,30 @@
+package org.sopt.app.application.rank;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.sopt.app.application.soptamp.SoptampUserInfo;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+
+public interface RankCacheService {
+    Set<TypedTuple<Long>> getRanking();
+
+    void createNewRank(Long userId);
+
+    void removeRank(Long userId);
+
+    void incrementScore(Long userId, int score);
+
+    void decreaseScore(Long userId, int score);
+
+    void initScore(Long userId);
+
+    void deleteAll();
+
+    void addAll(List<SoptampUserInfo> userInfos);
+
+    @Nullable
+    CachedUserInfo getUserInfo(Long id);
+
+    void updateCachedUserInfo(Long id, CachedUserInfo userInfo);
+}

--- a/src/main/java/org/sopt/app/application/rank/RankScheduler.java
+++ b/src/main/java/org/sopt/app/application/rank/RankScheduler.java
@@ -1,16 +1,9 @@
 package org.sopt.app.application.rank;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.sopt.app.application.soptamp.SoptampPointInfo.Main;
 import org.sopt.app.application.soptamp.SoptampUserFinder;
 import org.sopt.app.application.soptamp.SoptampUserInfo;
-import org.sopt.app.common.config.CacheType;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -18,23 +11,13 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class RankScheduler {
     private final SoptampUserFinder soptampUserFinder;
-    private final RedisTemplate<String, String> redisRankingTemplate;
+    private final RedisRankService redisRankService;
 
     // 매일 오전 4시에 정합성을 맞추기 위해 스케쥴링
     @Scheduled(cron = "0 4 * * * *")
     public void initialSoptampRank(){
         List<SoptampUserInfo> userInfos = soptampUserFinder.findAllOfCurrentGeneration();
-        Set<TypedTuple<String>> soptampScores = this.convertRankingSet(userInfos);
-        redisRankingTemplate.opsForZSet().removeRange(CacheType.SOPTAMP_SCORE.getCacheName(), 0, -1);
-        redisRankingTemplate.opsForZSet().add(
-                CacheType.SOPTAMP_SCORE.getCacheName(),
-                soptampScores
-        );
-    }
-
-    private Set<TypedTuple<String>> convertRankingSet(List<SoptampUserInfo> userInfos){
-        return userInfos.stream()
-                .map(user -> TypedTuple.of(user.getNickname(), user.getTotalPoints().doubleValue()))
-                .collect(Collectors.toSet());
+        redisRankService.deleteAll();
+        redisRankService.addAll(userInfos);
     }
 }

--- a/src/main/java/org/sopt/app/application/rank/RankScheduler.java
+++ b/src/main/java/org/sopt/app/application/rank/RankScheduler.java
@@ -1,0 +1,40 @@
+package org.sopt.app.application.rank;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.sopt.app.application.soptamp.SoptampPointInfo.Main;
+import org.sopt.app.application.soptamp.SoptampUserFinder;
+import org.sopt.app.application.soptamp.SoptampUserInfo;
+import org.sopt.app.common.config.CacheType;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class RankScheduler {
+    private final SoptampUserFinder soptampUserFinder;
+    private final RedisTemplate<String, String> redisRankingTemplate;
+
+    // 매일 오전 4시에 정합성을 맞추기 위해 스케쥴링
+    @Scheduled(cron = "0 4 * * * *")
+    public void initialSoptampRank(){
+        List<SoptampUserInfo> userInfos = soptampUserFinder.findAllOfCurrentGeneration();
+        Set<TypedTuple<String>> soptampScores = this.convertRankingSet(userInfos);
+        redisRankingTemplate.opsForZSet().removeRange(CacheType.SOPTAMP_SCORE.getCacheName(), 0, -1);
+        redisRankingTemplate.opsForZSet().add(
+                CacheType.SOPTAMP_SCORE.getCacheName(),
+                soptampScores
+        );
+    }
+
+    private Set<TypedTuple<String>> convertRankingSet(List<SoptampUserInfo> userInfos){
+        return userInfos.stream()
+                .map(user -> TypedTuple.of(user.getNickname(), user.getTotalPoints().doubleValue()))
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/org/sopt/app/application/rank/RedisRankService.java
+++ b/src/main/java/org/sopt/app/application/rank/RedisRankService.java
@@ -1,0 +1,52 @@
+package org.sopt.app.application.rank;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.soptamp.SoptampUserInfo;
+import org.sopt.app.common.config.CacheType;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisRankService {
+    private final RedisTemplate<String, String> redisRankingTemplate;
+
+    public void createNewRank(String nickname) {
+        redisRankingTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, 0);
+    }
+
+    public void removeRank(String nickname) {
+        redisRankingTemplate.opsForZSet().remove(CacheType.SOPTAMP_SCORE.getCacheName(), nickname);
+    }
+
+    public void incrementScore(String nickname, int score) {
+        redisRankingTemplate.opsForZSet().incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, score);
+    }
+
+    public void decreaseScore(String nickname, int score) {
+        redisRankingTemplate.opsForZSet().incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, -1 * score);
+    }
+
+    public void initScore(String nickname) {
+        redisRankingTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, 0);
+    }
+
+    public void deleteAll() {
+        redisRankingTemplate.delete(CacheType.SOPTAMP_SCORE.getCacheName());
+    }
+
+    public void addAll(List<SoptampUserInfo> userInfos){
+        Set<TypedTuple<String>> scores = this.convertRankingSet(userInfos);
+        redisRankingTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), scores);
+    }
+
+    private Set<TypedTuple<String>> convertRankingSet(List<SoptampUserInfo> userInfos){
+        return userInfos.stream()
+                .map(user -> TypedTuple.of(user.getNickname(), user.getTotalPoints().doubleValue()))
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/org/sopt/app/application/rank/RedisRankService.java
+++ b/src/main/java/org/sopt/app/application/rank/RedisRankService.java
@@ -1,9 +1,11 @@
 package org.sopt.app.application.rank;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.application.soptamp.SoptampUserInfo;
 import org.sopt.app.common.config.CacheType;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -11,42 +13,85 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
-public class RedisRankService {
-    private final RedisTemplate<String, String> redisRankingTemplate;
+public class RedisRankService implements RankCacheService{
+    private final RedisTemplate<String, Long> redisTemplate;
 
-    public void createNewRank(String nickname) {
-        redisRankingTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, 0);
+    @Override
+    public Set<TypedTuple<Long>> getRanking() {
+        try {
+            return redisTemplate.opsForZSet()
+                    .reverseRangeWithScores(CacheType.SOPTAMP_SCORE.getCacheName(), 0, -1);
+        }catch (Exception e){
+            log.warn("Redis에서 Soptamp 랭킹 조회 중 오류 발생", e);
+            return Collections.emptySet();
+        }
     }
 
-    public void removeRank(String nickname) {
-        redisRankingTemplate.opsForZSet().remove(CacheType.SOPTAMP_SCORE.getCacheName(), nickname);
+    @Override
+    public void createNewRank(Long userId) {
+        redisTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), userId, 0);
     }
 
-    public void incrementScore(String nickname, int score) {
-        redisRankingTemplate.opsForZSet().incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, score);
+    @Override
+    public void removeRank(Long userId) {
+        redisTemplate.opsForZSet().remove(CacheType.SOPTAMP_SCORE.getCacheName(), userId);
     }
 
-    public void decreaseScore(String nickname, int score) {
-        redisRankingTemplate.opsForZSet().incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, -1 * score);
+    @Override
+    public void incrementScore(Long userId, int score) {
+        redisTemplate.opsForZSet()
+                .incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), userId, score);
     }
 
-    public void initScore(String nickname) {
-        redisRankingTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), nickname, 0);
+    @Override
+    public void decreaseScore(Long userId, int score) {
+        redisTemplate.opsForZSet()
+                .incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), userId, -1 * score);
     }
 
+    @Override
+    public void initScore(Long userId) {
+        redisTemplate.opsForZSet()
+                .add(CacheType.SOPTAMP_SCORE.getCacheName(), userId, 0);
+    }
+
+    @Override
     public void deleteAll() {
-        redisRankingTemplate.delete(CacheType.SOPTAMP_SCORE.getCacheName());
+        redisTemplate.delete(CacheType.SOPTAMP_SCORE.getCacheName());
     }
 
-    public void addAll(List<SoptampUserInfo> userInfos){
-        Set<TypedTuple<String>> scores = this.convertRankingSet(userInfos);
-        redisRankingTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), scores);
+    @Override
+    public void updateCachedUserInfo(Long id, CachedUserInfo userInfo){
+        redisTemplate.opsForHash()
+                .put(CacheType.SOPTAMP_PROFILE_MESSAGE.getCacheName(), id, userInfo);
     }
 
-    private Set<TypedTuple<String>> convertRankingSet(List<SoptampUserInfo> userInfos){
+    @Override
+    public CachedUserInfo getUserInfo(Long id) {
+        try {
+            return (CachedUserInfo) redisTemplate.opsForHash()
+                    .get(CacheType.SOPTAMP_PROFILE_MESSAGE.getCacheName(), id);
+        } catch (Exception e) {
+            log.warn("Redis에서 프로필 메시지를 가져오는 중 오류 발생 (userId: {})", id, e);
+            return null;
+        }
+    }
+
+    @Override
+    public void addAll(List<SoptampUserInfo> userInfos) {
+        try {
+            Set<TypedTuple<Long>> scores = this.convertRankingSet(userInfos);
+            redisTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), scores);
+        } catch (Exception e) {
+            log.warn("Redis에 랭킹 데이터를 추가하는 중 오류 발생", e);
+        }
+    }
+
+    private Set<TypedTuple<Long>> convertRankingSet(List<SoptampUserInfo> userInfos){
         return userInfos.stream()
-                .map(user -> TypedTuple.of(user.getNickname(), user.getTotalPoints().doubleValue()))
+                .map(user -> TypedTuple.of(user.getUserId(), user.getTotalPoints().doubleValue()))
                 .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
@@ -38,4 +38,10 @@ public class SoptampUserFinder {
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
         return SoptampUserInfo.of(soptampUser);
     }
+
+    public SoptampUserInfo findById(Long userId) {
+        SoptampUser soptampUser = soptampUserRepository.findByUserId(userId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
+        return SoptampUserInfo.of(soptampUser);
+    }
 }

--- a/src/main/java/org/sopt/app/common/config/CacheType.java
+++ b/src/main/java/org/sopt/app/common/config/CacheType.java
@@ -1,0 +1,16 @@
+package org.sopt.app.common.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+    SOPTAMP_SCORE("soptamp_score", 12, 500),
+    SOPTAMP_PROFILE_MESSAGE("soptamp_profile_message", 12, 500)
+    ;
+
+    private final String cacheName;
+    private final int expiredAfterWrite;
+    private final int maximumSize;
+}

--- a/src/main/java/org/sopt/app/common/config/RedisConfig.java
+++ b/src/main/java/org/sopt/app/common/config/RedisConfig.java
@@ -1,13 +1,11 @@
 package org.sopt.app.common.config;
 
-import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.*;
 import org.springframework.data.redis.connection.*;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.*;
 
@@ -32,21 +30,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager cacheManager(RedisConnectionFactory factory) {
-        RedisCacheConfiguration cacheConfig =
-                RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new StringRedisSerializer()
-                ))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer()
-                ))
-                .entryTtl(Duration.ofMinutes(1L));
-
-        return RedisCacheManager
-                .RedisCacheManagerBuilder
-                .fromConnectionFactory(factory)
-                .cacheDefaults(cacheConfig)
-                .build();
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
     }
 }

--- a/src/main/java/org/sopt/app/common/config/RedisConfig.java
+++ b/src/main/java/org/sopt/app/common/config/RedisConfig.java
@@ -30,8 +30,8 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Long> redisTemplate() {
+        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/org/sopt/app/facade/RankFacade.java
+++ b/src/main/java/org/sopt/app/facade/RankFacade.java
@@ -102,6 +102,16 @@ public class RankFacade {
 
     @Transactional(readOnly = true)
     public Long findUserRank(Long userId) {
+        Set<TypedTuple<Long>> sortedScoreCaches =  rankCacheService.getRanking();
+        if (sortedScoreCaches != null && !sortedScoreCaches.isEmpty()) {
+            Long rank = 1L;
+            for(TypedTuple<Long> cache : sortedScoreCaches){
+                if(String.valueOf(cache.getValue()).equals(userId.toString())){
+                    return rank;
+                }
+                rank++;
+            }
+        }
         List<SoptampUserInfo> soptampUserInfos = soptampUserFinder.findAllOfCurrentGeneration();
         SoptampUserRankCalculator soptampUserRankCalculator = new SoptampUserRankCalculator(soptampUserInfos);
         return soptampUserRankCalculator.getUserRank(userId);

--- a/src/main/java/org/sopt/app/facade/RankFacade.java
+++ b/src/main/java/org/sopt/app/facade/RankFacade.java
@@ -1,7 +1,11 @@
 package org.sopt.app.facade;
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.rank.CachedUserInfo;
+import org.sopt.app.application.rank.RankCacheService;
 import org.sopt.app.application.rank.SoptampPartRankCalculator;
 import org.sopt.app.application.rank.SoptampUserRankCalculator;
 import org.sopt.app.application.soptamp.SoptampPointInfo.Main;
@@ -9,6 +13,7 @@ import org.sopt.app.application.soptamp.SoptampPointInfo.PartRank;
 import org.sopt.app.application.soptamp.SoptampUserFinder;
 import org.sopt.app.application.soptamp.SoptampUserInfo;
 import org.sopt.app.domain.enums.Part;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,12 +22,42 @@ import org.springframework.transaction.annotation.Transactional;
 public class RankFacade {
 
     private final SoptampUserFinder soptampUserFinder;
+    private final RankCacheService rankCacheService;
 
     @Transactional(readOnly = true)
     public List<Main> findCurrentRanks() {
+        Set<TypedTuple<Long>> cachedRanking =  rankCacheService.getRanking();
+        if (cachedRanking != null && !cachedRanking.isEmpty()) {
+            return getCachedRanking(cachedRanking);
+        }
         List<SoptampUserInfo> soptampUserInfos = soptampUserFinder.findAllOfCurrentGeneration();
+        rankCacheService.addAll(soptampUserInfos);
         SoptampUserRankCalculator soptampUserRankCalculator = new SoptampUserRankCalculator(soptampUserInfos);
         return soptampUserRankCalculator.calculateRank();
+    }
+
+    private List<Main> getCachedRanking(Set<TypedTuple<Long>> cachedRanking){
+        AtomicInteger rankPoint = new AtomicInteger(1);
+        return cachedRanking.stream()
+                .map(cachedRank -> convertCachedRankingToMain(cachedRank, rankPoint.getAndIncrement()))
+                .toList();
+    }
+
+    private Main convertCachedRankingToMain(TypedTuple<Long> cachedRanking, Integer rank){
+        Long id = Long.valueOf(String.valueOf(cachedRanking.getValue()));
+        Long point = (cachedRanking.getScore() != null) ? cachedRanking.getScore().longValue() : 0L;
+        CachedUserInfo userInfo = rankCacheService.getUserInfo(id);
+        if(userInfo == null){
+            SoptampUserInfo soptampUserInfo = soptampUserFinder.findById(id);
+            userInfo = CachedUserInfo.of(soptampUserInfo);
+            rankCacheService.updateCachedUserInfo(id, userInfo);
+        }
+        return Main.builder()
+                .nickname(userInfo.getName())
+                .point(point)
+                .profileMessage(userInfo.getProfileMessage())
+                .rank(rank)
+                .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/org/sopt/app/application/SoptampUserServiceTest.java
+++ b/src/test/java/org/sopt/app/application/SoptampUserServiceTest.java
@@ -24,9 +24,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.ActivityCardinalInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
+import org.sopt.app.application.rank.RankCacheService;
 import org.sopt.app.application.soptamp.SoptampUserInfo;
 import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.common.exception.BadRequestException;
+import org.sopt.app.domain.enums.PlaygroundPart;
 import org.sopt.app.interfaces.postgres.SoptampUserRepository;
 import org.sopt.app.domain.entity.soptamp.SoptampUser;
 
@@ -35,6 +37,9 @@ class SoptampUserServiceTest {
 
     @Mock
     private SoptampUserRepository soptampUserRepository;
+
+    @Mock
+    private RankCacheService rankCacheService;
 
     @InjectMocks
     private SoptampUserService soptampUserService;
@@ -98,6 +103,7 @@ class SoptampUserServiceTest {
                 .userId(SOPTAMP_USER_1.getUserId())
                 .nickname(SOPTAMP_USER_1.getNickname())
                 .totalPoints(SOPTAMP_USER_1.getTotalPoints())
+                .part(PlaygroundPart.SERVER)
                 .profileMessage(newProfileMessage)
                 .build();
 

--- a/src/test/java/org/sopt/app/facade/RankFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/RankFacadeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.sopt.app.common.fixtures.SoptampUserFixture.*;
 
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.rank.RankCacheService;
 import org.sopt.app.application.soptamp.SoptampPointInfo.Main;
 import org.sopt.app.application.soptamp.SoptampPointInfo.PartRank;
 import org.sopt.app.application.soptamp.SoptampUserFinder;
@@ -22,6 +24,9 @@ class RankFacadeTest {
     @Mock
     private SoptampUserFinder soptampUserFinder;
 
+    @Mock
+    private RankCacheService rankCacheService;
+
     @InjectMocks
     private RankFacade rankFacade;
 
@@ -30,7 +35,7 @@ class RankFacadeTest {
     void SUCCESS_findCurrentRanks() {
         //given
         given(soptampUserFinder.findAllOfCurrentGeneration()).willReturn(SOPTAMP_USER_INFO_LIST);
-
+        given(rankCacheService.getRanking()).willReturn(Collections.emptySet());
         // when
         List<Main> result = rankFacade.findCurrentRanks();
         List<Main> expected = List.of(


### PR DESCRIPTION
## 📝 PR Summary
Redis의 sorted set을 이용하여 솝탬프 랭킹을 캐싱하여 응답속도를 높혔습니다.
#### 🌴 Works
- [x] Redis sorted set을 이용한 솝탬프 랭킹 캐싱

#### 🌱 Related Issue
closed #472 
