### PR TITLE
[Fix] AWS Credential 시크릿에서 주입받아 배포하도록 수정 (#548)

### DIFF
--- a/.github/workflows/app-cd-dev.yml
+++ b/.github/workflows/app-cd-dev.yml
@@ -91,6 +91,11 @@ jobs:
           key: ${{ secrets.DEV_PEM_KEY }}
           script: |
             cd ~
-            sudo chmod +x ./app/script/*.sh
-            ./app/script/deploy.sh
+            cd ./app
+            echo "Creating .env file..."
+            echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_ID }}" > .env
+            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_KEY }}" >> .env
+            
+            sudo chmod +x ./script/*.sh
+            ./script/deploy.sh
             docker image prune -f

--- a/src/main/java/org/sopt/app/common/config/AwsConfig.java
+++ b/src/main/java/org/sopt/app/common/config/AwsConfig.java
@@ -1,8 +1,5 @@
 package org.sopt.app.common.config;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,21 +9,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class AwsConfig {
 
-    @Value("${cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String secretKey;
-
     @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean
     public AmazonS3 amazonS3() {
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         return AmazonS3ClientBuilder.standard()
                 .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
                 .build();
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #548 

## Work Description ✏️
### Situation
AWS Credential을 yml에서 주입하여 설정하는 기존 방식을 사용하고 있던 것을 발견했어요.
S3 관련 Access Denied 이슈를 발견하고, 수정하려고 하는데 액세스 키 값이 Github Secret과 yml에 둘 다 설정되어있고 둘의 일치 여부를 확인할 수 없어 디버깅이 어려웠어요.

### Action
이에, docker-compose로 배포 시에 `.env` 파일을 생성하고, 환경 변수를 Github Secret에서 동적으로 CD에서 주입한 뒤 AWS SDK가 기본 자격 증명 공급자 체인 (Default Credential Provider Chain)을 사용하도록 했어요.

작업 내용은 다음과 같아요.

1. AwsConfig에서 `@Value` 로 yml 값을 주입받던 코드 삭제 
```java
@Configuration
public class AwsConfig {

    @Value("${cloud.aws.region.static}")
    private String region;

    @Bean
    public AmazonS3 amazonS3() {
        return AmazonS3ClientBuilder.standard()
                .withRegion(region)
                .build();
    }
}
```

2. `.env` 파일을 동적으로 생성하고, AWS SDK가 자동으로 감지하도록 배포 스크립트 수정
```bash
- name: Docker Container Run
  uses: appleboy/ssh-action@master
  with:
    username: ec2-user
    host: ${{ secrets.DEV_SERVER_IP }}
    key: ${{ secrets.DEV_PEM_KEY }}
    script: |
      cd ~
      cd ./app
      echo "Creating .env file..."
      echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_ID }}" > .env
      echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_KEY }}" >> .env
      
      sudo chmod +x ./script/*.sh
      ./script/deploy.sh
      docker image prune -f
```
<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
