### PR TITLE
[FEAT] #709: 솝탬프 파트별 랭킹 파트원 수 고려해서 계산하도록 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/rank/AuthPartMemberCountReader.java
+++ b/src/main/java/org/sopt/app/application/rank/AuthPartMemberCountReader.java
@@ -4,6 +4,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.domain.enums.SoptPart;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -13,16 +14,19 @@ public class AuthPartMemberCountReader {
 
     private final JdbcTemplate jdbcTemplate;
 
+    @Value("${makers.auth.schema}")
+    private String authSchema;
+
     public Map<SoptPart, Long> getCurrentGenerationPartMemberCounts(Long generation) {
         String sql = """
             SELECT part, COUNT(*) AS member_count
-            FROM auth_prod.user_activity_histories
+            FROM %s.user_activity_histories
             WHERE generation = ?
               AND is_sopt = true
               AND role = 'MEMBER'
               AND part IN ('IOS', 'ANDROID', 'DESIGN', 'PLAN', 'SERVER', 'WEB')
             GROUP BY part
-            """;
+            """.formatted(authSchema);
 
         return jdbcTemplate.query(sql, rs -> {
             Map<SoptPart, Long> result = new EnumMap<>(SoptPart.class);

--- a/src/main/java/org/sopt/app/application/rank/AuthPartMemberCountReader.java
+++ b/src/main/java/org/sopt/app/application/rank/AuthPartMemberCountReader.java
@@ -1,0 +1,40 @@
+package org.sopt.app.application.rank;
+
+import java.util.EnumMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.domain.enums.SoptPart;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthPartMemberCountReader {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public Map<SoptPart, Long> getCurrentGenerationPartMemberCounts(Long generation) {
+        String sql = """
+            SELECT part, COUNT(*) AS member_count
+            FROM auth_prod.user_activity_histories
+            WHERE generation = ?
+              AND is_sopt = true
+              AND role = 'MEMBER'
+              AND part IN ('IOS', 'ANDROID', 'DESIGN', 'PLAN', 'SERVER', 'WEB')
+            GROUP BY part
+            """;
+
+        return jdbcTemplate.query(sql, rs -> {
+            Map<SoptPart, Long> result = new EnumMap<>(SoptPart.class);
+
+            while (rs.next()) {
+                result.put(
+                    SoptPart.valueOf(rs.getString("part")),
+                    rs.getLong("member_count")
+                );
+            }
+
+            return result;
+        }, generation);
+    }
+}

--- a/src/main/java/org/sopt/app/application/rank/SoptampPartRankCalculator.java
+++ b/src/main/java/org/sopt/app/application/rank/SoptampPartRankCalculator.java
@@ -19,7 +19,9 @@ import org.sopt.app.domain.enums.SoptPart;
 @RequiredArgsConstructor(access = AccessLevel.PUBLIC)
 public class SoptampPartRankCalculator {
 
-    private static final BigDecimal ZERO_POINT = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+    private static final int POINT_SCALE = 2;
+    private static final RoundingMode POINT_ROUNDING_MODE = RoundingMode.HALF_UP;
+    private static final BigDecimal ZERO_POINT = BigDecimal.ZERO.setScale(POINT_SCALE, POINT_ROUNDING_MODE);
 
     private final List<SoptampUserInfo> userInfos;
     private final Map<SoptPart, Long> partMemberCounts;
@@ -57,7 +59,7 @@ public class SoptampPartRankCalculator {
 
             BigDecimal averagePoint = memberCount == 0 ? ZERO_POINT
                 : BigDecimal.valueOf(totalScore)
-                    .divide(BigDecimal.valueOf(memberCount), 2, RoundingMode.HALF_UP);
+                    .divide(BigDecimal.valueOf(memberCount), POINT_SCALE, POINT_ROUNDING_MODE);
 
             averagePoints.put(part, averagePoint);
         }

--- a/src/main/java/org/sopt/app/application/rank/SoptampPartRankCalculator.java
+++ b/src/main/java/org/sopt/app/application/rank/SoptampPartRankCalculator.java
@@ -1,32 +1,90 @@
 package org.sopt.app.application.rank;
 
+import static java.util.Map.Entry.comparingByValue;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.soptamp.SoptampPointInfo.PartRank;
 import org.sopt.app.application.soptamp.SoptampUserInfo;
 import org.sopt.app.domain.enums.Part;
-
+import org.sopt.app.domain.enums.SoptPart;
 
 @RequiredArgsConstructor(access = AccessLevel.PUBLIC)
 public class SoptampPartRankCalculator {
 
-    private final List<SoptampUserInfo> userInfos;
+    private static final BigDecimal ZERO_POINT = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
 
-    private final PartScores partScores = new PartScores();
+    private final List<SoptampUserInfo> userInfos;
+    private final Map<SoptPart, Long> partMemberCounts;
 
     public List<PartRank> calculatePartRank() {
-        userInfos.forEach(this::calculatePartScore);
-        return Part.getPartsByReturnOrder().stream().map(part -> PartRank.builder()
+        PartScores partScores = new PartScores();
+        userInfos.forEach(userInfo -> addPartScore(userInfo, partScores));
+
+        Map<Part, BigDecimal> averagePoints = calculateAveragePoints(partScores);
+        Map<Part, Integer> ranks = calculateRanks(averagePoints);
+
+        return Part.getPartsByReturnOrder().stream()
+            .map(part -> PartRank.builder()
                 .part(part.getPartName())
-                .rank(partScores.getRank(part))
-                .points(partScores.getPoints(part))
-                .build()).toList();
+                .rank(ranks.get(part))
+                .points(averagePoints.get(part))
+                .build())
+            .toList();
     }
 
-    private void calculatePartScore(SoptampUserInfo userInfo) {
-        Part.getAllParts().stream()
-                .filter(part -> userInfo.getNickname().startsWith(part.getPartName()))
-                .forEach(part -> partScores.addPartScore(part, userInfo.getTotalPoints()));
+    private void addPartScore(SoptampUserInfo userInfo, PartScores partScores) {
+        Part part = SoptPart.toPart(userInfo.getPart());
+        if (part == null) {
+            return;
+        }
+        partScores.addPartScore(part, userInfo.getTotalPoints());
+    }
+
+    private Map<Part, BigDecimal> calculateAveragePoints(PartScores partScores) {
+        Map<Part, BigDecimal> averagePoints = new EnumMap<>(Part.class);
+
+        for (Part part : Part.getPartsByReturnOrder()) {
+            long totalScore = partScores.getPoints(part);
+            long memberCount = partMemberCounts.getOrDefault(SoptPart.valueOf(part.name()), 0L);
+
+            BigDecimal averagePoint = memberCount == 0 ? ZERO_POINT
+                : BigDecimal.valueOf(totalScore)
+                    .divide(BigDecimal.valueOf(memberCount), 2, RoundingMode.HALF_UP);
+
+            averagePoints.put(part, averagePoint);
+        }
+
+        return averagePoints;
+    }
+
+    private Map<Part, Integer> calculateRanks(Map<Part, BigDecimal> averagePoints) {
+        List<Entry<Part, BigDecimal>> sortedParts = averagePoints.entrySet().stream()
+            .sorted(comparingByValue(Comparator.reverseOrder()))
+            .toList();
+
+        Map<Part, Integer> ranks = new EnumMap<>(Part.class);
+        BigDecimal previousPoint = null;
+        int currentRank = 0;
+
+        for (int i = 0; i < sortedParts.size(); i++) {
+            Entry<Part, BigDecimal> entry = sortedParts.get(i);
+
+            if (previousPoint == null || entry.getValue().compareTo(previousPoint) != 0) {
+                currentRank = i + 1;
+                previousPoint = entry.getValue();
+            }
+
+            ranks.put(entry.getKey(), currentRank);
+        }
+
+        return ranks;
     }
 }

--- a/src/main/java/org/sopt/app/application/rank/SoptampPartRankCalculator.java
+++ b/src/main/java/org/sopt/app/application/rank/SoptampPartRankCalculator.java
@@ -1,6 +1,8 @@
 package org.sopt.app.application.rank;
 
 import static java.util.Map.Entry.comparingByValue;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.summingLong;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -27,9 +29,7 @@ public class SoptampPartRankCalculator {
     private final Map<SoptPart, Long> partMemberCounts;
 
     public List<PartRank> calculatePartRank() {
-        PartScores partScores = new PartScores();
-        userInfos.forEach(userInfo -> addPartScore(userInfo, partScores));
-
+        Map<Part, Long> partScores = calculatePartScores();
         Map<Part, BigDecimal> averagePoints = calculateAveragePoints(partScores);
         Map<Part, Integer> ranks = calculateRanks(averagePoints);
 
@@ -42,20 +42,28 @@ public class SoptampPartRankCalculator {
             .toList();
     }
 
-    private void addPartScore(SoptampUserInfo userInfo, PartScores partScores) {
-        Part part = SoptPart.toPart(userInfo.getPart());
-        if (part == null) {
-            return;
+    private Map<Part, Long> calculatePartScores() {
+        Map<Part, Long> partScores = userInfos.stream()
+            .filter(userInfo -> SoptPart.toPart(userInfo.getPart()) != null)
+            .collect(groupingBy(
+                userInfo -> SoptPart.toPart(userInfo.getPart()),
+                () -> new EnumMap<>(Part.class),
+                summingLong(SoptampUserInfo::getTotalPoints)
+            ));
+
+        for (Part part : Part.getAllParts()) {
+            partScores.putIfAbsent(part, 0L);
         }
-        partScores.addPartScore(part, userInfo.getTotalPoints());
+
+        return partScores;
     }
 
-    private Map<Part, BigDecimal> calculateAveragePoints(PartScores partScores) {
+    private Map<Part, BigDecimal> calculateAveragePoints(Map<Part, Long> partScores) {
         Map<Part, BigDecimal> averagePoints = new EnumMap<>(Part.class);
 
         for (Part part : Part.getPartsByReturnOrder()) {
-            long totalScore = partScores.getPoints(part);
-            long memberCount = partMemberCounts.getOrDefault(SoptPart.valueOf(part.name()), 0L);
+            long totalScore = partScores.getOrDefault(part, 0L);
+            long memberCount = getMemberCount(part);
 
             BigDecimal averagePoint = memberCount == 0 ? ZERO_POINT
                 : BigDecimal.valueOf(totalScore)
@@ -65,6 +73,10 @@ public class SoptampPartRankCalculator {
         }
 
         return averagePoints;
+    }
+
+    private long getMemberCount(Part part) {
+        return partMemberCounts.getOrDefault(SoptPart.valueOf(part.name()), 0L);
     }
 
     private Map<Part, Integer> calculateRanks(Map<Part, BigDecimal> averagePoints) {

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampPointInfo.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampPointInfo.java
@@ -1,5 +1,6 @@
 package org.sopt.app.application.soptamp;
 
+import java.math.BigDecimal;
 import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -31,6 +32,6 @@ public class SoptampPointInfo {
     public static class PartRank {
         private String part;
         private Integer rank;
-        private Long points;
+        private BigDecimal points;
     }
 }

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
@@ -4,6 +4,7 @@ import static java.util.function.UnaryOperator.identity;
 
 import java.util.List;
 import java.util.Map;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
@@ -20,6 +21,7 @@ public class SoptampUserFinder {
 
     private final SoptampUserRepository soptampUserRepository;
 
+    @Getter
     @Value("${sopt.current.generation}")
     private Long currentGeneration;
 

--- a/src/main/java/org/sopt/app/facade/RankFacade.java
+++ b/src/main/java/org/sopt/app/facade/RankFacade.java
@@ -9,6 +9,7 @@ import org.sopt.app.application.soptamp.*;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.enums.Part;
+import org.sopt.app.domain.enums.SoptPart;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ public class RankFacade {
 
     private final SoptampUserFinder soptampUserFinder;
     private final RankCacheService rankCacheService;
+    private final AuthPartMemberCountReader authPartMemberCountReader;
 
     @Value("${makers.app.soptamp.appjam-mode:false}")
     private boolean appjamMode;
@@ -102,7 +104,8 @@ public class RankFacade {
             throw new BadRequestException(ErrorCode.INVALID_APPJAM_SEASON_REQUEST);
         }
         List<SoptampUserInfo> soptampUserInfos = soptampUserFinder.findAllOfCurrentGeneration();
-        SoptampPartRankCalculator soptampPartRankCalculator = new SoptampPartRankCalculator(soptampUserInfos);
+        Map<SoptPart, Long> partMemberCounts = authPartMemberCountReader.getCurrentGenerationPartMemberCounts(soptampUserFinder.getCurrentGeneration());
+        SoptampPartRankCalculator soptampPartRankCalculator = new SoptampPartRankCalculator(soptampUserInfos, partMemberCounts);
         return soptampPartRankCalculator.calculatePartRank();
     }
 
@@ -112,10 +115,12 @@ public class RankFacade {
             throw new BadRequestException(ErrorCode.INVALID_APPJAM_SEASON_REQUEST);
         }
         List<SoptampUserInfo> soptampUserInfos = soptampUserFinder.findAllOfCurrentGeneration();
-        SoptampPartRankCalculator soptampPartRankCalculator = new SoptampPartRankCalculator(soptampUserInfos);
+        Map<SoptPart, Long> partMemberCounts = authPartMemberCountReader.getCurrentGenerationPartMemberCounts(soptampUserFinder.getCurrentGeneration());
+        SoptampPartRankCalculator soptampPartRankCalculator = new SoptampPartRankCalculator(soptampUserInfos, partMemberCounts);
         return soptampPartRankCalculator.calculatePartRank().stream()
-                .filter(partRank -> partRank.getPart().equals(part.getPartName()))
-                .findFirst().orElseThrow();
+            .filter(partRank -> partRank.getPart().equals(part.getPartName()))
+            .findFirst()
+            .orElseThrow();
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/org/sopt/app/common/fixtures/SoptampUserFixture.java
+++ b/src/test/java/org/sopt/app/common/fixtures/SoptampUserFixture.java
@@ -154,4 +154,12 @@
          );
      }
 
+     public static final Map<SoptPart, Long> PART_MEMBER_COUNT_MAP = Map.of(
+         SoptPart.PLAN, 10L,
+         SoptPart.DESIGN, 10L,
+         SoptPart.WEB, 10L,
+         SoptPart.IOS, 10L,
+         SoptPart.ANDROID, 10L,
+         SoptPart.SERVER, 30L
+     );
  }

--- a/src/test/java/org/sopt/app/facade/RankFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/RankFacadeTest.java
@@ -338,10 +338,7 @@ class RankFacadeTest {
             // when
             PartRank result = rankFacade.findPartRank(Part.SERVER);
 
-            BigDecimal serverPoint = BigDecimal.valueOf(
-                    SERVER_PART_SOPTAMP_USER.stream().mapToLong(SoptampUser::getTotalPoints).sum()
-                )
-                .divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.SERVER)), 2, RoundingMode.HALF_UP);
+            BigDecimal serverPoint = BigDecimal.valueOf(SERVER_PART_SOPTAMP_USER.stream().mapToLong(SoptampUser::getTotalPoints).sum()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.SERVER)), 2, RoundingMode.HALF_UP);
 
             // then
             assertThat(result)

--- a/src/test/java/org/sopt/app/facade/RankFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/RankFacadeTest.java
@@ -3,6 +3,8 @@ package org.sopt.app.facade;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.sopt.app.common.fixtures.SoptampUserFixture.CURRENT_GENERATION;
+import static org.sopt.app.common.fixtures.SoptampUserFixture.PART_MEMBER_COUNT_MAP;
 import static org.sopt.app.common.fixtures.SoptampUserFixture.SERVER_PART_SOPTAMP_USER;
 import static org.sopt.app.common.fixtures.SoptampUserFixture.SERVER_PART_SOPTAMP_USER_INFO_LIST;
 import static org.sopt.app.common.fixtures.SoptampUserFixture.SOPTAMP_PROFILE_MESSAGE_CACHE;
@@ -18,6 +20,8 @@ import static org.sopt.app.domain.enums.Part.ANDROID;
 import static org.sopt.app.domain.enums.Part.DESIGN;
 import static org.sopt.app.domain.enums.Part.IOS;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.List;
 import org.assertj.core.groups.Tuple;
@@ -29,12 +33,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.rank.AuthPartMemberCountReader;
 import org.sopt.app.application.rank.RankCacheService;
 import org.sopt.app.application.soptamp.SoptampPointInfo.Main;
 import org.sopt.app.application.soptamp.SoptampPointInfo.PartRank;
 import org.sopt.app.application.soptamp.SoptampUserFinder;
 import org.sopt.app.domain.entity.soptamp.SoptampUser;
 import org.sopt.app.domain.enums.Part;
+import org.sopt.app.domain.enums.SoptPart;
 
 @ExtendWith(MockitoExtension.class)
 class RankFacadeTest {
@@ -44,6 +50,9 @@ class RankFacadeTest {
 
     @Mock
     private RankCacheService rankCacheService;
+
+    @Mock
+    private AuthPartMemberCountReader authPartMemberCountReader;
 
     @InjectMocks
     private RankFacade rankFacade;
@@ -215,7 +224,7 @@ class RankFacadeTest {
         List<Main> result = rankFacade.findCurrentRanksByPart(Part.SERVER);
 
         // then
-       assertThat(result)
+        assertThat(result)
            .hasSize(SERVER_PART_SOPTAMP_USER_INFO_LIST.size())
            .extracting(Main::getRank, Main::getNickname, Main::getPoint)
            .containsExactlyInAnyOrder(
@@ -248,34 +257,45 @@ class RankFacadeTest {
         void setUp(){
             // given
             when(soptampUserFinder.findAllOfCurrentGeneration()).thenReturn(SOPTAMP_USER_INFO_LIST);
+            when(soptampUserFinder.getCurrentGeneration()).thenReturn(CURRENT_GENERATION);
+            when(authPartMemberCountReader.getCurrentGenerationPartMemberCounts(CURRENT_GENERATION))
+                .thenReturn(PART_MEMBER_COUNT_MAP);
 
             //when
             result = rankFacade.findAllPartRanks();
         }
 
-
         @Test
         @DisplayName("SUCCESS 파트별 솝탬프 포인트 랭킹 조회 시 기-디-웹-아-안-서 순서대로 조회함")
         void SUCCESS_findAllPartRanks_sortedByPart() {
+            BigDecimal planPoint = BigDecimal.ZERO.setScale(2);
+            BigDecimal designPoint = BigDecimal.valueOf(SOPTAMP_USER_4.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.DESIGN)), 2, RoundingMode.HALF_UP);
+            BigDecimal webPoint = BigDecimal.ZERO.setScale(2);
+            BigDecimal iosPoint = BigDecimal.valueOf(SOPTAMP_USER_3.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.IOS)), 2, RoundingMode.HALF_UP);
+            BigDecimal androidPoint = BigDecimal.valueOf(SOPTAMP_USER_2.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.ANDROID)), 2, RoundingMode.HALF_UP);
+            BigDecimal serverPoint = BigDecimal.valueOf(SERVER_PART_SOPTAMP_USER.stream().mapToLong(SoptampUser::getTotalPoints).sum()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.SERVER)), 2, RoundingMode.HALF_UP);
+
             //then
             assertThat(result)
-                .extracting(PartRank::getPart)
-                 .containsExactly(Part.PLAN.getPartName(),
-                    Part.DESIGN.getPartName(),
-                    Part.WEB.getPartName(),
-                    Part.IOS.getPartName(),
-                    Part.ANDROID.getPartName(),
-                    Part.SERVER.getPartName());
+                .extracting(PartRank::getPart, PartRank::getRank, PartRank::getPoints)
+                .containsExactly(
+                    Tuple.tuple(Part.PLAN.getPartName(), 5, planPoint),
+                    Tuple.tuple(Part.DESIGN.getPartName(), 2, designPoint),
+                    Tuple.tuple(Part.WEB.getPartName(), 5, webPoint),
+                    Tuple.tuple(Part.IOS.getPartName(), 2, iosPoint),
+                    Tuple.tuple(Part.ANDROID.getPartName(), 4, androidPoint),
+                    Tuple.tuple(Part.SERVER.getPartName(), 1, serverPoint)
+                );
         }
 
         @Test
         @DisplayName("SUCCESS 파트별 솝탬프 포인트가 동점일 경우 랭킹도 동점으로 조회됨")
         void SUCCESS_findAllPartRanks_whenTiedPart() {
-            Long tiedPoint = SOPTAMP_USER_3.getTotalPoints();
+            BigDecimal tiedPoint = BigDecimal.valueOf(SOPTAMP_USER_3.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.IOS)), 2, RoundingMode.HALF_UP);
 
             // then
             List<PartRank> tiedPart = result.stream()
-                .filter(partRank -> partRank.getPoints().equals(tiedPoint))
+                .filter(partRank -> partRank.getPoints().compareTo(tiedPoint) == 0)
                 .toList();
 
             assertThat(tiedPart)
@@ -290,10 +310,12 @@ class RankFacadeTest {
         @Test
         @DisplayName("SUCCESS 이전에 솝탬프 포인트가 동점인 파트가 존재했을 경우 다음 순위는 동점 파트 수를 건너뛰고 계산됨")
         void SUCCESS_findAllPartRanks_whenAfterTiedPart(){
+            BigDecimal androidPoint = BigDecimal.valueOf(SOPTAMP_USER_2.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.ANDROID)), 2, RoundingMode.HALF_UP);
+
             // then
             assertThat(result)
-                .extracting(PartRank::getPart, PartRank::getRank)
-                .contains(Tuple.tuple(Part.ANDROID.getPartName(), 4));
+                .extracting(PartRank::getPart, PartRank::getRank, PartRank::getPoints)
+                .contains(Tuple.tuple(Part.ANDROID.getPartName(), 4, androidPoint));
         }
 
     }
@@ -305,6 +327,9 @@ class RankFacadeTest {
         @BeforeEach
         void setUp(){
             when(soptampUserFinder.findAllOfCurrentGeneration()).thenReturn(SOPTAMP_USER_INFO_LIST);
+            when(soptampUserFinder.getCurrentGeneration()).thenReturn(CURRENT_GENERATION);
+            when(authPartMemberCountReader.getCurrentGenerationPartMemberCounts(CURRENT_GENERATION))
+                .thenReturn(PART_MEMBER_COUNT_MAP);
         }
 
         @Test
@@ -313,12 +338,15 @@ class RankFacadeTest {
             // when
             PartRank result = rankFacade.findPartRank(Part.SERVER);
 
+            BigDecimal serverPoint = BigDecimal.valueOf(
+                    SERVER_PART_SOPTAMP_USER.stream().mapToLong(SoptampUser::getTotalPoints).sum()
+                )
+                .divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.SERVER)), 2, RoundingMode.HALF_UP);
+
             // then
             assertThat(result)
                 .extracting(PartRank::getPart, PartRank::getRank, PartRank::getPoints)
-                .contains(Part.SERVER.getPartName(), 1, SERVER_PART_SOPTAMP_USER.stream()
-                    .mapToLong(SoptampUser::getTotalPoints)
-                    .sum());
+                .contains(Part.SERVER.getPartName(), 1, serverPoint);
         }
 
         @Test
@@ -328,14 +356,17 @@ class RankFacadeTest {
             PartRank designResult = rankFacade.findPartRank(DESIGN);
             PartRank iosResult = rankFacade.findPartRank(IOS);
 
+            BigDecimal designPoint = BigDecimal.valueOf(SOPTAMP_USER_4.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.DESIGN)), 2, RoundingMode.HALF_UP);
+            BigDecimal iosPoint = BigDecimal.valueOf(SOPTAMP_USER_3.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.IOS)), 2, RoundingMode.HALF_UP);
+
             // then
             assertThat(designResult)
                 .extracting(PartRank::getPart, PartRank::getRank, PartRank::getPoints)
-                .contains(Part.DESIGN.getPartName(), 2, SOPTAMP_USER_4.getTotalPoints());
+                .contains(Part.DESIGN.getPartName(), 2, designPoint);
 
             assertThat(iosResult)
                 .extracting(PartRank::getPart, PartRank::getRank, PartRank::getPoints)
-                .contains(Part.IOS.getPartName(), 2, SOPTAMP_USER_3.getTotalPoints());
+                .contains(Part.IOS.getPartName(), 2, iosPoint);
         }
 
         @Test
@@ -344,10 +375,12 @@ class RankFacadeTest {
             // when
             PartRank result = rankFacade.findPartRank(ANDROID);
 
+            BigDecimal androidPoint = BigDecimal.valueOf(SOPTAMP_USER_2.getTotalPoints()).divide(BigDecimal.valueOf(PART_MEMBER_COUNT_MAP.get(SoptPart.ANDROID)), 2, RoundingMode.HALF_UP);
+
             // then
             assertThat(result)
                 .extracting(PartRank::getPart, PartRank::getRank, PartRank::getPoints)
-                .contains(ANDROID.getPartName(), 4, SOPTAMP_USER_2.getTotalPoints());
+                .contains(ANDROID.getPartName(), 4, androidPoint);
         }
 
     }
@@ -419,7 +452,5 @@ class RankFacadeTest {
                 assertThat(resultUser4).isBetween(3L, 4L);
             }
         }
-
     }
-
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #709 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

파트별 랭킹 점수를 총점 / 현재 기수 파트원 수 기준으로 계산하도록 수정했습니다.
- 현재 기수의 파트원 수는 auth 스키마의 `user_activity_histories`에서 조회하도록 했고, `is_sopt = true`, `role = MEMBER` 조건으로 일반 파트원 수만 반영되도록 했습니다. 
- 계산 로직은 기존 총점을 먼저 모은 뒤, 파트별 인원 수로 나누어 평균 점수를 만든 다음 이 값을 기준으로 rank를 다시 계산하도록 구성했습니다.  동점인 경우에는 기존처럼 공동 순위가 유지되도록 처리했습니다.
- 응답 순서는 기존의 기획-디자인-웹-아요-안드-서버순서를 그대로 유지했습니다. 점수 계산 기준만 바꾸고 응답 순서까지 바뀌면 기존 화면 영향이 있을 수 있어, rank 계산과 응답 순서를 분리해서 구현했습니다.
- 평균 점수는 소수점 둘째 자리까지 반올림해서 내려가도록 수정했고, 테스트도 함께 수정해 평균 점수, 공동 순위, 기존 응답 순서를 검증하도록 반영했습니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->