### PR TITLE
[Fix] 플그로 로그인 시 soptamp 관련 로직 무조건 통과하도록 변경 및 테스트용 로그 삭제 (#516)

### DIFF
--- a/src/main/java/org/sopt/app/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/app/facade/AuthFacade.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class AuthFacade {
 
     private final JwtTokenService jwtTokenService;
@@ -39,14 +38,8 @@ public class AuthFacade {
                 playgroundToken, playgroundInfo.getId()
         );
         Long latestGeneration = playgroundProfile.getLatestActivity().getGeneration();
-        log.error("latestGeneration: {}", latestGeneration);
-        log.error("playgroundProfile.getGeneration: {}", playgroundProfile.getLatestActivity().getGeneration());
         Long userId = userService.upsertUser(LoginInfo.of(playgroundInfo, playgroundToken));
         soptampUserService.upsertSoptampUser(playgroundProfile, userId);
-
-//        if (playgroundAuthService.isCurrentGeneration(latestGeneration)){
-//            soptampUserService.upsertSoptampUser(playgroundProfile, userId);
-//        }
 
         AppToken appToken = jwtTokenService.issueNewTokens(userId, playgroundInfo.getId());
         return AppAuthResponse.builder()


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #516 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
솝트로그 조회 시 간헐적으로 솝탬프 관련 오류가 뜨는 것을 확인했어요.
```
2025-03-28T13:39:40.122Z ERROR 1 --- [app-server] [nio-8080-exec-8] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: java.lang.IllegalArgumentException: User not found] with root cause

java.lang.IllegalArgumentException: User not found
	at org.sopt.app.application.rank.SoptampUserRankCalculator.lambda$getUserRank$3(SoptampUserRankCalculator.java:34) ~[!/:0.0.1-SNAPSHOT]
	at java.base/java.util.Optional.orElseThrow(Optional.java:403) ~[na:na]
	at org.sopt.app.application.rank.SoptampUserRankCalculator.getUserRank(SoptampUserRankCalculator.java:34) ~[!/:0.0.1-SNAPSHOT]
	at org.sopt.app.facade.RankFacade.findUserRank(RankFacade.java:117) ~[!/:0.0.1-SNAPSHOT]
```

해당 오류는 솝트로그 조회 API 중, 솝탬프 랭크를 가져오는 로직에서 발생한 문제인데요.
```java
// 활동 기수인 경우 솝탬프 랭크 가져오는 로직
if (isActive) {
    soptampRank = rankFacade.findUserRank(user.getId());
}
```
이 때 soptamp_user에 등록되지 않은 경우 Not Found로 오류가 발생하고 있었어요.

기존에는 플그로 로그인/회원가입 시 기수를 확인 후에 soptamp_user를 생성하거나 기수를 업데이트하는 방식이었는데,
이를 플그로 로그인/회원가입 시에 사용자의 최근 기수로 soptamp_user를 무조건 생성하거나 업데이트하도록 변경했어요.
https://github.com/sopt-makers/sopt-backend/blob/5eb2b98b0b8167c41a980bf16dbe58a249544812/src/main/java/org/sopt/app/facade/AuthFacade.java#L42-L44

https://github.com/sopt-makers/sopt-backend/blob/092b671e468b5a09debcd02f96e38b46a1a93753/src/main/java/org/sopt/app/facade/AuthFacade.java#L42

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
