### PR TITLE
[FEAT] 솝커톤 후기 작성 api 구현 - #553

### DIFF
--- a/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
+++ b/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
@@ -1,5 +1,6 @@
 package org.sopt.app.common.config;
 
 public enum OperationConfigCategory {
-    FLOATING_BUTTON
+    FLOATING_BUTTON,
+    REVIEW_FORM
 }

--- a/src/main/java/org/sopt/app/common/config/WebSecurityConfig.java
+++ b/src/main/java/org/sopt/app/common/config/WebSecurityConfig.java
@@ -40,6 +40,7 @@ public class WebSecurityConfig {
             "/api/v2/user/main",
             "/api/v2/home/app-service",
             "/api/v2/home/floating-button",
+            "/api/v2/home/review-form"
     };
 
     private final JwtExceptionFilter jwtExceptionFilter;

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -141,7 +141,9 @@ public class HomeFacade {
     }
 
     @Transactional(readOnly = true)
-    public ReviewFormResponse getReviewFormInfo() {
+    public ReviewFormResponse getReviewFormInfo(User user) {
+        boolean isActive = true;
+        if (user == null) isActive = false;
         Map<String, String> operationConfigMap = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.REVIEW_FORM).stream()
             .collect(Collectors.toMap(OperationConfig::getKey, OperationConfig::getValue));
 
@@ -149,7 +151,8 @@ public class HomeFacade {
                 operationConfigMap.get("title"),
                 operationConfigMap.get("subTitle"),
                 operationConfigMap.get("actionButtonName"),
-                operationConfigMap.get("linkUrl")
+                operationConfigMap.get("linkUrl"),
+                isActive
         );
     }
 }

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -92,8 +92,8 @@ public class HomeFacade {
     public List<RecentPostsResponse> getRecentPosts(User user) {
         return playgroundAuthService.getRecentPostsWithMemberInfo(user.getPlaygroundToken());
     }
-  
-    public List<EmploymentPostResponse> getHomeEmploymentPost(User  user) {
+
+    public List<EmploymentPostResponse> getHomeEmploymentPost(User user) {
         return playgroundAuthService.getPlaygroundEmploymentPostWithMemberInfo(user.getPlaygroundToken());
     }
 
@@ -138,5 +138,18 @@ public class HomeFacade {
                 isActive
         );
 
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewFormResponse getReviewFormInfo() {
+        Map<String, String> operationConfigMap = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.REVIEW_FORM).stream()
+            .collect(Collectors.toMap(OperationConfig::getKey, OperationConfig::getValue));
+
+        return ReviewFormResponse.of(
+                operationConfigMap.get("title"),
+                operationConfigMap.get("subTitle"),
+                operationConfigMap.get("actionButtonName"),
+                operationConfigMap.get("linkUrl")
+        );
     }
 }

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -140,9 +140,10 @@ public class HomeController {
     })
     @GetMapping("/review-form")
     public ResponseEntity<ReviewFormResponse> getReviewForm(
+             @AuthenticationPrincipal User user
     ) {
         return ResponseEntity.ok(
-            homeFacade.getReviewFormInfo()
+            homeFacade.getReviewFormInfo(user)
         );
     }
 }

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -131,4 +131,18 @@ public class HomeController {
                 homeFacade.getFloatingButtonInfo(user)
         );
     }
+
+    @Operation(summary = "후기 폼 정보 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "401", description = "token error", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping("/review-form")
+    public ResponseEntity<ReviewFormResponse> getReviewForm(
+    ) {
+        return ResponseEntity.ok(
+            homeFacade.getReviewFormInfo()
+        );
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/home/response/ReviewFormResponse.java
+++ b/src/main/java/org/sopt/app/presentation/home/response/ReviewFormResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.app.presentation.home.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewFormResponse {
+	private String title;
+	private String subTitle;
+	private String actionButtonName;
+	private String linkUrl;
+
+	public static ReviewFormResponse of(String title, String subTitle,
+		String actionButtonName, String linkUrl) {
+		return ReviewFormResponse.builder()
+			.title(title)
+			.subTitle(subTitle)
+			.actionButtonName(actionButtonName)
+			.linkUrl(linkUrl)
+			.build();
+	}
+}

--- a/src/main/java/org/sopt/app/presentation/home/response/ReviewFormResponse.java
+++ b/src/main/java/org/sopt/app/presentation/home/response/ReviewFormResponse.java
@@ -10,14 +10,16 @@ public class ReviewFormResponse {
 	private String subTitle;
 	private String actionButtonName;
 	private String linkUrl;
+	private Boolean isActive;
 
 	public static ReviewFormResponse of(String title, String subTitle,
-		String actionButtonName, String linkUrl) {
+		String actionButtonName, String linkUrl, Boolean isActive) {
 		return ReviewFormResponse.builder()
 			.title(title)
 			.subTitle(subTitle)
 			.actionButtonName(actionButtonName)
 			.linkUrl(linkUrl)
+			.isActive(isActive)
 			.build();
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #553 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 솝커톤 후기 작성 관련 api 구현
- 영재님이 만드신 운영관련 테이블 양식에 맞춰 비슷한 방식으로 후기 작성 관련 정보들을 조회하도록 api를 구현했습니다.
- 노출여부 : 솝커톤은 활동기수, 비활동기수 모두 참여 가능하므르 노출 여부는 회원 여부에 따라서만 결정하도록 했습니다. 회원인 경우 노출, 비회원인 경우 비노출하도록 isActive 필드를 내려줍니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="742" alt="image" src="https://github.com/user-attachments/assets/b35fadd2-965b-49a7-a00c-bbb539f3418c" />
로컬 테스트인 관계로 비회원, 즉 isActive false인 경우로 테스트했습니다.
머지 후 db에 관련 데이터 추가해두겠습니다!

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
