### PR TITLE
[Feat] #586 - default User 생성 api 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/user/UserInfo.java
+++ b/src/main/java/org/sopt/app/application/user/UserInfo.java
@@ -1,0 +1,4 @@
+package org.sopt.app.application.user;
+
+public record UserInfo (Long userId){
+}

--- a/src/main/java/org/sopt/app/application/user/UserService.java
+++ b/src/main/java/org/sopt/app/application/user/UserService.java
@@ -96,4 +96,14 @@ public class UserService {
                 .map(Icons::getIconUrl)
                 .toList();
     }
+
+    @Transactional
+    public UserInfo createUser(Long userId) {
+        User user = User.builder()
+            .id(userId)
+            .build();
+        User savedUser = userRepository.save(user);
+
+        return new UserInfo(savedUser.getId());
+    }
 }

--- a/src/main/java/org/sopt/app/common/response/ErrorCode.java
+++ b/src/main/java/org/sopt/app/common/response/ErrorCode.java
@@ -23,7 +23,7 @@ public enum ErrorCode {
     INVALID_PLAYGROUND_CODE("유효하지 않은 플레이그라운드 OAuth 코드입니다.", HttpStatus.UNAUTHORIZED),
     UNAUTHORIZED("권한이 없습니다", HttpStatus.UNAUTHORIZED),
     TOKEN_EXPIRED("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
-
+    INVALID_INTERNAL_API_KEY("유효하지 않은 내부 API key 입니다.", HttpStatus.UNAUTHORIZED),
     // AUTH_CLIENT
     RESPONSE_ERROR("외부 서버 응답 오류", HttpStatus.INTERNAL_SERVER_ERROR),
     COMMUNICATION_ERROR("외부 서버 통신 실패", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/org/sopt/app/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/org/sopt/app/common/security/config/WebSecurityConfig.java
@@ -40,6 +40,7 @@ public class WebSecurityConfig {
             "/api/v2/firebase/**",
             "/api/v2/notification/**",
             "/api/v2/user/main",
+            "/api/v2/user/register",
             "/api/v2/home/app-service",
             "/api/v2/home/floating-button",
             "/api/v2/home/review-form"

--- a/src/main/java/org/sopt/app/facade/UserFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserFacade.java
@@ -10,6 +10,8 @@ import org.sopt.app.application.playground.PlaygroundAuthService;
 import org.sopt.app.application.notification.NotificationService;
 import org.sopt.app.application.app_service.AppServiceService;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
+import org.sopt.app.application.user.UserInfo;
+import org.sopt.app.application.user.UserService;
 import org.sopt.app.domain.entity.User;
 import org.sopt.app.presentation.user.UserResponse.*;
 import org.sopt.app.presentation.user.UserResponseMapper;
@@ -25,6 +27,7 @@ public class UserFacade {
     private final AppServiceService appServiceService;
     private final UserResponseMapper userResponseMapper;
     private final PlatformService platformService;
+    private final UserService userService;
 
     @Transactional(readOnly = true)
     public MainView getMainViewInfo(Long userId) {
@@ -49,5 +52,10 @@ public class UserFacade {
         return appServiceService.getAllAppService().stream()
                 .map(AppService::of)
                 .toList();
+    }
+
+    @Transactional
+    public UserInfo createUser(Long requestUserId){
+        return userService.createUser(requestUserId);
     }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserRequest.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserRequest.java
@@ -16,4 +16,13 @@ public class UserRequest {
         @NotNull(message = "profileMessage may not be null")
         private String profileMessage;
     }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PUBLIC)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CreateUserRequest{
+        @Schema(description = "생성된 UserId", example = "101")
+        @NotNull(message = "userId may not be null")
+        private Long userId;
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -5,12 +5,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.sopt.app.application.app_service.dto.AppServiceInfo;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
 import org.sopt.app.domain.enums.PlaygroundPart;
 
@@ -185,5 +185,12 @@ public class UserResponse {
                     .todayFortuneText(fortuneText)
                     .build();
         }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Create {
+        @Schema(description = "생성된 유저 ID", example = "101")
+        private Long userId;
     }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
@@ -2,6 +2,7 @@ package org.sopt.app.presentation.user;
 
 import org.mapstruct.*;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
+import org.sopt.app.application.user.UserInfo;
 import org.sopt.app.presentation.user.UserResponse.*;
 
 @Mapper(
@@ -17,4 +18,6 @@ public interface UserResponseMapper {
     UserResponse.ProfileMessage of(ProfileMessage profileMessage);
 
     UserResponse.Generation ofGeneration(PlaygroundProfileInfo.UserActiveInfo userActiveInfo);
+
+    Create ofCreate(UserInfo userInfo);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #586

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 플랫폼 팀 요청으로 default User 를 생성하는 api 구현

- [ ] 머지 전 yml 파일 업데이트하기

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢
- 내부 API Key가 유효하지 않은 경우의 예외를 "유효하지 않은 내부 API key 입니다." 로 처리했는데 좀 더 세세하게 작성하는 게 좋다고 생각하시나요? 우선 이렇게 한 이유는 요청자는 어짜피 본인의 요청이 어느팀에서 보낸건지를 모를 수 없을 테니 어느팀에서 보낸 요청에 대한 문제인지를 메세지로 전달하는 것은 불필요하다고 판단 + 너무 세세한 정보는 노출하지 않는게 좋겠다는 생각이 있었습니다. 
- create.sql로 테이블 생성 시 stamp의 user_id 에 대한 물리적 FK, app_user의 PK 전략 두 가지 문제가 존재해서 추후 싱크를 맞출 필요가 있을 것 같습니다. 우선 dev, prod에서 사용하는 DB의 경우 모두 잘 설정되어 있어서 건드리진 않았습니다. 


<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
