### PR TITLE
[Refactor] 솝탬프 관련 로직 리팩토링 - #529

### DIFF
--- a/src/main/java/org/sopt/app/application/stamp/StampService.java
+++ b/src/main/java/org/sopt/app/application/stamp/StampService.java
@@ -32,7 +32,7 @@ public class StampService {
     public StampInfo.Stamp findStamp(Long missionId, Long userId) {
         val entity = stampRepository.findByUserIdAndMissionId(userId, missionId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.STAMP_NOT_FOUND));
-        validateStampInfo(entity);
+        entity.validate();
         return StampInfo.Stamp.builder()
                 .id(entity.getId())
                 .contents(entity.getContents())
@@ -42,24 +42,6 @@ public class StampService {
                 .updatedAt(entity.getUpdatedAt())
                 .missionId(entity.getMissionId())
                 .build();
-    }
-
-    private void validateStampInfo(Stamp entity) {
-        if (!StringUtils.hasText(entity.getContents())) {
-            if(entity.getContents().isEmpty()) {
-                log.warn("Stamp ID-{}: stamp contents is empty", entity.getId());
-            }
-            throw new BadRequestException(ErrorCode.INVALID_STAMP_CONTENTS);
-        }
-        if (entity.getImages().isEmpty()) {
-            throw new BadRequestException(ErrorCode.INVALID_STAMP_IMAGES);
-        }
-        if (entity.getActivityDate() == null) {
-            throw new BadRequestException(ErrorCode.INVALID_STAMP_ACTIVITY_DATE);
-        }
-        if (entity.getMissionId() == null) {
-            throw new BadRequestException(ErrorCode.INVALID_STAMP_MISSION_ID);
-        }
     }
 
     @Transactional
@@ -200,6 +182,12 @@ public class StampService {
         return stampRepository.findById(stampId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.STAMP_NOT_FOUND))
                 .getMissionId();
+    }
+
+    @Transactional(readOnly = true)
+    public Stamp getStampById(Long stampId) {
+        return stampRepository.findById(stampId)
+            .orElseThrow(() -> new BadRequestException(ErrorCode.STAMP_NOT_FOUND));
     }
 
     public void deleteAll() {

--- a/src/main/java/org/sopt/app/common/exception/ForbiddenException.java
+++ b/src/main/java/org/sopt/app/common/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package org.sopt.app.common.exception;
+
+import org.sopt.app.common.response.ErrorCode;
+
+public class ForbiddenException extends BaseException {
+	public ForbiddenException() { super(ErrorCode.FORBIDDEN);}
+
+	public ForbiddenException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/org/sopt/app/common/response/ErrorCode.java
+++ b/src/main/java/org/sopt/app/common/response/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     REDIS_CONNECTION_ERROR("레디스 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ENTITY_NOT_FOUND("객체를 찾을수 없습니다.", HttpStatus.NOT_FOUND),
     BAD_REQUEST("잘못된 요청입니다", HttpStatus.BAD_REQUEST),
+    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
     // AUTH
     INVALID_ACCESS_TOKEN("유효하지 않은 앱 어세스 토큰입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN("유효하지 않은 앱 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
@@ -46,6 +47,7 @@ public enum ErrorCode {
     INVALID_STAMP_IMAGES("스탬프 이미지가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_STAMP_MISSION_ID("스탬프 미션 ID가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_STAMP_ID("스탬프 ID가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    STAMP_DELETE_FORBIDDEN("자신의 스탬프만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
 
     // NOTIFICATION
     NOTIFICATION_NOT_FOUND("존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/org/sopt/app/domain/entity/soptamp/Stamp.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptamp/Stamp.java
@@ -5,7 +5,10 @@ import jakarta.persistence.*;
 import java.util.List;
 import lombok.*;
 import org.hibernate.annotations.Type;
+import org.sopt.app.common.exception.BadRequestException;
+import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.BaseEntity;
+import org.springframework.util.StringUtils;
 
 @Entity
 @Getter
@@ -42,4 +45,20 @@ public class Stamp extends BaseEntity {
     public void changeActivityDate(String activityDate) {
         this.activityDate = activityDate;
     }
+
+    public void validate() {
+        if (!StringUtils.hasText(this.contents)) {
+            throw new BadRequestException(ErrorCode.INVALID_STAMP_CONTENTS);
+        }
+        if (this.images == null || this.images.isEmpty()) {
+            throw new BadRequestException(ErrorCode.INVALID_STAMP_IMAGES);
+        }
+        if (this.activityDate == null) {
+            throw new BadRequestException(ErrorCode.INVALID_STAMP_ACTIVITY_DATE);
+        }
+        if (this.missionId == null) {
+            throw new BadRequestException(ErrorCode.INVALID_STAMP_MISSION_ID);
+        }
+    }
+
 }

--- a/src/main/java/org/sopt/app/facade/SoptampFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptampFacade.java
@@ -8,8 +8,11 @@ import org.sopt.app.application.mission.MissionService;
 import org.sopt.app.application.soptamp.*;
 import org.sopt.app.application.stamp.StampInfo.Stamp;
 import org.sopt.app.application.stamp.StampService;
+import org.sopt.app.common.exception.ForbiddenException;
+import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.soptamp.Mission;
 import org.sopt.app.presentation.rank.*;
+import org.sopt.app.presentation.stamp.StampRequest;
 import org.sopt.app.presentation.stamp.StampRequest.RegisterStampRequest;
 import org.sopt.app.presentation.stamp.StampResponse.SoptampReportResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,10 +43,20 @@ public class SoptampFacade {
     }
 
     @Transactional
+    public Stamp editStamp(Long userId, StampRequest.EditStampRequest request){
+        return stampService.editStampContents(request, userId);
+    }
+
+    @Transactional
     public void deleteStamp(Long userId, Long stampId){
-        val missionId = stampService.getMissionIdByStampId(stampId);
-        val mission = missionService.getMissionById(missionId);
+        val stamp = stampService.getStampById(stampId);
+        if(!stamp.getUserId().equals(userId)){
+            throw new ForbiddenException(ErrorCode.STAMP_DELETE_FORBIDDEN);
+        }
+
+        val mission = missionService.getMissionById(stamp.getMissionId());
         soptampUserService.subtractPointByLevel(userId, mission.getLevel());
+
         stampService.deleteStampById(stampId);
     }
 

--- a/src/main/java/org/sopt/app/presentation/stamp/StampController.java
+++ b/src/main/java/org/sopt/app/presentation/stamp/StampController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.val;
-import org.sopt.app.application.stamp.StampService;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.facade.SoptampFacade;
 import org.sopt.app.presentation.stamp.StampResponse.SoptampReportResponse;
@@ -23,9 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @SecurityRequirement(name = "Authorization")
 public class StampController {
 
-    private final StampService stampService;
     private final SoptampFacade soptampFacade;
-
     private final StampResponseMapper stampResponseMapper;
 
     @Operation(summary = "스탬프 조회하기")
@@ -71,7 +68,7 @@ public class StampController {
             @AuthenticationPrincipal User user,
             @Valid @RequestBody StampRequest.EditStampRequest editStampRequest
     ) {
-        val stamp = stampService.editStampContents(editStampRequest, user.getId());
+        val stamp = soptampFacade.editStamp(user.getId(), editStampRequest);
         val response = stampResponseMapper.of(stamp.getId());
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/org/sopt/app/presentation/stamp/StampRequest.java
+++ b/src/main/java/org/sopt/app/presentation/stamp/StampRequest.java
@@ -25,41 +25,43 @@ public class StampRequest {
     }
 
     @Getter
-    @AllArgsConstructor(access = AccessLevel.PUBLIC)
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class RegisterStampRequest {
+    public static class RegisterStampRequest extends BaseStampRequest{
 
+        public RegisterStampRequest(Long missionId, String image, String contents, String activityDate) {
+            super(missionId, image, contents, activityDate);
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class EditStampRequest extends BaseStampRequest{
+
+        public EditStampRequest(Long missionId, String image, String contents, String activityDate) {
+            super(missionId, image, contents, activityDate);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static abstract class BaseStampRequest {
         @Schema(description = "미션 아이디", example = "1")
         @NotNull(message = "missionId may not be null")
         private Long missionId;
-        @Schema(description = "스탬프 이미지", example = "https://s3.ap-northeast-2.amazonaws.com/example/283aab53-22e3-46da-85ec-146c99f82ed4.jpeg")
+
+        @Schema(description = "스탬프 이미지", example = "https://s3.ap-northeast-2.amazonaws.com/example/283aab53-22e3-46da-85ec-146c99f82ed4")
         @NotNull(message = "image may not be null")
         private String image;
+
         @Schema(description = "스탬프 내용", example = "스탬프 찍었다!")
         @NotNull(message = "contents may not be null")
         @NotEmpty(message = "contents may not be empty")
         private String contents;
+
         @Schema(description = "활동 날짜", example = "2024.04.08")
         @NotNull(message = "activity date may not be null")
         private String activityDate;
-    }
 
-    @Getter
-    @AllArgsConstructor(access = AccessLevel.PUBLIC)
-    @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class EditStampRequest {
-
-        @Schema(description = "미션 아이디", example = "1")
-        @NotNull(message = "missionId may not be null")
-        private Long missionId;
-        @Schema(description = "스탬프 이미지", example = "https://s3.ap-northeast-2.amazonaws.com/example/283aab53-22e3-46da-85ec-146c99f82ed4")
-        @NotNull(message = "image may not be null")
-        private String image;
-        @Schema(description = "스탬프 내용", example = "스탬프 찍었다!")
-        @NotNull(message = "contents may not be null")
-        private String contents;
-        @Schema(description = "활동 날짜", example = "2024.04.08")
-        @NotNull(message = "activity date may not be null")
-        private String activityDate;
     }
 }

--- a/src/test/java/org/sopt/app/facade/SoptampFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptampFacadeTest.java
@@ -15,6 +15,7 @@ import org.sopt.app.application.mission.*;
 import org.sopt.app.application.soptamp.*;
 import org.sopt.app.application.stamp.*;
 import org.sopt.app.common.fixtures.SoptampFixture;
+import org.sopt.app.domain.entity.soptamp.Stamp;
 import org.sopt.app.presentation.stamp.StampRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,7 +70,15 @@ class SoptampFacadeTest {
     @DisplayName("SUCCESS_스탬프 삭제하기")
     void SUCCESS_deleteStamp() {
         // given
-        given(stampService.getMissionIdByStampId(STAMP_ID)).willReturn(MISSION_ID);
+        Stamp stamp = Stamp.builder()
+            .id(STAMP_ID)
+            .userId(SOPTAMP_USER_ID)
+            .missionId(MISSION_ID)
+            .images(STAMP_IMG_PATHS)
+            .contents(STAMP_CONTENTS)
+            .activityDate(STAMP_ACTIVITY_DATE)
+            .build();
+        given(stampService.getStampById(STAMP_ID)).willReturn(stamp);
         given(missionService.getMissionById(MISSION_ID)).willReturn(MissionInfo.Level.of(MISSION_LEVEL));
 
         // when


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #529 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
1. 요청 DTO 구조 개선
- RegisterStampRequest, EditStampRequest의 공통 필드 추출 → BaseStampRequest 상속 구조로 리팩토링
389b8b655678a5a1a41c93d6f4d00c71b338cbe3

2. 유효성 검사 책임 분리
- 기존 StampService.validateStampInfo() 삭제
- 엔티티 내 Stamp.validate() 메서드로 유효성 검사 책임 이동
ddfc31f01e1f4a9509e964614275d8116de2e204

3. 권한 체크 로직 추가
- 기존에 스탬프 삭제 시 유저 본인의 스탬프인지 검증하지 않고 삭제가 이루어졌음
- 스탬프 삭제 시 userId vs stamp.userId 비교하여 권한 검증 추가
    - 권한 없을 경우 ForbiddenException + STAMP_DELETE_FORBIDDEN 에러코드 반환
0f7590e1a2f7b46355fe3d6b476926629d68c67c

- 이에 맞춰 SoptampFacadeTest도 수정했습니다
2cf79b9c510346db7bf7cd3eecaca7d1027a9d65

5. 서비스 계층 의존성 정리
- StampController에서 stampService 직접 호출 제거
    - 모든 비즈니스 로직은 SoptampFacade 통해 위임
- editStamp() 또한 Facade에서 수정 처리 로직 담당
75999492e721b1bca7e443ee74ea22a58a4b7b5d

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

스탬프 삭제 권한 미체크를 제외하면 솝탬프 로직 상 문제는 보이지 않아서 리팩토링 위주로 작업이 이루어졌습니다!