### PR TITLE
[FEAT] #566 - 홈 플그 게시물 관련 api의 dto 필드 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundPopularPost.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundPopularPost.java
@@ -1,9 +1,12 @@
 package org.sopt.app.application.playground.dto;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record PlaygroundPopularPost(
 	@JsonProperty("id") Long playgroundPostId,
+	@Nullable Long userId,
 	String profileImage,
 	String name,
 	String generationAndPart,
@@ -14,10 +17,10 @@ public record PlaygroundPopularPost(
 	String webLink
 ) {
 	public static PlaygroundPopularPost from(
-		Long postId, String profileImage, String name, String generationAndPart, int rank, String category, String content, String title, String webLink
+		Long postId, Long userId, String profileImage, String name, String generationAndPart, int rank, String category, String content, String title, String webLink
 	) {
 		return new PlaygroundPopularPost(
-			postId, profileImage, name, generationAndPart, rank, category, title, content, webLink
+			postId, userId, profileImage, name, generationAndPart, rank, category, title, content, webLink
 		);
 	}
 }

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPost.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPost.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import org.sopt.app.common.config.OperationConfig;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -14,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record PlaygroundRecentPost(
 	@JsonProperty("id") Long playgroundPostId,
+	@Nullable Long userId,
 	String profileImage,
 	String name,
 	String generationAndPart,
@@ -34,7 +37,7 @@ public record PlaygroundRecentPost(
 	);
 
 	public static PlaygroundRecentPost from(
-		Long postId, String profileImage, String name, String generationAndPart,
+		Long postId, Long userId, String profileImage, String name, String generationAndPart,
 		String category, String title, String content, String webLink, String createdAt,
 		Map<String, String> imageConfigMap
 	) {
@@ -44,6 +47,7 @@ public record PlaygroundRecentPost(
 			String defaultMessage = CATEGORY_MESSAGES.getOrDefault(category, "플레이그라운드에 새 글 올려봐!");
 			String image = imageConfigMap.getOrDefault(category + ".imageUrl", imageConfigMap.get("unknown.imageUrl"));
 			return new PlaygroundRecentPost(
+				null,
 				null,
 				image,
 				null,
@@ -58,7 +62,7 @@ public record PlaygroundRecentPost(
 		}
 
 		return new PlaygroundRecentPost(
-			postId, profileImage, name, generationAndPart, category, title, content, webLink, createdAt, false);
+			postId, userId, profileImage, name, generationAndPart, category, title, content, webLink, createdAt, false);
 	}
 
 	private static boolean isOutdated(String createdAt) {

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -171,6 +171,7 @@ public class HomeFacade {
         return playgroundAuthService.getPlaygroundRecentPosts().stream()
             .map(post -> PlaygroundRecentPost.from(
                 post.playgroundPostId(),
+                post.userId(),
                 post.profileImage(),
                 post.name(),
                 post.generationAndPart(),


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #566 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기획 요구사항에 맞춰 홈 플그 게시물 관련 api의 dto에 userId 필드를 추가했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
