### PR TITLE
[Feat] #676 앱잼탬프 미션 목록 조회 API 파라미터 변경

### DIFF
--- a/src/main/java/org/sopt/app/application/appjamuser/AppjamUserService.java
+++ b/src/main/java/org/sopt/app/application/appjamuser/AppjamUserService.java
@@ -29,9 +29,9 @@ public class AppjamUserService {
     }
 
     public TeamSummary getTeamSummaryByUserId(Long userId) {
-        val appjamUser = appjamUserRepository.findByUserId(userId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.TEAM_NOT_FOUND));
-        return TeamSummary.from(appjamUser);
+        return appjamUserRepository.findByUserId(userId)
+            .map(TeamSummary::from)
+            .orElseGet(TeamSummary::empty);
     }
 
     public boolean isAppjamParticipant(Long userId) {

--- a/src/main/java/org/sopt/app/facade/MissionFacade.java
+++ b/src/main/java/org/sopt/app/facade/MissionFacade.java
@@ -2,7 +2,6 @@ package org.sopt.app.facade;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.sopt.app.application.appjamuser.AppjamUserInfo.AppjamUserStatus;
 import org.sopt.app.application.appjamuser.AppjamUserInfo.TeamSummary;
 import org.sopt.app.application.appjamuser.AppjamUserService;
 import org.sopt.app.application.mission.AppjamMissionService;
@@ -25,22 +24,18 @@ public class MissionFacade {
         @Nullable TeamNumber teamNumber,
         @Nullable Boolean complete
     ) {
-        if (teamNumber == null) {
-            val missions = appjamMissionService.getDisplayedMissions();
-            return AppjamMissionInfos.of(AppjamUserStatus.appjamNotJoined(), TeamSummary.empty(),
-                missions);
-        }
-
-        val teamSummary = appjamUserService.getTeamSummaryByTeamNumber(teamNumber);
+        val teamSummary = resolveTeamSummary(userId, teamNumber);
         val appjamUserStatus = appjamUserService.getAppjamUserStatus(userId);
-        if (complete != null) {
-            return AppjamMissionInfos.of(
-                appjamUserStatus,
-                teamSummary,
-                appjamMissionService.getMissionsByTeamAndCondition(teamNumber, complete));
-        }
+
         return AppjamMissionInfos.of(appjamUserStatus, teamSummary,
-            appjamMissionService.getMissionsByTeam(teamNumber));
+            appjamMissionService.getMissions(teamSummary.getTeamNumber(), complete));
+    }
+
+    private TeamSummary resolveTeamSummary(Long userId, TeamNumber teamNumber) {
+        if (teamNumber != null) {
+            return appjamUserService.getTeamSummaryByTeamNumber(teamNumber);
+        }
+        return appjamUserService.getTeamSummaryByUserId(userId);
     }
 
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserController.java
@@ -158,6 +158,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Deprecated
     @Operation(summary = "앱잼 팀 정보 조회")
     @GetMapping("/appjam-info")
     public ResponseEntity<UserResponse.AppjamStatusResponse> getTeamInfo(


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #676

## Work Description ✏️
- 앱잼탬프 미션 목록 조회 API 파라미터 변경
- 기존에 teamNumber 파라미터가 null 일 경우 앱잼 미참여 유저를 위한 응답값을 내려주던 방식을 teamNumber 파라미터가 null 일 경우 요청한 유저에 따른 응답값을 내려주도록 변경
  - 변경 전
    - teamNumber 파라미터가 있는 경우 해당 팀의 미션 목록 조회를 반환
    - teamNumber 파라미터가 없는 경우 단순 전체 미션 목록 조회를 반환
  - 변경 후
    - teamNumber 파라미터가 있는 경우 해당 팀의 미션 목록 조회를 반환
    - teamNumber 파라미터가 없는 경우 요청한 유저의 미션 목록 조회를 반환(팀이 있는 경우 해당 팀의 미션 목록 조회, 팀이 없는 경우 단순 전체 미션 목록 조회)

- 기존에 service 단 메서드에서 분기 처리를 진행하던 부분을 service 단 내부로 옮겨서 분기 처리가 늘어갈 경우에 좀 더 편하게 대응할 수 있도록 함. 이 과정에서 부득이하게 boolean 같은 primitive 타입을 포기하고 TeamNumber 나 Boolean이 service 단까지 null 일 수 있음이 전파됨
## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
