### PR TITLE
[MODIFY] health check시에 RETRIES 시간 증가

### DIFF
--- a/script/deploy_container.sh
+++ b/script/deploy_container.sh
@@ -7,7 +7,7 @@ deploy_container() {
     echo "docker-compose pull & up ..."
 
     docker-compose pull redis
+    docker-compose up -d redis
     docker-compose pull ${CONTAINER_NAME}
-    docker-compose up -d app-redis
     docker-compose up -d ${CONTAINER_NAME}
 }

--- a/script/health_check.sh
+++ b/script/health_check.sh
@@ -6,12 +6,12 @@ health_check() {
   local PORT=$1
   local RETRIES="${RETRIES:-5}"
 
-  echo "▶️ Start health check after 15 seconds"
-  sleep 15
+  echo "▶️ Start health check after 20 seconds"
+  sleep 20
 
   for retry_count in $(seq 1 $RETRIES); do
     echo "🔎 Health Check on Port ${PORT} (Attempt: ${retry_count}/${RETRIES})..."
-    sleep 3
+    sleep 5
 
     HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${PORT}${HEALTH_CHECK_URL})
 


### PR DESCRIPTION
## 📝 PR Summary
health check시에 마지막 retries까지 가서야 health check가 성공하는 문제가 있어 RETRIES 시간을 증가했습니다.
\+ docker-compose를 이용해 redis를 실행시키는 과정에서의 오류를 수정했습니다.

#### 🌴 Works
- [x] health check시에 RETRIES 시간 증가
- [x] docker-compose를 이용해 redis를 제대로 실행할 수 있도록 수정 

#### 🌱 Related Issue
closed #491 

#### 🌵 PR 참고사항
- 확인하시고 머지 부탁드릴게요!
- dev 환경 docker 무중단 배포 기능 적용완료했고, 테스트 완료했습니다.
