### PR TITLE
[Fix] #640 박수친 유저 조회 profileImage nullable하게 수정

### DIFF
--- a/src/main/java/org/sopt/app/facade/SoptampFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptampFacade.java
@@ -1,5 +1,7 @@
 package org.sopt.app.facade;
 
+import static java.util.Optional.*;
+
 import java.util.List;
 
 import java.util.Objects;
@@ -112,7 +114,7 @@ public class SoptampFacade {
         val imageMap = platformInfos.stream()
             .collect(Collectors.toMap(
                 p -> (long) p.userId(),
-                p -> java.util.Optional.ofNullable(p.profileImage()).orElse(""),
+                p -> ofNullable(p.profileImage()).orElse(""),
                 (a, b) -> a,
                 java.util.LinkedHashMap::new
             ));


### PR DESCRIPTION
## Related issue 🛠

- closes #640 

## To Reviewers 📢

플폼에서 받아오는 `getPlatformUserInfosResponse` 활용해서 매핑시 
프로필 이미지는 `nullable` 하게 설정되어야해서 
`getClapUsersPage` 메서드 수정해주었습니다
