### PR TITLE
[Fix] 솝트로그 관련 이슈 해결 (#519)

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
@@ -6,11 +6,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import java.util.*;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.enums.PlaygroundPart;
 import org.sopt.app.domain.enums.UserStatus;
 
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PlaygroundProfileInfo {
 
@@ -121,7 +123,17 @@ public class PlaygroundProfileInfo {
         }
 
         public PlaygroundPart getPlaygroundPart() {
-            return findPlaygroundPartByPartName(cardinalInfo.split(",")[1]);
+            try {
+                String[] parts = cardinalInfo.split(",");
+                if (parts.length < 2) {
+                    log.warn("Invalid cardinalInfo format: {}", cardinalInfo);
+                    return PlaygroundPart.NONE;
+                }
+                return findPlaygroundPartByPartName(parts[1]);
+            } catch (Exception e) {
+                log.warn("Error parsing PlaygroundPart from cardinalInfo: {}", cardinalInfo, e);
+                return PlaygroundPart.NONE;
+            }
         }
     }
 

--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -106,17 +106,21 @@ public class UserController {
         Boolean isActive = playgroundProfile.getLatestActivity().getGeneration().equals(generation);
         boolean isFortuneChecked = fortuneService.isExistTodayFortune((user.getId()));
         String fortuneText = isFortuneChecked?fortuneService.getTodayFortuneWordByUserId(user.getId(), LocalDate.now()).title():"오늘 내 운세는?";
-        if (isActive) {
-            soptampRank = rankFacade.findUserRank(user.getId());
-        } else {
-            List<Long> generations = playgroundProfile.getAllActivities().stream()
+
+//        if (isActive) {
+//            // soptampRank = rankFacade.findUserRank(user.getId());
+//        } else {
+//
+//        }
+
+        List<Long> generations = playgroundProfile.getAllActivities().stream()
                 .map(PlaygroundProfileInfo.ActivityCardinalInfo::getGeneration)
                 .toList();
 
-            if (!generations.isEmpty()) {
-                soptDuring = (long) ActivityDurationCalculator.calculate(generations);
-            }
+        if (!generations.isEmpty()) {
+            soptDuring = (long) ActivityDurationCalculator.calculate(generations);
         }
+
         List<String> icons = authFacade.getIcons(isActive ? IconType.ACTIVE : IconType.INACTIVE);
         List<String> iconsMutableList = new ArrayList<>(icons);
         List<String> iconPriority = List.of("sop-level", "poke", "soptamp", "duration");


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #519 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
솝트로그가 일부 유저에게 안 열리는 이슈를 해결합니다.

### ArrayIndexOutOfBoundsException 이슈

- 솝트로그 조회 시, 플그에서 받아온 정보를 바탕으로 기수와 파트를 `split()`으로 꺼내옵니다. 
해당 과정에서, 데이터가 어떻게 오는지는 확인하지 못했지만, 아래의 로그를 확인했습니다.
```
2025-03-30T17:58:58.229+09:00 ERROR 2500635 --- [app-server] [nio-8080-exec-4] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1] with root cause

java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at org.sopt.app.application.playground.dto.PlaygroundProfileInfo$ActivityCardinalInfo.getPlaygroundPart(PlaygroundProfileInfo.java:124) ~[!/:0.0.1-SNAPSHOT]
	at org.sopt.app.presentation.user.UserResponse$SoptLog.lambda$of$0(UserResponse.java:176) ~[!/:0.0.1-SNAPSHOT]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[na:na]
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[na:na]
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[na:na]
	at org.sopt.app.presentation.user.UserResponse$SoptLog.of(UserResponse.java:177) ~[!/:0.0.1-SNAPSHOT]
	at org.sopt.app.presentation.user.UserController.getUserSoptLog(UserController.java:131) ~[!/:0.0.1-SNAPSHOT]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:255) ~[spring-web-6.1.11.jar!/:6.1.11]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188) ~[spring-web-6.1.11.jar!/:6.1.11]
```

- 이를 해결하기 위해, cardinalInfo의 length를 확인하고 로그를 남기는 로직을 추가했습니다. 
https://github.com/sopt-makers/sopt-backend/blob/35bd8c486fedf2f246cedb1177356fee5f19b7b1/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java#L125-L138

<br>

### 솝트로그 솝탬프 제외 후 duration 리턴으로 변경
- 솝탬프가 닫혀있으므로, 활동기수의 경우에도 솝트와 N개월로 리턴되도록 이전 로직을 주석처리했습니다.
https://github.com/sopt-makers/sopt-backend/blob/35bd8c486fedf2f246cedb1177356fee5f19b7b1/src/main/java/org/sopt/app/presentation/user/UserController.java#L110-L122

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
