### PR TITLE
[fix] #606 - 콕찌르기/Platform 연동 안정화 & Slack 로깅 예외 방지

### DIFF
--- a/src/main/java/org/sopt/app/application/platform/PlatformClient.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformClient.java
@@ -1,22 +1,27 @@
 package org.sopt.app.application.platform;
 
 import feign.HeaderMap;
-import feign.Param;
+import feign.Headers;
 import feign.QueryMap;
 import feign.RequestLine;
-import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+
+import org.sopt.app.application.platform.dto.PlatformUserIdsRequest;
 import org.sopt.app.application.platform.dto.PlatformUserInfoWrapper;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 @EnableFeignClients
 public interface PlatformClient {
 
+    // 유저정보 GET (CSV 쿼리)
     @RequestLine("GET /api/v1/users")
     PlatformUserInfoWrapper getPlatformUserInfo(@HeaderMap final Map<String, String> headers,
-                                                @QueryMap Map<String, Collection<String>> queryMap);
+                                                @QueryMap Map<String, String> queryMap);
 
+    // 유저정보 조회 POST (JSON 바디)
+    @RequestLine("POST /api/v1/users")
+    @Headers("Content-Type: application/json")
+    PlatformUserInfoWrapper postPlatformUserInfo(@HeaderMap Map<String, String> headers,
+        PlatformUserIdsRequest body);
 }

--- a/src/main/java/org/sopt/app/application/platform/dto/PlatformUserIdsRequest.java
+++ b/src/main/java/org/sopt/app/application/platform/dto/PlatformUserIdsRequest.java
@@ -1,0 +1,5 @@
+package org.sopt.app.application.platform.dto;
+
+import java.util.List;
+
+public record PlatformUserIdsRequest(List<Long> userIds) {}

--- a/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
@@ -12,6 +12,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +25,6 @@ public class PokeHistoryService {
 
         return pokeHistoryList.stream()
                 .map(PokeHistoryInfo::from)
-                .sorted(Comparator.comparing(PokeHistoryInfo::getCreatedAt).reversed())
                 .toList();
     }
 
@@ -54,6 +54,9 @@ public class PokeHistoryService {
     }
 
     public Page<PokeHistory> getAllLatestPokeHistoryIn(List<Long> targetHistoryIds, Pageable pageable) {
+        if (targetHistoryIds == null || targetHistoryIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
         return pokeHistoryRepository.findAllByIdIsInOrderByCreatedAtDesc(targetHistoryIds, pageable);
     }
 
@@ -79,6 +82,7 @@ public class PokeHistoryService {
         return pokeHistories.stream().map(PokeHistoryInfo::from).toList();
     }
 
+    @Transactional
     @EventListener(UserWithdrawEvent.class)
     public void handleUserWithdrawEvent(final UserWithdrawEvent event) {
         pokeHistoryRepository.deleteAllByPokerIdInQuery(event.getUserId());

--- a/src/main/java/org/sopt/app/common/response/ErrorCode.java
+++ b/src/main/java/org/sopt/app/common/response/ErrorCode.java
@@ -44,6 +44,9 @@ public enum ErrorCode {
     PLAYGROUND_PROFILE_NOT_EXISTS("플레이그라운드 프로필을 등록하지 않은 유저입니다.", HttpStatus.NOT_FOUND),
     INVALID_PLAYGROUND_CARDINAL_INFO("플레이그라운드 활동 정보가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
 
+    // PLATFORM
+    PLATFORM_USER_NOT_EXISTS("플랫폼 유저 정보를 가져올 수 없습니다.", HttpStatus.NOT_FOUND),
+
     // OPERATION
     OPERATION_PROFILE_NOT_EXISTS("운영 서비스에 존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND),
 
@@ -76,6 +79,7 @@ public enum ErrorCode {
     POKE_HISTORY_NOT_FOUND("해당 찌르기 내역은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     POKE_MESSAGE_TYPE_NOT_FOUND("해당 찌르기 메시지 타입은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     POKE_MESSAGE_MUST_NOT_BE_NULL("찌르기 메시지 타입은 필수 값입니다.", HttpStatus.BAD_REQUEST),
+    SELF_POKE_NOT_ALLOWED("본인을 찌를 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_POKE("이미 찌르기를 보낸 친구입니다.", HttpStatus.CONFLICT),
 
     // FRIEND

--- a/src/main/java/org/sopt/app/common/response/SlackLoggerAspect.java
+++ b/src/main/java/org/sopt/app/common/response/SlackLoggerAspect.java
@@ -11,6 +11,7 @@ import org.sopt.app.application.slack.SlackService;
 import org.sopt.app.domain.entity.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Aspect
@@ -22,26 +23,70 @@ public class SlackLoggerAspect {
     private final HttpServletRequest request;
     private final SlackService slackService;
 
-    private Long getUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        val user = (User) authentication.getPrincipal();
-        return user.getId();
+    // 가능한 모든 케이스에서 userId를 안전하게 추출
+    private Long resolveUserIdSafely() {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null) return null;
+
+            Object principal = authentication.getPrincipal();
+
+            // 1) 애플리케이션에서 전역적으로 쓰는 Long
+            if (principal instanceof Long l) return l;
+
+            // 2) 도메인 User 엔티티
+            if (principal instanceof User u) return u.getId();
+
+            // 3) Spring Security UserDetails (username이 숫자 id일 수 있음)
+            if (principal instanceof UserDetails ud) {
+                return parseLongOrNull(ud.getUsername());
+            }
+
+            // 4) String (예: "anonymousUser" 또는 "123")
+            if (principal instanceof String s) {
+                Long parsed = parseLongOrNull(s);
+                if (parsed != null) return parsed; // 숫자면 사용
+                return null; // anonymous 등은 null 처리
+            }
+
+            // 5) JWT/기타 토큰: authentication.getName()이 종종 subject/username
+            return parseLongOrNull(authentication.getName());
+        } catch (Exception ex) {
+            log.debug("SlackLoggerAspect: failed to resolve user id: {}", ex.getMessage());
+            return null; // userId를 못 구해도 로깅은 계속 진행
+        }
+    }
+
+    private Long parseLongOrNull(String v) {
+        if (v == null) return null;
+        try { return Long.parseLong(v); }
+        catch (NumberFormatException e) { return null; }
     }
 
     @Before(value = "@annotation(org.sopt.app.common.response.SlackLogger)")
     public void sendLogForError(final JoinPoint joinPoint) {
-        Object[] args = joinPoint.getArgs();
-        if (args.length != 1) {
-            log.warn("Slack Logger Failed : Invalid Used");
-            return;
-        }
+        try {
+            Object[] args = joinPoint.getArgs();
 
-        if (args[0] instanceof Exception e) {
-            String requestUrl = request.getRequestURI();
-            String requestMethod = request.getMethod();
-            ExceptionWrapper exceptionWrapper = extractExceptionWrapper(e);
-            slackService.sendSlackMessage(
-                    SlackMessageGenerator.generate(exceptionWrapper,getUserId(),requestMethod,requestUrl));
+            // 이 애스펙트는 보통 ControllerAdvice의 핸들러(예외 1개 파라미터)를 대상으로 사용된다고 가정
+            if (args.length == 1 && args[0] instanceof Exception e) {
+                String requestUrl = request.getRequestURI();
+                String requestMethod = request.getMethod();
+
+                ExceptionWrapper exceptionWrapper = extractExceptionWrapper(e);
+                Long userId = resolveUserIdSafely();
+
+                slackService.sendSlackMessage(
+                    SlackMessageGenerator.generate(exceptionWrapper, userId, requestMethod, requestUrl)
+                );
+            } else {
+                // 잘못 붙은 경우에도 전체 플로우를 깨지 않도록 경고만 남김
+                log.warn("Slack Logger skipped: invalid usage (expects single Exception arg). method={}, args={}",
+                    joinPoint.getSignature(), args.length);
+            }
+        } catch (Exception ex) {
+            // 로거 자체가 장애 유발하지 않도록 방어
+            log.error("Slack Logger failed: {}", ex.getMessage(), ex);
         }
     }
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/PokeHistoryRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/PokeHistoryRepository.java
@@ -6,6 +6,7 @@ import org.sopt.app.domain.entity.poke.PokeHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,9 +24,11 @@ public interface PokeHistoryRepository extends JpaRepository<PokeHistory, Long> 
 
     Page<PokeHistory> findAllByIdIsInOrderByCreatedAtDesc(List<Long> historyIds, Pageable pageable);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE From PokeHistory ph WHERE ph.pokedId = :userId")
     void deleteAllByPokedIdInQuery(@Param("userId") Long userId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE From PokeHistory ph WHERE ph.pokerId = :userId")
     void deleteAllByPokerIdInQuery(@Param("userId") Long userId);
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #606 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 작업 내용 요약
- Feign 파라미터 포맷 수정으로 Platform 유저 조회 500 이슈 해결
- Slack 로깅 중 발생하던 ClassCastException 제거(로깅 안전화)
- 콕찌르기 응답의 userId 표기 오류 수정 및 에지케이스 하드닝

### 배경 / 현상
- Platform 유저 조회 실패(Feign 500) : GET /api/v1/users 호출 시 Required request parameter 'userIds' ... is not present로 500 발생.
- Slack 로깅 중 500(ClassCastException) : @AuthenticationPrincipal Long을 쓰는 컨트롤러에서, AOP가 principal을 User로 캐스팅하며 ClassCastException.
- 콕찌르기 응답에서 userId가 “내 ID”로 표기 : 상대 프로필 DTO 구성 시 ID 세팅 오류.
- 빈 리스트에서 get(0) 사용으로 NPE 위험 : "누가 나를 찔렀어요" 조회 경로 등 일부 스트림 처리 구간.
- 플랫폼에만 존재하고 로컬 DB엔 없는 유저 찌르기 시 404 : 사전 검증/에러 메시지 정제 필요.
- 에지케이스에서 500 가능성 : (1) 상호 친구 ID가 비어있을 때 외부 호출, (2) 추천할 친구가 없을 때 NPE, (3) 빈 IN 조건 조회, (4) 삭제 쿼리 트랜잭션 경계 등.

### 원인 분석
1. userIds 쿼리 포맷 불일치
서버 명세는 userIds=1,2,3 CSV 1개 키를 요구. 기존 코드는
Map<String, Collection<String>>로 userIds 키를 여러 번 넣어 실제로는 서버가 파라미터 미존재로 인식.
2. SlackLoggerAspect의 고정 캐스팅
전역적으로 @AuthenticationPrincipal Long을 사용하는데 AOP에서 (User) principal 캐스팅을 시도해 예외.
3. 상대/나 ID 혼용
PokeFacade#getFriendUserInfo()에서 PokedUserInfo.userId에 userId(나)를 넣고 있었음.
4. 빈 리스트에 대한 안전장치 부족
.get(0)로 첫 요소 접근, 빈 컬렉션에 대한 외부 호출, 빈 IN 쿼리 등.
5. 플랫폼-only 유저
로컬 User 미존재 케이스가 자연스럽게 NotFound로 떨어지지 않거나 메시지가 불명확.

### 변경 사항 (Fixes)
**Platform 연동**
- 쿼리 파라미터 포맷 수정
  - PlatformService#createQueryParams(List<Long>) → Map<String, String> 반환으로 변경.
  - userIds를 1,2,3 CSV 단일 키로 구성.
  - 빈 리스트 요청 시 BadRequestException(ErrorCode.INVALID_PARAMETER)로 조기 차단.
- 헤더 키 통일
  - X-Api-Key, X-Service-Name로 일관화(HTTP 헤더는 대소문자 무시지만 팀 컨벤션에 맞춤).
- Null/Empty 응답 방어
  - PlatformUserInfoWrapper.data()가 null/empty면 BadRequestException(ErrorCode.PLATFORM_USER_NOT_EXISTS).

**Slack 로깅**
- Aspect 하드닝
  - resolveUserIdSafely() 추가: Long, User, UserDetails(username), String, Authentication#getName()까지 폭넓게 해석.
  - 전체를 try/catch로 감싸 로거 자체가 장애를 유발하지 않도록 처리.
  - 잘못 붙은 포인트컷(파라미터 1개 Exception 아님)인 경우 WARN 로그만 남기고. 패스.

**콕찌르기 도메인**
- 상대 ID 세팅 버그 수정
  - PokeFacade#getFriendUserInfo(...)에서 PokedUserInfo.userId = friendUserId로 수정.
- 빈 리스트 안전화 및 외부 호출 가드
  - getMostRecentPokeMeHistory, getAllPokeMeHistory, 우정도별 조회 등에서 get(0) 제거 → findFirst().orElse(null) + null 필터.
  - createMutualFriendNames(...): 상호친구 ID가 비어있으면 외부 API(platform) 호출 스킵하고 즉시 문구 생성.
  - getFriend(...): 추천할 친구 ID가 null이거나 로컬 미존재면 빈 리스트 반환.
  - PokeHistoryService#getAllLatestPokeHistoryIn(...): 빈 IN이면 Page.empty(pageable) 즉시 반환.
  - PokeHistoryService#handleUserWithdrawEvent(...): @Transactional 추가해 삭제 쿼리의 트랜잭션 보장.
- 에러 메시지 정제 및 사전 검증
  - 자기 자신 찌르기 차단: SELF_POKE_NOT_ALLOWED
  - 로컬 DB 미존재 유저 찌르기 차단: USER_NOT_FOUND (플랫폼-only 유저 온보딩 전까지 명확한 응답)

**리팩토링/기타**
- 중복 정렬 제거
  - PokeHistoryService#getAllOfPokeBetween(...)에서 DB 정렬을 그대로 사용하도록 스트림 정렬 제거.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
