### PR TITLE
[fix] #619 - SoptampUser 의 안드로이드 파트명 prefix 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/app_service/SoptampBadgeManager.java
+++ b/src/main/java/org/sopt/app/application/app_service/SoptampBadgeManager.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.app_service.dto.AppServiceBadgeInfo;
 import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.domain.enums.Part;
-import org.sopt.app.domain.enums.PlaygroundPart;
+import org.sopt.app.domain.enums.SoptPart;
 import org.sopt.app.facade.RankFacade;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -19,7 +19,7 @@ public class SoptampBadgeManager implements AppServiceBadgeManager {
 
     @Override
     public AppServiceBadgeInfo acquireAppServiceBadgeInfo(final Long userId) {
-        Part part = PlaygroundPart.toPart(soptampUserService.getSoptampUserInfo(userId).getPart());
+        Part part = SoptPart.toPart(soptampUserService.getSoptampUserInfo(userId).getPart());
         if(part == null) {
             return AppServiceBadgeInfo.createWithAllDisabled();
         }

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
@@ -1,6 +1,6 @@
 package org.sopt.app.application.playground.dto;
 
-import static org.sopt.app.domain.enums.PlaygroundPart.findPlaygroundPartByPartName;
+import static org.sopt.app.domain.enums.SoptPart.findPlaygroundPartByPartName;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
@@ -9,7 +9,7 @@ import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
-import org.sopt.app.domain.enums.PlaygroundPart;
+import org.sopt.app.domain.enums.SoptPart;
 import org.sopt.app.domain.enums.UserStatus;
 
 @Slf4j
@@ -125,17 +125,17 @@ public class PlaygroundProfileInfo {
             }
         }
 
-        public PlaygroundPart getPlaygroundPart() {
+        public SoptPart getPlaygroundPart() {
             try {
                 String[] parts = cardinalInfo.split(",");
                 if (parts.length < 2) {
                     log.warn("Invalid cardinalInfo format: {}", cardinalInfo);
-                    return PlaygroundPart.NONE;
+                    return SoptPart.NONE;
                 }
                 return findPlaygroundPartByPartName(parts[1]);
             } catch (Exception e) {
                 log.warn("Error parsing PlaygroundPart from cardinalInfo: {}", cardinalInfo, e);
-                return PlaygroundPart.NONE;
+                return SoptPart.NONE;
             }
         }
     }

--- a/src/main/java/org/sopt/app/application/rank/CachedUserInfo.java
+++ b/src/main/java/org/sopt/app/application/rank/CachedUserInfo.java
@@ -1,6 +1,6 @@
 package org.sopt.app.application.rank;
 
-import static org.sopt.app.domain.enums.PlaygroundPart.toPart;
+import static org.sopt.app.domain.enums.SoptPart.toPart;
 
 import java.io.Serializable;
 import lombok.AccessLevel;

--- a/src/main/java/org/sopt/app/application/rank/RankScheduler.java
+++ b/src/main/java/org/sopt/app/application/rank/RankScheduler.java
@@ -14,7 +14,7 @@ public class RankScheduler {
     private final RedisRankService redisRankService;
 
     // 매일 오전 4시에 정합성을 맞추기 위해 스케쥴링
-    @Scheduled(cron = "0 4 * * * *")
+    @Scheduled(cron = "0 0 4 * * *")
     public void initialSoptampRank(){
         List<SoptampUserInfo> userInfos = soptampUserFinder.findAllOfCurrentGeneration();
         redisRankService.deleteAll();

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserInfo.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserInfo.java
@@ -2,7 +2,7 @@ package org.sopt.app.application.soptamp;
 
 import lombok.*;
 import org.sopt.app.domain.entity.soptamp.SoptampUser;
-import org.sopt.app.domain.enums.PlaygroundPart;
+import org.sopt.app.domain.enums.SoptPart;
 
 @Getter
 @Builder
@@ -14,7 +14,7 @@ public class SoptampUserInfo {
     private String profileMessage;
     private Long totalPoints;
     private String nickname;
-    private PlaygroundPart part;
+    private SoptPart part;
 
     public static SoptampUserInfo of(SoptampUser soptampUser) {
         return SoptampUserInfo.builder()

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -1,21 +1,19 @@
 package org.sopt.app.application.soptamp;
 
 import static org.sopt.app.domain.entity.soptamp.SoptampUser.createNewSoptampUser;
-import static org.sopt.app.domain.enums.PlaygroundPart.findPlaygroundPartByPartName;
+import static org.sopt.app.domain.enums.SoptPart.findPlaygroundPartByPartName;
 
 import java.util.*;
 import lombok.*;
 
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.ActivityCardinalInfo;
-import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
 import org.sopt.app.application.rank.CachedUserInfo;
 import org.sopt.app.application.rank.RankCacheService;
 import org.sopt.app.application.user.UserWithdrawEvent;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.soptamp.SoptampUser;
-import org.sopt.app.domain.enums.PlaygroundPart;
+import org.sopt.app.domain.enums.SoptPart;
 import org.sopt.app.interfaces.postgres.SoptampUserRepository;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -88,7 +86,7 @@ public class SoptampUserService {
     }
 
     private String generateUniqueNickname(String nickname, String part) {
-        String prefixPartName = PlaygroundPart.findPlaygroundPartByPartName(part).getShortedPartName();
+        String prefixPartName = SoptPart.findPlaygroundPartByPartName(part).getShortedPartName();
         StringBuilder uniqueNickname = new StringBuilder().append(prefixPartName).append(nickname);
         if (soptampUserRepository.existsByNickname(uniqueNickname.toString())) {
             return addSuffixToNickname(uniqueNickname);

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -88,7 +88,7 @@ public class SoptampUserService {
     }
 
     private String generateUniqueNickname(String nickname, String part) {
-        String prefixPartName = "iOS".equalsIgnoreCase(part) ? "아요" : part;
+        String prefixPartName = PlaygroundPart.findPlaygroundPartByPartName(part).getShortedPartName();
         StringBuilder uniqueNickname = new StringBuilder().append(prefixPartName).append(nickname);
         if (soptampUserRepository.existsByNickname(uniqueNickname.toString())) {
             return addSuffixToNickname(uniqueNickname);

--- a/src/main/java/org/sopt/app/domain/entity/soptamp/SoptampUser.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptamp/SoptampUser.java
@@ -3,7 +3,7 @@ package org.sopt.app.domain.entity.soptamp;
 import jakarta.persistence.*;
 import lombok.*;
 import org.sopt.app.domain.entity.BaseEntity;
-import org.sopt.app.domain.enums.PlaygroundPart;
+import org.sopt.app.domain.enums.SoptPart;
 
 @Entity
 @Getter
@@ -27,13 +27,13 @@ public class SoptampUser extends BaseEntity {
     private Long generation;
 
     @Enumerated(EnumType.STRING)
-    private PlaygroundPart part;
+    private SoptPart part;
 
     public void initTotalPoints() {
         this.totalPoints = 0L;
     }
 
-    public static SoptampUser createNewSoptampUser(Long userId, String nickname, Long generation, PlaygroundPart part) {
+    public static SoptampUser createNewSoptampUser(Long userId, String nickname, Long generation, SoptPart part) {
         return SoptampUser.builder()
                 .userId(userId)
                 .nickname(nickname)
@@ -44,7 +44,7 @@ public class SoptampUser extends BaseEntity {
                 .build();
     }
 
-    public void updateChangedGenerationInfo(Long generation, PlaygroundPart part, String nickname) {
+    public void updateChangedGenerationInfo(Long generation, SoptPart part, String nickname) {
         this.generation = generation;
         this.part = part;
         this.nickname = nickname;

--- a/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
+++ b/src/main/java/org/sopt/app/domain/enums/PlaygroundPart.java
@@ -35,7 +35,7 @@ public enum PlaygroundPart {
 
     public static PlaygroundPart findPlaygroundPartByPartName(String partName) {
         return Arrays.stream(PlaygroundPart.values())
-                .filter(playgroundPart -> playgroundPart.partName.equals(partName))
+                .filter(playgroundPart -> playgroundPart.partName.equalsIgnoreCase(partName))
                 .findAny()
                 .orElse(PlaygroundPart.NONE);
     }

--- a/src/main/java/org/sopt/app/domain/enums/SoptPart.java
+++ b/src/main/java/org/sopt/app/domain/enums/SoptPart.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public enum PlaygroundPart {
+public enum SoptPart {
     PRESIDENT("회장", "회장"),
     VICE_PRESIDENT("부회장", "부회장"),
     GENERAL_AFFAIR("총무", "총무"),
@@ -33,15 +33,15 @@ public enum PlaygroundPart {
     final String partName;
     final String shortedPartName;
 
-    public static PlaygroundPart findPlaygroundPartByPartName(String partName) {
-        return Arrays.stream(PlaygroundPart.values())
+    public static SoptPart findPlaygroundPartByPartName(String partName) {
+        return Arrays.stream(SoptPart.values())
                 .filter(playgroundPart -> playgroundPart.partName.equalsIgnoreCase(partName))
                 .findAny()
-                .orElse(PlaygroundPart.NONE);
+                .orElse(SoptPart.NONE);
     }
 
-    public static Part toPart(PlaygroundPart playgroundPart) {
-        return switch (playgroundPart) {
+    public static Part toPart(SoptPart soptPart) {
+        return switch (soptPart) {
             case PLAN, PLAN_PART_LEADER -> Part.PLAN;
             case DESIGN, DESIGN_PART_LEADER -> Part.DESIGN;
             case ANDROID, ANDROID_PART_LEADER -> Part.ANDROID;

--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,9 +20,8 @@ import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
 import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.common.utils.ActivityDurationCalculator;
-import org.sopt.app.domain.entity.User;
 import org.sopt.app.domain.enums.IconType;
-import org.sopt.app.domain.enums.PlaygroundPart;
+import org.sopt.app.domain.enums.SoptPart;
 import org.sopt.app.facade.AuthFacade;
 import org.sopt.app.facade.PokeFacade;
 import org.sopt.app.facade.RankFacade;
@@ -109,7 +107,7 @@ public class UserController {
         Long soptDuring = null;
 
         Optional<Long> latestGeneration = playgroundProfile.getAllActivities().stream()
-                .filter(c -> !c.getPlaygroundPart().getPartName().equals(PlaygroundPart.NONE.getPartName()))
+                .filter(c -> !c.getPlaygroundPart().getPartName().equals(SoptPart.NONE.getPartName()))
                 .map(PlaygroundProfileInfo.ActivityCardinalInfo::getGeneration)
                 .max(Comparator.naturalOrder());
 

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.sopt.app.application.app_service.dto.AppServiceInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
-import org.sopt.app.domain.enums.PlaygroundPart;
+import org.sopt.app.domain.enums.SoptPart;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserResponse {
@@ -175,7 +175,7 @@ public class UserResponse {
                     .profileImage(playgroundProfile.getProfileImage() != null ? playgroundProfile.getProfileImage() : "")
                     .part(playgroundProfile.getAllActivities().stream()
                             .map(c -> c.getPlaygroundPart().getPartName())
-                            .filter(c -> !c.equals(PlaygroundPart.NONE.getPartName()))
+                            .filter(c -> !c.equals(SoptPart.NONE.getPartName()))
                             .collect(Collectors.joining("/")))
                     .profileMessage(playgroundProfile.getIntroduction() != null ? playgroundProfile.getIntroduction() : "")
                     .during(during != null ? during + "개월" : "")


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #619 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- SoptampUser 의 Android 파트의 파트명 prefix 를 '안드로이드' 에서 '안드'로 사용하도록 수정했습니다.
- 기존 iOS 를 처리하시는 부분을 하드코딩으로 처리하신 이유가 이전에는 Playground 에서 제공하던 파트명을 현재는 플랫폼에서 제공해주기 때문에 그렇게 하신 것 같은데, 제가 명세서를 확인해보니 내려주는 값들은 비슷해서 하드코딩 보단 Enum이 낫겠다고 생각해서 PlaygroundPart 를 사용하도록 수정했습니다. 그런데 이 플랫폼 측에서 전달받은 데이터를 PlaygroundPart enum 으로 처리한다면 추후 혼란이 있을 수 있을 것 같은데 enum 명을 수정하는게 좋을까요?? 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
