### PR TITLE
[Feat] #680 앱잼탬프 스탬프 등록 API 응답값에 User Profile 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/stamp/StampInfo.java
+++ b/src/main/java/org/sopt/app/application/stamp/StampInfo.java
@@ -135,4 +135,45 @@ public class StampInfo {
         }
     }
 
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class StampWithProfile {
+
+        private Long id;
+        private String contents;
+        private List<String> images;
+        private Long userId;
+        private Long missionId;
+        private String activityDate;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private String ownerNickname;
+        private String ownerProfileImage;
+        private int clapCount;
+        private int viewCount;
+
+        public static StampInfo.StampWithProfile of(
+            StampInfo.Stamp stamp,
+            String ownerNickname,
+            String ownerProfileImage
+        ) {
+            return StampWithProfile.builder()
+                .id(stamp.getId())
+                .contents(stamp.getContents())
+                .images(stamp.getImages())
+                .userId(stamp.getUserId())
+                .missionId(stamp.getMissionId())
+                .activityDate(stamp.getActivityDate())
+                .createdAt(stamp.getCreatedAt())
+                .updatedAt(stamp.getUpdatedAt())
+                .ownerNickname(ownerNickname)
+                .ownerProfileImage(ownerProfileImage)
+                .clapCount(stamp.getClapCount())
+                .viewCount(stamp.getViewCount())
+                .build();
+        }
+    }
+
 }

--- a/src/main/java/org/sopt/app/facade/AppjamtampFacade.java
+++ b/src/main/java/org/sopt/app/facade/AppjamtampFacade.java
@@ -55,7 +55,7 @@ public class AppjamtampFacade {
     }
 
     @Transactional
-    public StampInfo.Stamp uploadStamp(Long userId, RegisterStampRequest registerStampRequest) {
+    public StampInfo.StampWithProfile uploadStamp(Long userId, RegisterStampRequest registerStampRequest) {
         val appjamUserStatus = appjamUserService.getAppjamUserStatus(userId);
         if (!appjamUserStatus.isAppjamJoined()) {
             throw new BadRequestException(ErrorCode.TEAM_FORBIDDEN);
@@ -65,7 +65,9 @@ public class AppjamtampFacade {
         val result = appjamStampService.uploadStamp(registerStampRequest, userId);
         Level mission = missionService.getMissionLevelById(registerStampRequest.getMissionId());
         soptampUserService.addPointByLevel(userId, mission.getLevel());
-        return result;
+        val soptampUser = soptampUserFinder.findById(userId);
+        val userInfo = platformService.getPlatformUserInfoResponse(userId);
+        return StampInfo.StampWithProfile.of(result, soptampUser.getNickname(), userInfo.profileImage());
     }
 
     public AppjamUserStatus getAppjampStatus(Long userId){

--- a/src/main/java/org/sopt/app/presentation/appjamtamp/AppjamtampResponse.java
+++ b/src/main/java/org/sopt/app/presentation/appjamtamp/AppjamtampResponse.java
@@ -116,6 +116,10 @@ public class AppjamtampResponse {
         private LocalDateTime createdAt;
         @Schema(description = "스탬프 수정 일시", example = "2023-03-29T18:39:42.106369")
         private LocalDateTime updatedAt;
+        @Schema(description = "앱잼탬프 주인 닉네임", example = "서버홍길동")
+        private String ownerNickname;
+        @Schema(description = "앱잼탬프 주인 프로필 이미지", example = "example.com")
+        private String ownerProfileImage;
         @Schema(description = "미션 아이디", example = "3")
         private Long missionId;
         @Schema(description = "총 박수 횟수", example = "124")

--- a/src/main/java/org/sopt/app/presentation/appjamtamp/AppjamtampResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/appjamtamp/AppjamtampResponseMapper.java
@@ -21,7 +21,7 @@ import org.sopt.app.presentation.appjamtamp.AppjamtampResponse.AppjamMissionResp
 )
 public interface AppjamtampResponseMapper {
 
-    AppjamtampResponse.StampMain of(StampInfo.Stamp stampInfo);
+    AppjamtampResponse.StampMain of(StampInfo.StampWithProfile stampInfo);
 
     @Mapping(source = "appjamJoined", target = "isAppjamJoined")
     AppjamMissionResponses of(AppjamMissionInfos missionList);


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #680

## Work Description ✏️
- 클라이언트 요구사항에 맞춰 앱잼탬프 스탬프 등록 API 응답값에 UserProfile 정보 추가
  - name의 경우 SoptampUser 의 nickName을 사용
  - profileImage의 경우 auth 서버의 이미지를 사용

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
