### PR TITLE
[fix] #616 - 솝탬프 순위 계산 로직 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/rank/SoptampUserRankCalculator.java
+++ b/src/main/java/org/sopt/app/application/rank/SoptampUserRankCalculator.java
@@ -28,7 +28,7 @@ public class SoptampUserRankCalculator {
         return Long.valueOf(soptampUserInfos.stream()
                 .sorted(Comparator.comparing(SoptampUserInfo::getTotalPoints).reversed())
                 .map(user -> new AbstractMap.SimpleEntry<>(rankPoint.getAndIncrement(), user))
-                .filter(entry -> entry.getValue().getId().equals(userId))
+                .filter(entry -> entry.getValue().getUserId().equals(userId))
                 .map(AbstractMap.SimpleEntry::getKey)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("User not found")));


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #616 
## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 솝탬프 계산 로직에서 userId를 비교하도록 수정. 기존에는 SoptampUser의 id를 사용하여 오류 발생

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
