### PR TITLE
[Fix] 솝트로그, 솝탬프 관련 이슈 해결 (#527)

### DIFF
--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -23,6 +23,7 @@ import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.common.utils.ActivityDurationCalculator;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.domain.enums.IconType;
+import org.sopt.app.domain.enums.PlaygroundPart;
 import org.sopt.app.facade.AuthFacade;
 import org.sopt.app.facade.PokeFacade;
 import org.sopt.app.facade.RankFacade;
@@ -108,7 +109,7 @@ public class UserController {
         Long soptDuring = null;
 
         Optional<Long> latestGeneration = playgroundProfile.getAllActivities().stream()
-                .filter(c -> !c.getPlaygroundPart().getPartName().equals("미상"))
+                .filter(c -> !c.getPlaygroundPart().getPartName().equals(PlaygroundPart.NONE.getPartName()))
                 .map(PlaygroundProfileInfo.ActivityCardinalInfo::getGeneration)
                 .max(Comparator.naturalOrder());
 

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -169,12 +169,12 @@ public class UserResponse {
             return SoptLog.builder()
                     .soptLevel("Lv." + soptLevel)
                     .pokeCount(pokeCount + "회")
-                    // 솝탬프 오픈 전까지는 순위 부분에 공개 예정! 표시
                     .soptampRank(soptampRank != null ? soptampRank + "등" : "공개 예정!")
                     .userName(playgroundProfile.getName())
                     .profileImage(playgroundProfile.getProfileImage() != null ? playgroundProfile.getProfileImage() : "")
                     .part(playgroundProfile.getAllActivities().stream()
                             .map(c -> c.getPlaygroundPart().getPartName())
+                            .filter(c -> !c.equals("미상"))
                             .collect(Collectors.joining("/")))
                     .profileMessage(playgroundProfile.getIntroduction() != null ? playgroundProfile.getIntroduction() : "")
                     .during(during != null ? during + "개월" : "")

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -12,6 +12,7 @@ import lombok.ToString;
 import org.sopt.app.application.app_service.dto.AppServiceInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
+import org.sopt.app.domain.enums.PlaygroundPart;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserResponse {
@@ -174,7 +175,7 @@ public class UserResponse {
                     .profileImage(playgroundProfile.getProfileImage() != null ? playgroundProfile.getProfileImage() : "")
                     .part(playgroundProfile.getAllActivities().stream()
                             .map(c -> c.getPlaygroundPart().getPartName())
-                            .filter(c -> !c.equals("미상"))
+                            .filter(c -> !c.equals(PlaygroundPart.NONE.getPartName()))
                             .collect(Collectors.joining("/")))
                     .profileMessage(playgroundProfile.getIntroduction() != null ? playgroundProfile.getIntroduction() : "")
                     .during(during != null ? during + "개월" : "")


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #527 

## Work Description ✏️
솝트로그 관련 이슈를 해결합니다.

### 1. 솝트로그 기수 `미상` 값 제거
- 명예오비 앱잼이나 프로젝트를 활동한 기수가 아닐 때 수행했을 시, 미상으로 파트 이름을 추출하도록 되어있어요. 
- 이를 솝트로그 API 응답에서 미상 값을 명시적으로 제거했어요.
https://github.com/sopt-makers/sopt-backend/blob/6c980c6c7d6233edf20f12606501af366a8feb8c/src/main/java/org/sopt/app/presentation/user/UserResponse.java#L176-L179

### 2. 솝트로그 명예오비 오류나는 이슈 해결
- 솝트로그 조회 시, `isActive` 를 판단하는 기준이 모호하여 오류가 있었어요.
- 기존에는 가장 최근의 Activity을 가져와서 현재 기수와 같으면 isActive로 판단했는데, 명예OB 앱잼의 경우도 활동 기수의 활동으로 플그에서 응답이 오기 때문에 이 경우를 filter로 제외하도록 했어요. 
https://github.com/sopt-makers/sopt-backend/blob/6c980c6c7d6233edf20f12606501af366a8feb8c/src/main/java/org/sopt/app/presentation/user/UserController.java#L111-L116

### 3. 솝트로그 솝탬프 등수 다시 오픈
- 이제 솝탬프를 오픈해야 하므로, 솝트로그에서 솝탬프 등수를 다시 표시하도록 변경했어요.
- isActive가  reference 타입으로 지정되어 있어, `equals()` 비교가 아닌 `Boolean.TRUE.equals(isActive)` 로 안전하게 비교하도록 했어요.
https://github.com/sopt-makers/sopt-backend/blob/3ab8d0db271495b723372c28766c9a056053571f/src/main/java/org/sopt/app/presentation/user/UserController.java#L120-L122
<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
