### PR TITLE
[FEAT] 홈화면 플레이그라운드 최신 게시물 목록 조회 api 구현 - #558

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -36,6 +36,7 @@ import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.OwnPlaygrou
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundMain;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.UserActiveInfo;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
 import org.sopt.app.application.playground.dto.PostWithMemberInfo;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.UnauthorizedException;
@@ -271,8 +272,6 @@ public class PlaygroundAuthService {
                 .toList();
     }
 
-
-
     public List<EmploymentPostResponse> getPlaygroundEmploymentPostWithMemberInfo(String playgroundToken) {
         List<EmploymentPostResponse> employmentPosts = getPlaygroundEmploymentPost(playgroundToken);
         return getPostsWithMemberInfo(playgroundToken, employmentPosts);
@@ -312,5 +311,10 @@ public class PlaygroundAuthService {
     public PlaygroundProfile getPlayGroundProfile(String accessToken) {
         Map<String, String> requestHeader = createAuthorizationHeaderByUserPlaygroundToken(accessToken);
         return playgroundClient.getPlayGroundProfile(requestHeader);
+    }
+
+    public List<PlaygroundRecentPost> getPlaygroundRecentPosts(String accessToken) {
+        Map<String, String> requestHeader = createAuthorizationHeaderByUserPlaygroundToken(accessToken);
+        return playgroundClient.getPlaygroundRecentPosts(requestHeader);
     }
 }

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
@@ -1,6 +1,5 @@
 package org.sopt.app.application.playground;
 
-
 import feign.*;
 import java.util.*;
 import org.sopt.app.application.playground.dto.PlayGroundCoffeeChatWrapper;
@@ -10,6 +9,7 @@ import org.sopt.app.application.playground.dto.PlayGroundEmploymentResponse;
 import org.sopt.app.application.playground.dto.PlayGroundPostDetailResponse;
 import org.sopt.app.application.playground.dto.PlayGroundUserSoptLevelResponse;
 import org.sopt.app.application.playground.dto.PlaygroundPostInfo.PlaygroundPostResponse;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
 import org.sopt.app.application.playground.dto.PlaygroundUserFindCondition;
 import org.sopt.app.application.playground.dto.RecommendedFriendInfo.PlaygroundUserIds;
 import org.sopt.app.presentation.auth.AppAuthRequest.*;
@@ -62,7 +62,7 @@ public interface PlaygroundClient {
     @RequestLine("GET /api/v1/members/coffeechat")
     PlayGroundCoffeeChatWrapper getCoffeeChatList(@HeaderMap Map<String, String> headers);
 
-    @RequestLine("GET /api/v1/community/posts/{postId}")
+    @RequestLine("GET /api/v1/community/posts/{playgroundPostId}")
     PlayGroundPostDetailResponse getPlayGroundPostDetail(@HeaderMap Map<String, String> headers,
                                                          @Param Long postId);
 
@@ -71,4 +71,7 @@ public interface PlaygroundClient {
 
     @RequestLine("GET /api/v1/members/profile/me")
     PlaygroundProfile getPlayGroundProfile(@HeaderMap Map<String, String> headers);
+
+    @RequestLine("GET /api/v1/community/posts/latest")
+    List<PlaygroundRecentPost> getPlaygroundRecentPosts(@HeaderMap Map<String, String> headers);
 }

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPost.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPost.java
@@ -1,0 +1,24 @@
+package org.sopt.app.application.playground.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record PlaygroundRecentPost(
+	@JsonProperty("id") Long playgroundPostId,
+	String profileImage,
+	String name,
+	String generationAndPart,
+	String category,
+	String title,
+	String content,
+	String webLink,
+	@JsonIgnore String createdAt
+){
+	public static PlaygroundRecentPost from(
+		Long postId, String profileImage, String name, String generationAndPart,
+		String category, String title, String content, String webLink, String createdAt
+	) {
+		return new PlaygroundRecentPost(
+			postId, profileImage, name, generationAndPart, category, title, content, webLink, createdAt);
+	}
+}

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPostsResponse.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPostsResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.app.application.playground.dto;
+
+import java.util.List;
+
+public record PlaygroundRecentPostsResponse(
+	List<PlaygroundRecentPost> recentPosts
+) {
+	public static PlaygroundRecentPostsResponse from(List<PlaygroundRecentPost> recentPosts) {
+		return new PlaygroundRecentPostsResponse(recentPosts);
+	}
+}

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -13,6 +13,7 @@ import org.sopt.app.application.app_service.*;
 import org.sopt.app.application.app_service.dto.*;
 import org.sopt.app.application.description.DescriptionInfo.MainDescription;
 import org.sopt.app.application.description.DescriptionService;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
 import org.sopt.app.common.config.OperationConfig;
 import org.sopt.app.common.config.OperationConfigCategory;
 import org.sopt.app.common.utils.ActivityDurationCalculator;
@@ -154,5 +155,10 @@ public class HomeFacade {
                 operationConfigMap.get("linkUrl"),
                 isActive
         );
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlaygroundRecentPost> getPlaygroundRecentPosts(User user) {
+        return playgroundAuthService.getPlaygroundRecentPosts(user.getPlaygroundToken());
     }
 }

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.app_service.dto.AppServiceEntryStatusResponse;
 import org.sopt.app.application.meeting.MeetingResponse;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPostsResponse;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.facade.HomeFacade;
 import org.sopt.app.presentation.home.response.*;
@@ -54,7 +55,6 @@ public class HomeController {
         );
     }
 
-    
     @Operation(summary = "최근 게시물 카테고리별 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "success"),
@@ -67,6 +67,20 @@ public class HomeController {
     ) {
         return ResponseEntity.ok(
                 homeFacade.getRecentPosts(user));
+    }
+
+    @Operation(summary = "최신 게시물 목록 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "401", description = "token error", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping("/posts/latest")
+    public ResponseEntity<PlaygroundRecentPostsResponse> getRecentPosts(
+        @AuthenticationPrincipal User user
+    ) {
+        return ResponseEntity.ok(
+            PlaygroundRecentPostsResponse.from(homeFacade.getPlaygroundRecentPosts(user)));
     }
 
     @Operation(summary = "최근 채용탭 10개 조회")


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #558 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- /api/v1/community/posts/latest internal API 연동 (PlaygroundClient)
- PlaygroundRecentPost, PlaygroundRecentPostsResponse DTO 생성 및 매핑
- HomeController /api/v2/user/posts/latest 엔드포인트 추가

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->
- 게시물 createdAt 기준 분기 로직은 미구현 상태 (기획 요구사항 확인 후 후속 작업 예정)

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
