### PR TITLE
[FIX] #568 - Feign POST 요청 누락된 Content-Type 헤더 추가 및 후기폼 서버드리븐 isActive 활성화 로직 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/app_service/AppServiceName.java
+++ b/src/main/java/org/sopt/app/application/app_service/AppServiceName.java
@@ -10,7 +10,8 @@ public enum AppServiceName {
     SOPTAMP("솝탬프", "SOPTAMP","soptampBadgeManager"),
     FORTUNE("솝마디", "FORTUNE","fortuneBadgeManager"),
     OTHERS("", "OTHERS","defaultBadgeManager"),
-    FLOATING_BUTTON("FAB", "FLOATING_BUTTON", "floatingButtonBadgeManager");
+    FLOATING_BUTTON("FAB", "FLOATING_BUTTON", "floatingButtonBadgeManager"),
+    REVIEW_FORM("후기폼", "REVIEW_FORM", "reviewFormBadgeManager");
 
     private final String exposedName;
     private final String serviceName;

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
@@ -12,6 +12,7 @@ import org.sopt.app.application.playground.dto.RecommendedFriendInfo.PlaygroundU
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 
@@ -34,7 +35,7 @@ public interface PlaygroundClient {
     @RequestLine("GET /internal/api/v1/members/profile/me?memberId={memberId}")
     PlaygroundProfile getPlayGroundProfile(@Param("memberId") Long memberId);
 
-    // header 제외
+    @Headers("Content-Type: application/json")
     @RequestLine("POST /internal/api/v1/members/profile/recommend")
     PlaygroundUserIds getPlaygroundUserIdsByCondition(@RequestBody PlaygroundUserFindCondition condition);
 

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -130,7 +130,6 @@ public class HomeFacade {
                     appServiceService.getAppService(AppServiceName.FLOATING_BUTTON.getServiceName()).getInactiveUser();
         }
 
-
         Map<String, String> operationConfigMap = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.FLOATING_BUTTON).stream()
                 .collect(Collectors.toMap(OperationConfig::getKey, OperationConfig::getValue));
 
@@ -148,8 +147,14 @@ public class HomeFacade {
 
     @Transactional(readOnly = true)
     public ReviewFormResponse getReviewFormInfo(Long userId) {
-        boolean isActive = true;
-        if (userId == null) isActive = false;
+        boolean isActive = false;
+        if (userId != null) {
+            UserStatus userStatus = platformService.getStatus(userId);
+            isActive = userStatus == UserStatus.ACTIVE ?
+                appServiceService.getAppService(AppServiceName.REVIEW_FORM.getServiceName()).getActiveUser() :
+                appServiceService.getAppService(AppServiceName.REVIEW_FORM.getServiceName()).getInactiveUser();
+        }
+
         Map<String, String> operationConfigMap = operationConfigService
             .getOperationConfigByOperationConfigType(OperationConfigCategory.REVIEW_FORM).stream()
             .collect(Collectors.toMap(OperationConfig::getKey, OperationConfig::getValue));


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #568 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### Feign POST 요청 누락된 Content-Type 헤더 추가
- 이전에는 `@HeaderMap`을 통해 직접 전달되던 `Content-Type: application/json` 헤더가 누락되어, 서버에서 `415 Unsupported Media Type` 에러 발생
- `PlaygroundClient.getPlaygroundUserIdsByCondition(...)` 메서드에 `@Headers("Content-Type: application/json")` 애너테이션 추가
- 빈 filters 등 직렬화 문제 없는 것 확인 (JacksonEncoder 적용됨)
- 관련 설정: `ClientConfig.java`에서 JacksonEncoder 이미 적용된 것 확인

### 후기폼 서버드리븐 isActive 활성화 로직 추가
- `getReviewFormInfo(Long userId)` 메서드에 서버 기반의 `isActive` 활성화 로직 적용
- 기존 `getFloatingButtonInfo(...)`와 동일한 방식으로:
  - `userId` 유효성 확인 후
  - `platformService.getStatus(...)` 호출하여 유저 상태 확인
  - `AppServiceService`에서 `REVIEW_FORM` 기준의 활성/비활성 상태 조회
  - `AppServiceName.REVIEW_FORM` (`serviceName = "REVIEW_FORM"`) 값 사용
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
