### PR TITLE
[Feat] #593 - 플그관련 default 유저 삭제 Internal api 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/user/UserService.java
+++ b/src/main/java/org/sopt/app/application/user/UserService.java
@@ -106,4 +106,12 @@ public class UserService {
 
         return new UserInfo(savedUser.getId());
     }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        userRepository.findUserById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        userRepository.deleteById(userId);
+    }
 }

--- a/src/main/java/org/sopt/app/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/org/sopt/app/common/security/config/WebSecurityConfig.java
@@ -41,6 +41,7 @@ public class WebSecurityConfig {
             "/api/v2/notification/**",
             "/api/v2/user/main",
             "/api/v2/user/register",
+            "/api/v2/user/rollback/{userId}",
             "/api/v2/home/app-service",
             "/api/v2/home/floating-button",
             "/api/v2/home/review-form"

--- a/src/main/java/org/sopt/app/facade/UserFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserFacade.java
@@ -58,4 +58,9 @@ public class UserFacade {
     public UserInfo createUser(Long requestUserId){
         return userService.createUser(requestUserId);
     }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        userService.deleteUser(userId);
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
@@ -18,7 +18,9 @@ import org.sopt.app.presentation.user.UserResponse.Create;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -84,5 +86,23 @@ public class UserOriginalController {
         return ResponseEntity.ok(
             userResponseMapper.ofCreate(
                 userFacade.createUser(request.getUserId())));
+    }
+
+    @Operation(summary = "default 유저 레코드 삭제(rollback)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "401", description = "token error", content = @Content),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long userId,
+                                                    @RequestHeader("apiKey") String apiKey,
+                                                    @Value("${internal.auth.api-key}") String internalApiKey) {
+        if (!internalApiKey.equals(apiKey)) {
+            throw new UnauthorizedException(ErrorCode.INVALID_INTERNAL_API_KEY);
+        }
+
+        userFacade.deleteUser(userId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
@@ -79,9 +79,7 @@ public class UserOriginalController {
         @RequestHeader("apiKey") String apiKey,
         @Value("${internal.auth.api-key}") String internalApiKey
     ){
-        if(!internalApiKey.equals(apiKey)){
-            throw new UnauthorizedException(ErrorCode.INVALID_INTERNAL_API_KEY);
-        }
+        validateInternalApiKey(apiKey, internalApiKey);
 
         return ResponseEntity.ok(
             userResponseMapper.ofCreate(
@@ -98,11 +96,15 @@ public class UserOriginalController {
     public ResponseEntity<Void> deleteUser(@PathVariable Long userId,
                                                     @RequestHeader("apiKey") String apiKey,
                                                     @Value("${internal.auth.api-key}") String internalApiKey) {
-        if (!internalApiKey.equals(apiKey)) {
-            throw new UnauthorizedException(ErrorCode.INVALID_INTERNAL_API_KEY);
-        }
+        validateInternalApiKey(apiKey, internalApiKey);
 
         userFacade.deleteUser(userId);
         return ResponseEntity.ok().build();
+    }
+
+    private void validateInternalApiKey(String requestApiKey, String configuredApiKey) {
+        if (!configuredApiKey.equals(requestApiKey)) {
+            throw new UnauthorizedException(ErrorCode.INVALID_INTERNAL_API_KEY);
+        }
     }
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserOriginalController.java
@@ -94,7 +94,7 @@ public class UserOriginalController {
             @ApiResponse(responseCode = "401", description = "token error", content = @Content),
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    @DeleteMapping("/{userId}")
+    @DeleteMapping("/rollback/{userId}")
     public ResponseEntity<Void> deleteUser(@PathVariable Long userId,
                                                     @RequestHeader("apiKey") String apiKey,
                                                     @Value("${internal.auth.api-key}") String internalApiKey) {


### PR DESCRIPTION
## Related issue 🛠

- closes #593 

## Work Description ✏️

- [x] `DELETE` 메소드로 `default` 유저 삭제 `Internal api `구현

## Uncompleted Tasks 😅

x

## To Reviewers 📢

1. 선행작업 완료해준 재헌님께서 PR에서도 작성해주신 부분이긴한데, `create.sql`로 테이블 생성 시 안맞는 부분들이 조금 있었어서 해당 부분은 조금씩 수정하면서 테스트 진행했습니다
2. `DELETE` 메소드의 응답 `HTTP` 코드는 204가 원칙인걸로 알고있긴하지만, 컨벤션으로 200으로 통일된거같아, 다른 `API`들이랑 동일하게 `HttpStatus.OK`로 반환해주었습니다
3. 존재하지 않는 유저의 삭제 요청에 대한 예외처리를 어디 비즈니스 로직에서 진행해줄지도 고민이 많이 됐었는데, 최대한 기존에 구현되어 있었던 컨벤션에 맞춰서 `UserService`단에서 던져주도록 하였습니다
4. 간단한 작업이긴 했으나, 첫 PR이라 컨벤션 관련한 부분은 꼼꼼하게 봐주시면 감사하겠습니다 🙇🏻‍♂️
