### PR TITLE
[FIX] #564 - 토큰 형식 변경 및 internal api 관련 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -35,13 +35,13 @@ public class PlaygroundAuthService {
     @Value("${makers.playground.web-page}")
     private String playgroundWebPageUrl;
 
-    public PlaygroundProfile getPlaygroundMemberProfile(Long userId) {
-        try {
-            return playgroundClient.getPlaygroundMemberProfiles(userId).getFirst();
-        } catch (BadRequest e) {
-            throw new BadRequestException(ErrorCode.PLAYGROUND_PROFILE_NOT_EXISTS);
-        }
-    }
+    // public PlaygroundProfile getPlaygroundMemberProfile(Long userId) {
+    //     try {
+    //         return playgroundClient.getPlaygroundMemberProfiles(userId).getFirst();
+    //     } catch (BadRequest e) {
+    //         throw new BadRequestException(ErrorCode.PLAYGROUND_PROFILE_NOT_EXISTS);
+    //     }
+    // }
 
     public List<PlaygroundProfile> getPlaygroundMemberProfiles(List<Long> userIds) {
         String stringifyIds = userIds.stream()

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
@@ -19,16 +19,20 @@ import feign.RequestLine;
 public interface PlaygroundClient {
 
     // headers 제외
-    @RequestLine("GET /internal/api/v1/members/profile?memberIds={memberId}")
-    List<PlaygroundProfile> getPlaygroundMemberProfiles(@Param("memberId") Long playgroundId);
+    // @RequestLine("GET /internal/api/v1/members/profile?memberIds={memberId}")
+    // List<PlaygroundProfile> getPlaygroundMemberProfiles(@Param("memberId") Long playgroundId);
 
     // headers 제외
     @RequestLine("GET /internal/api/v1/members/profile?memberIds={encodedIds}")
     List<PlaygroundProfile> getPlaygroundMemberProfiles(@Param(value = "encodedIds") String encodedIds);
 
     // headers 제외, userId
-    @RequestLine("GET /api/v1/members/profile/me?memberId={memberId}")
+    @RequestLine("GET /internal/api/v1/members/profile/me?memberId={memberId}")
     OwnPlaygroundProfile getOwnPlaygroundProfile(@Param("memberId") Long userId);
+
+    // headermap 제외 memberId 추가
+    @RequestLine("GET /internal/api/v1/members/profile/me?memberId={memberId}")
+    PlaygroundProfile getPlayGroundProfile(@Param("memberId") Long memberId);
 
     // header 제외
     @RequestLine("POST /internal/api/v1/members/profile/recommend")
@@ -36,11 +40,7 @@ public interface PlaygroundClient {
 
     // headermap 제외
     @RequestLine("GET /internal/api/v1/members/{memberId}/project")
-    PlayGroundUserSoptLevelResponse getPlayGroundUserSoptLevel(@Param Long memberId);
-
-    // headermap 제외 memberId 추가
-    @RequestLine("GET /api/v1/members/profile/me?memberId={memberId}")
-    PlaygroundProfile getPlayGroundProfile(@Param Long memberId);
+    PlayGroundUserSoptLevelResponse getPlayGroundUserSoptLevel(@Param("memberId") Long memberId);
 
     // headermap 제외
     @RequestLine("GET /internal/api/v1/community/posts/latest")

--- a/src/main/java/org/sopt/app/common/config/OpenApiConfig.java
+++ b/src/main/java/org/sopt/app/common/config/OpenApiConfig.java
@@ -1,7 +1,6 @@
 package org.sopt.app.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
@@ -22,8 +21,9 @@ import org.springframework.stereotype.Component;
 )
 @SecurityScheme(
         name = "Authorization",
-        type = SecuritySchemeType.APIKEY,
-        in = SecuritySchemeIn.HEADER
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
 )
 @Component
 public class OpenApiConfig {

--- a/src/main/java/org/sopt/app/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/app/common/security/filter/JwtAuthenticationFilter.java
@@ -39,6 +39,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String getAuthorizationToken(final HttpServletRequest request) {
-        return request.getHeader(HttpHeaders.AUTHORIZATION);
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith(ACCESS_TOKEN_PREFIX)) {
+            return header.substring(ACCESS_TOKEN_PREFIX.length());
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #564 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### JwtSecurityFilter 관련
클라이언트에서 전달하는 access token이 "Bearer " 접두어를 포함하는 경우,
토큰 파싱 시 형식 오류로 인해 JWT 인증이 실패하는 문제를 수정했습니다.

- Authorization 헤더에서 "Bearer " 접두어 제거 후 토큰만 추출
- JWT 파싱 오류 방지 및 HTTP 표준 준수

### Swagger 관련
- 기존 APIKEY 방식에서 HTTP + bearer 방식으로 변경
- Swagger UI의 Authorize 창에서 토큰만 입력하면 Authorization 헤더에 "Bearer " 자동 포함되도록 설정
- Authorization 스키마 이름은 기존과 동일하게 유지

### internal api 관련
플그 팀에 맞춰 internal api endpoint를 일부 수정했습니다.
플레이그라운드 팀과의 소통 오류로 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

### internal api 관련
플레이그라운드 팀과의 소통 오류로 일부 internal api가 플레이그라운드 서비스에서 제외된 상황입니다. 담당자와 소통 후 api 요청을 새로 드린 상황으로, 이로 인해 일부 internal api를 필요로하는 api에서 500이 발생할 수 있습니다.