### PR TITLE
[Fix] 솝탬프 랭크 null인 경우 문자열 처리

### DIFF
--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -169,7 +169,8 @@ public class UserResponse {
             return SoptLog.builder()
                     .soptLevel("Lv." + soptLevel)
                     .pokeCount(pokeCount + "회")
-                    .soptampRank(soptampRank != null ? soptampRank + "등" : "")
+                    // 솝탬프 오픈 전까지는 순위 부분에 공개 예정! 표시
+                    .soptampRank(soptampRank != null ? soptampRank + "등" : "공개 예정!")
                     .userName(playgroundProfile.getName())
                     .profileImage(playgroundProfile.getProfileImage() != null ? playgroundProfile.getProfileImage() : "")
                     .part(playgroundProfile.getAllActivities().stream()


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #521 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
솝탬프 일시 중단으로 인해 "공개 예정!" 이라는 문자열이 내려오도록 수정했어요.

https://github.com/sopt-makers/sopt-backend/blob/aedf20f825349540f734dc1b4dc988cc2794e993/src/main/java/org/sopt/app/presentation/user/UserResponse.java#L173
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
