### PR TITLE
[FIX] 홈화면 최신 행사 일정 관련 이슈 - #523

### DIFF
--- a/src/main/java/org/sopt/app/application/calendar/CalendarServiceImpl.java
+++ b/src/main/java/org/sopt/app/application/calendar/CalendarServiceImpl.java
@@ -63,12 +63,9 @@ public class CalendarServiceImpl implements CalendarService {
     }
 
     private Optional<Calendar> getRecentCalendar(List<Calendar> calendars) {
-        List<Calendar> sorted = calendars.stream()
+        return calendars.stream()
             .sorted(Comparator.comparing(Calendar::getStartDate)
                 .thenComparing(Calendar::getEndDate))
-            .toList();
-
-        return sorted.stream()
             .filter(calendar -> !calendar.getStartDate().isBefore(CurrentDate.now()))
             .findFirst();
     }

--- a/src/main/java/org/sopt/app/application/calendar/CalendarServiceImpl.java
+++ b/src/main/java/org/sopt/app/application/calendar/CalendarServiceImpl.java
@@ -63,9 +63,14 @@ public class CalendarServiceImpl implements CalendarService {
     }
 
     private Optional<Calendar> getRecentCalendar(List<Calendar> calendars) {
-        return calendars.stream()
-                .filter(calendar -> !calendar.getStartDate().isBefore(CurrentDate.now))
-                .findFirst();
+        List<Calendar> sorted = calendars.stream()
+            .sorted(Comparator.comparing(Calendar::getStartDate)
+                .thenComparing(Calendar::getEndDate))
+            .toList();
+
+        return sorted.stream()
+            .filter(calendar -> !calendar.getStartDate().isBefore(CurrentDate.now()))
+            .findFirst();
     }
 
     @Override

--- a/src/main/java/org/sopt/app/application/fortune/FortuneService.java
+++ b/src/main/java/org/sopt/app/application/fortune/FortuneService.java
@@ -68,7 +68,7 @@ public class FortuneService {
 
     public boolean isExistTodayFortune(final Long userId) {
         return userFortuneRepository.findByUserId(userId)
-                .map(userFortune -> userFortune.getCheckedAt().equals(CurrentDate.now))
+                .map(userFortune -> userFortune.getCheckedAt().equals(CurrentDate.now()))
                 .orElse(false);
     }
 }

--- a/src/main/java/org/sopt/app/application/user/UserService.java
+++ b/src/main/java/org/sopt/app/application/user/UserService.java
@@ -1,6 +1,5 @@
 package org.sopt.app.application.user;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -86,18 +85,6 @@ public class UserService {
 
     public boolean isUserExist(Long userId) {
         return userRepository.existsById(userId);
-    }
-
-    public Long getDuration(Long myGeneration, Long currentGeneration) {
-        long monthsBetweenGenerations = (currentGeneration - myGeneration) * 6;
-        LocalDate now = LocalDate.now();
-        int currentMonth = now.getMonthValue();
-        int startMonth = (currentGeneration % 2 == 0) ? 3 : 9;
-        int monthsSinceStart = currentMonth - startMonth;
-        if (monthsSinceStart < 0) {
-            monthsSinceStart += 12;
-        }
-        return monthsBetweenGenerations + monthsSinceStart;
     }
 
     public List<String> getIcons(IconType iconType) {

--- a/src/main/java/org/sopt/app/common/utils/ActivityDurationCalculator.java
+++ b/src/main/java/org/sopt/app/common/utils/ActivityDurationCalculator.java
@@ -34,7 +34,7 @@ public final class ActivityDurationCalculator {
     }
 
     private static int getMonthDifferenceFromNow(LocalDate startDate) {
-        Period period = Period.between(startDate, CurrentDate.now);
+        Period period = Period.between(startDate, CurrentDate.now());
         return period.getYears() * 12 + period.getMonths() + 1;
     }
 }

--- a/src/main/java/org/sopt/app/common/utils/CurrentDate.java
+++ b/src/main/java/org/sopt/app/common/utils/CurrentDate.java
@@ -5,5 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class CurrentDate {
-    public static final LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
+    public static LocalDate now() {
+        return ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
+    }
 }

--- a/src/main/java/org/sopt/app/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/app/facade/AuthFacade.java
@@ -80,10 +80,6 @@ public class AuthFacade {
         return playgroundAuthService.getPlayGroundProfile(user.getPlaygroundToken());
     }
 
-    public Long getDuration(Long myGeneration, Long generation) {
-        return userService.getDuration(myGeneration, generation);
-    }
-
     public List<String> getIcons(IconType iconType) {
         return userService.getIcons(iconType);
     }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #523 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

### 홈화면 최신 일정 불일치 이슈
- 최신 일정을 산정하는 기준이 CurrentDate.now였는데, 현재 날짜를 계산하는 CurrentDate class에서 now가 static final 필드여서 서버 시작 시점에 날짜가 고정돼있던 이슈를 발견했습니다. 그래서 동적으로 최신 날짜를 계산하도록 메소드화 시켰습니다.
0214dba900680256b38fb402cd79347f0a6e3d36

- 또한 전체 일정을 불러올 때는 시작일자 기준으로 정렬 후 시작일자가 동일한 일정은 종료일자를 기준으로 한번 더 정렬하게 되는데 최신 일정은 시작일자로만 정렬하고 있었기에 정렬 기준을 통일시켰습니다.
53779b500188716fbc182e420ab3040cea8d5265

- 하지만 이슈 리포트에서 날짜가 각각 4/3, 4/5로 다르게 불러와진 1차 세미나의 경우 디버깅했을 때 코드 상 이상이 없었고, 로컬에서 동일한 데이터셋으로 테스트했을 때에도 정상적으로 작동해서 redis cache 문제인 것으로 추정돼 prod, dev 서버에서 캘린더 캐시를 한번 정리했습니다.
- 현재 제 계정 기준으로는 정상적으로 날짜도 동일하게 조회되고 최신 일정도 1차 세미나로 불러와집니다. 유저별로 다른 최신 일정이 조회된 것은 CurrentDate 이슈, 날짜가 다르게 불러와진 것은 기존의 캐시에 4/3으로 기재된 이슈인 것으로 추정되나 우선 더 qa가 필요할 것 같습니다.


이외에 이전 pr의 리팩토링으로 더이상 사용하지 않게 된 메소드들을 삭제했습니다.
a6f7ae993318bc32d622bae5de26009c16113bfa
c9ccffdc4108604a62df149c7102be8b800f600c

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="589" alt="image" src="https://github.com/user-attachments/assets/063fa067-e2ee-4e15-a5c7-ba3a3e2c9c1c" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
