### PR TITLE
Refactor/#508 modify with qa

### DIFF
--- a/src/main/java/org/sopt/app/application/calendar/CalendarServiceImpl.java
+++ b/src/main/java/org/sopt/app/application/calendar/CalendarServiceImpl.java
@@ -56,7 +56,8 @@ public class CalendarServiceImpl implements CalendarService {
     }
 
     private List<Calendar> cacheAllCalendarResponse() {
-        List<Calendar> calendars = calendarRepository.findAllByGenerationOrderByStartDate(currentGeneration);
+        List<Calendar> calendars = calendarRepository.findAllByGenerationOrderByStartDateAscEndDateAsc(currentGeneration);
+
         cachedCalendarRepository.save(new CachedAllCalendarResponse(currentGeneration, new Calendars(calendars)));
         return calendars;
     }

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
@@ -96,6 +96,12 @@ public class PlaygroundProfileInfo {
                     .sorted(Comparator.comparing(ActivityCardinalInfo::getGeneration, Comparator.reverseOrder()))
                     .toList().getFirst();
         }
+
+        public List<ActivityCardinalInfo> getAllActivities() {
+            return activities.stream()
+                    .sorted(Comparator.comparing(ActivityCardinalInfo::getGeneration, Comparator.reverseOrder()))
+                    .toList();
+        }
     }
 
     @Getter

--- a/src/main/java/org/sopt/app/facade/RankFacade.java
+++ b/src/main/java/org/sopt/app/facade/RankFacade.java
@@ -93,7 +93,7 @@ public class RankFacade {
 
     @Transactional(readOnly = true)
     public PartRank findPartRank(Part part) {
-        List<SoptampUserInfo> soptampUserInfos = soptampUserFinder.findAllByPartAndCurrentGeneration(part);
+        List<SoptampUserInfo> soptampUserInfos = soptampUserFinder.findAllOfCurrentGeneration();
         SoptampPartRankCalculator soptampPartRankCalculator = new SoptampPartRankCalculator(soptampUserInfos);
         return soptampPartRankCalculator.calculatePartRank().stream()
                 .filter(partRank -> partRank.getPart().equals(part.getPartName()))

--- a/src/main/java/org/sopt/app/interfaces/postgres/CalendarRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/CalendarRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
 
-    List<Calendar> findAllByGenerationOrderByStartDate(final Integer generation);
+    List<Calendar> findAllByGenerationOrderByStartDateAscEndDateAsc(final Integer generation);
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -2,12 +2,15 @@ package org.sopt.app.presentation.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.sopt.app.application.app_service.dto.AppServiceInfo;
+import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -169,7 +172,9 @@ public class UserResponse {
                     .soptampRank(soptampRank != null ? soptampRank + "등" : "")
                     .userName(playgroundProfile.getName())
                     .profileImage(playgroundProfile.getProfileImage() != null ? playgroundProfile.getProfileImage() : "")
-                    .part(partTypeToKorean?playgroundProfile.getLatestActivity().getPlaygroundPart().getPartName():playgroundProfile.getLatestActivity().getPlaygroundPart().toString())
+                    .part(playgroundProfile.getAllActivities().stream()
+                            .map(c -> c.getPlaygroundPart().getPartName())
+                            .collect(Collectors.joining("/")))
                     .profileMessage(playgroundProfile.getIntroduction() != null ? playgroundProfile.getIntroduction() : "")
                     .during(during != null ? during + "개월" : "")
                     .isActive(isActive)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #508 

## Work Description ✏️
permalink로 다는 것 보다 diff로 보는 게 편하실 것 같아 각 작업 사항에 대한 커밋을 링크로 달아두었습니다 :) !

<!-- 작업 내용을 간단히 소개주세요 -->
- 전체 일정 캘린더 종료날짜 정렬을 추가해 순서를 수정했어요. 솝커톤과 세미나가 같은 날이지만 세미나는 당일에 끝나고 솝커톤은 세미나 뒤 다음날에 끝나므로 종료날짜 오름차순으로 정렬했어요. 15fbb179838a8602db57e3f66403099f3def7352

- 홈 뱃지 숫자를 수정했어요. 솝탬프 랭크는 전체 파트의 솝탬프 기록을 가져와서 계산한 뒤에 해당 유저의 파트 랭크를 뽑아 리턴해야 하는데, 기존 로직은 해당 파트만을 계산 로직에 넣어 무조건 1위를 반환할 수 밖에 없었어요. (혼자만의 경쟁을 한 것임) a8411f6c2579afb4829c485bfb0c3ab9e77d897f
  - 솝탬프는 해결했지만, fortune 관련된 것은 로컬에서는 확인하지 않았을 경우 `N`, 확인한 경우 `빈 문자열`로 응답하는 것을 확인했어요. 이것도 dev 배포 후 테스트한 뒤 결과 남기겠습니다.

- 수료한 파트가 여러개일 경우 전부 중복 제거하지 않고 FE에 내려주도록 수정했어요. 
전부 가져오는 메서드를 작성한 뒤 71005811d09592d9234fd4f652028a7f26530c1a 
join을 이용해서 슬래시로 구분해서 FE에 내리도록 했어요. 43fbfc8f3455d887d561d4ea08bac6d4a42ea20e

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
스웨거로

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->
플그 로직이 섞여있어서, 로컬에서는 플그 로직을 임의로 처리한 뒤 테스트 완료했고 dev에 배포 후 테스트 할 예정이예요.
## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
