### PR TITLE
[FIX} 주인이 아닌 스탬프 삭제 권한 이슈 해결 - #533

### DIFF
--- a/src/main/java/org/sopt/app/application/stamp/StampService.java
+++ b/src/main/java/org/sopt/app/application/stamp/StampService.java
@@ -10,6 +10,7 @@ import lombok.val;
 import org.sopt.app.application.user.UserWithdrawEvent;
 import org.sopt.app.common.event.EventPublisher;
 import org.sopt.app.common.exception.BadRequestException;
+import org.sopt.app.common.exception.ForbiddenException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.soptamp.Stamp;
 import org.sopt.app.interfaces.postgres.StampRepository;
@@ -185,9 +186,9 @@ public class StampService {
     }
 
     @Transactional(readOnly = true)
-    public Stamp getStampById(Long stampId) {
-        return stampRepository.findById(stampId)
-            .orElseThrow(() -> new BadRequestException(ErrorCode.STAMP_NOT_FOUND));
+    public Stamp getStampForDelete(Long stampId, Long userId) {
+        return stampRepository.findByIdAndUserId(stampId, userId)
+            .orElseThrow(() -> new ForbiddenException(ErrorCode.STAMP_DELETE_FORBIDDEN));
     }
 
     public void deleteAll() {

--- a/src/main/java/org/sopt/app/facade/SoptampFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptampFacade.java
@@ -8,8 +8,6 @@ import org.sopt.app.application.mission.MissionService;
 import org.sopt.app.application.soptamp.*;
 import org.sopt.app.application.stamp.StampInfo.Stamp;
 import org.sopt.app.application.stamp.StampService;
-import org.sopt.app.common.exception.ForbiddenException;
-import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.soptamp.Mission;
 import org.sopt.app.presentation.rank.*;
 import org.sopt.app.presentation.stamp.StampRequest;
@@ -49,11 +47,7 @@ public class SoptampFacade {
 
     @Transactional
     public void deleteStamp(Long userId, Long stampId){
-        val stamp = stampService.getStampById(stampId);
-        if(!stamp.getUserId().equals(userId)){
-            throw new ForbiddenException(ErrorCode.STAMP_DELETE_FORBIDDEN);
-        }
-
+        val stamp = stampService.getStampForDelete(stampId, userId);
         val mission = missionService.getMissionById(stamp.getMissionId());
         soptampUserService.subtractPointByLevel(userId, mission.getLevel());
 

--- a/src/main/java/org/sopt/app/interfaces/postgres/StampRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/StampRepository.java
@@ -13,4 +13,6 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
 
     void deleteAllByUserId(Long userId);
 
+    Optional<Stamp> findByIdAndUserId(Long id, Long userId);
+
 }

--- a/src/test/java/org/sopt/app/facade/SoptampFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptampFacadeTest.java
@@ -1,6 +1,6 @@
 package org.sopt.app.facade;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.sopt.app.common.fixtures.SoptampFixture.*;
@@ -78,7 +78,7 @@ class SoptampFacadeTest {
             .contents(STAMP_CONTENTS)
             .activityDate(STAMP_ACTIVITY_DATE)
             .build();
-        given(stampService.getStampById(STAMP_ID)).willReturn(stamp);
+        given(stampService.getStampForDelete(STAMP_ID, SOPTAMP_USER_ID)).willReturn(stamp);
         given(missionService.getMissionById(MISSION_ID)).willReturn(MissionInfo.Level.of(MISSION_LEVEL));
 
         // when


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #533 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
지난 pr에서 주인이 아닌 스탬프 삭제 권한을 검증하기 위해 SoptampFacade 내부에서 stamp.getUserId().equals(userId)로 소유자 검증하도록 수정했지만 여전히 소유자가 아님에도 삭제가 가능한 이슈를 발견했습니다.
기존 코드는 stampService.getStampById()는 userId 없이 stampId만으로 접근 가능해, 구조적으로도 보안에 취약한 부분이 있다고 판단해서 이번 수정에서는 stamp 조회 시점에서부터 userId를 명시적으로 요구하는 getStampForDelete() 메서드를 분리하여
소유자 검증이 누락되거나 우회되는 문제를 구조적으로 차단하였습니다.
권한 체크가 적용된 메서드 추가 및 사용

- StampService#getStampForDelete(Long stampId, Long userId) 추가
    - 본인 소유 스탬프인지 확인하고, 아니라면 ForbiddenException 발생 
    27870763986023d4376dbc4545bd3eb7c2b98cb6
    - SoptampFacade#deleteStamp() 에서 기존 getStampById() → getStampForDelete() 로 변경 
    856890a3f07de5d8d22838aae20d30ed4a665d47


- 테스트 코드 수정
    - SoptampFacadeTest#SUCCESS_deleteStamp() 에서 getStampById() 를 getStampForDelete() 호출 시나리오로 변경
    ef7fa8e5e5114f611f12b8635e1ce0c619d0250d

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
