### PR TITLE
[FEAT] 플레이그라운드 카테고리별 게시물 조회 api에 url 추가 - #504

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -193,7 +193,7 @@ public class PlaygroundAuthService {
     }
 
     public List<RecentPostsResponse> getRecentPosts(String token) {
-        Map<String, String> headers = createAuthorizationHeaderByUserPlaygroundToken(token);
+        final Map<String, String> headers = createAuthorizationHeaderByUserPlaygroundToken(token);
 
         try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
             return collectHotAndCategoryPosts(headers, executor);

--- a/src/main/java/org/sopt/app/presentation/home/response/RecentPostsResponse.java
+++ b/src/main/java/org/sopt/app/presentation/home/response/RecentPostsResponse.java
@@ -19,16 +19,31 @@ public class RecentPostsResponse implements PostWithMemberInfo {
     private String category;
     private String content;
     private Boolean isHotPost;
+    private String url;
     
     
-    public static RecentPostsResponse of(PlaygroundPostResponse playgroundPostResponse) {
+    public static RecentPostsResponse of(PlaygroundPostResponse playgroundPostResponse, String url) {
         return RecentPostsResponse.builder()
                 .id(playgroundPostResponse.postId())
                 .title(playgroundPostResponse.title())
                 .category("HOT")
+                .url(url)
                 .content(playgroundPostResponse.content())
                 .isHotPost(true)
                 .build();
+    }
+
+    public RecentPostsResponse withUrl(String url) {
+        return RecentPostsResponse.builder()
+            .id(this.id)
+            .title(this.title)
+            .profileImage(this.profileImage)
+            .name(this.name)
+            .category(this.category)
+            .content(this.content)
+            .isHotPost(this.isHotPost)
+            .url(url)
+            .build();
     }
 
     public RecentPostsResponse withMemberDetail(String name, String profileImage) {

--- a/src/test/java/org/sopt/app/application/PlaygroundAuthServiceTest.java
+++ b/src/test/java/org/sopt/app/application/PlaygroundAuthServiceTest.java
@@ -1,5 +1,6 @@
 package org.sopt.app.application;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.when;
 import io.jsonwebtoken.ExpiredJwtException;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.app.application.auth.dto.PlaygroundAuthTokenInfo.RefreshedToken;
+import org.sopt.app.application.playground.dto.PlayGroundPostCategory;
+import org.sopt.app.application.playground.dto.PlaygroundPostInfo.PlaygroundPostResponse;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.*;
 import org.sopt.app.application.playground.PlaygroundAuthService;
 import org.sopt.app.common.exception.BadRequestException;
@@ -23,6 +27,7 @@ import org.sopt.app.domain.enums.UserStatus;
 import org.sopt.app.application.playground.PlaygroundClient;
 import org.sopt.app.presentation.auth.AppAuthRequest.AccessTokenRequest;
 import org.sopt.app.presentation.auth.AppAuthRequest.CodeRequest;
+import org.sopt.app.presentation.home.response.RecentPostsResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException.BadRequest;
 
@@ -36,6 +41,11 @@ class PlaygroundAuthServiceTest {
     private PlaygroundAuthService playgroundAuthService;
 
     private final String token = "header.payload.signature";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(playgroundAuthService, "playgroundWebPageUrl", "http://localhost:3000");
+    }
 
     // getPlaygroundAccessToken
     @Test
@@ -266,4 +276,103 @@ class PlaygroundAuthServiceTest {
         // then
         assertDoesNotThrow(() -> playgroundAuthService.getOwnPlaygroundProfile(token));
     }
+
+    @Test
+    @DisplayName("Hot 게시물이 올바르게 응답되는지")
+    void SUCCESS_testHotPostIncludedInRecentPosts() {
+        // given
+        PlaygroundPostResponse hotPost = new PlaygroundPostResponse(1L, "Hot Title", "Hot Content");
+
+        when(playgroundClient.getPlaygroundHotPost(anyMap()))
+            .thenReturn(hotPost);
+
+        when(playgroundClient.getRecentPosts(anyMap(), anyString()))
+            .thenReturn(null);
+
+        // when
+        List<RecentPostsResponse> result = playgroundAuthService.getRecentPosts(token);
+
+        // then
+        assertThat(result).hasSize(1);
+        RecentPostsResponse response = result.get(0);
+        assertThat(response.getTitle()).isEqualTo("Hot Title");
+        assertThat(response.getIsHotPost()).isTrue();
+        assertThat(response.getUrl()).isEqualTo("http://localhost:3000/?feed=1");
+    }
+
+    @Test
+    @DisplayName("카테고리 게시물이 모두 포함되는지")
+    void SUCCESS_testAllCategoryPostsIncluded() {
+        // given
+        when(playgroundClient.getPlaygroundHotPost(anyMap())).thenReturn(null);
+
+        when(playgroundClient.getRecentPosts(anyMap(), eq(PlayGroundPostCategory.SOPT_ACTIVITY.getDisplayName())))
+            .thenReturn(createMockCategoryPost(2L, "SOPT"));
+        when(playgroundClient.getRecentPosts(anyMap(), eq(PlayGroundPostCategory.FREE.getDisplayName())))
+            .thenReturn(createMockCategoryPost(3L, "Free"));
+        when(playgroundClient.getRecentPosts(anyMap(), eq(PlayGroundPostCategory.PART.getDisplayName())))
+            .thenReturn(createMockCategoryPost(4L, "Part"));
+
+        // when
+        List<RecentPostsResponse> result = playgroundAuthService.getRecentPosts(token);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting("title").containsExactlyInAnyOrder("SOPT", "Free", "Part");
+    }
+
+    @Test
+    @DisplayName("게시물 URL이 올바르게 포함되는지")
+    void SUCCESS_testGeneratedUrlForPosts() {
+        // given
+        PlaygroundPostResponse post = new PlaygroundPostResponse(99L, "URL Test", "본문");
+
+        when(playgroundClient.getPlaygroundHotPost(anyMap()))
+            .thenReturn(post);
+
+        when(playgroundClient.getRecentPosts(anyMap(), anyString()))
+            .thenReturn(null);
+
+        // when
+        List<RecentPostsResponse> result = playgroundAuthService.getRecentPosts(token);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getUrl()).isEqualTo("http://localhost:3000/?feed=99");
+    }
+
+    @Test
+    @DisplayName("카테고리 게시물 일부가 실패해도 나머지는 반환")
+    void SUCCESS_testPartialFailureInCategoryPosts() {
+        // given
+        when(playgroundClient.getPlaygroundHotPost(anyMap())).thenReturn(null);
+
+        when(playgroundClient.getRecentPosts(anyMap(), eq(PlayGroundPostCategory.SOPT_ACTIVITY.getDisplayName())))
+            .thenThrow(new RuntimeException("API 실패"));
+
+        when(playgroundClient.getRecentPosts(anyMap(), eq(PlayGroundPostCategory.FREE.getDisplayName())))
+            .thenReturn(createMockCategoryPost(10L, "Free"));
+
+        when(playgroundClient.getRecentPosts(anyMap(), eq(PlayGroundPostCategory.PART.getDisplayName())))
+            .thenReturn(createMockCategoryPost(11L, "Part"));
+
+        // when
+        List<RecentPostsResponse> result = playgroundAuthService.getRecentPosts(token);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("title").containsExactlyInAnyOrder("Free", "Part");
+    }
+
+    private RecentPostsResponse createMockCategoryPost(Long id, String title) {
+        return RecentPostsResponse.builder()
+            .id(id)
+            .title(title)
+            .content("내용")
+            .category("FREE")
+            .isHotPost(false)
+            .url("http://localhost:3000/?feed=" + id)
+            .build();
+    }
+
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #504 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- RecentPostsResponse에 url 필드를 추가하면서 외부 Playground API로부터 받은 게시물 응답(PlaygroundPostResponse)에 URL을 직접 조립해 추가하는 방식으로 변경했습니다. url 생성은 기존의 convertPlaygroundWebPageUrl를 활용했습니다.
- 가독성과 책임분리를 위해 hot게시물 조회, 최근게시물 조회, 두 게시물 목록 합치기의 세 과정을 모두 담당하던 기존의 getRecentPosts에서 각 단계를 분리해 private 메소드들을 작성했습니다.
- 외부 api를 호출하는 특성상 local test 진행이 어려워 test code를 작성했습니다. test는 모두 통과했으니 dev 서버에서 테스트해보면 좋을 듯합니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
