### PR TITLE
[Feat] #719 poke/to/me API 단일 랜덤 조회로 변경

### DIFF
--- a/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
@@ -10,6 +10,7 @@ import org.sopt.app.domain.entity.poke.PokeHistory;
 import org.sopt.app.interfaces.postgres.PokeHistoryRepository;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,18 +29,10 @@ public class PokeHistoryService {
                 .toList();
     }
 
-    public List<Long> getPokedFriendIds(Long userId) {
-        val friends = pokeHistoryRepository.findAllByPokerIdAndIsReply(userId, false);
-        return friends.stream()
-                .map(PokeHistory::getPokedId)
-                .toList();
-    }
-
-    public List<Long> getPokeFriendIds(Long userId) {
-        val friends = pokeHistoryRepository.findAllByPokedIdAndIsReply(userId, false);
-        return friends.stream()
-                .map(PokeHistory::getPokerId)
-                .toList();
+    public Optional<PokeHistory> getRandomUnRepliedPokeMeHistory(Long userId) {
+        return pokeHistoryRepository.findRandomUnRepliedPokeMeHistory(userId, PageRequest.of(0, 1))
+            .stream()
+            .findFirst();
     }
 
     public List<Long> getPokeMeUserIds(Long userId) {

--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -3,7 +3,6 @@ package org.sopt.app.facade;
 import static org.sopt.app.application.poke.PokeInfo.NEW_FRIEND_MANY_MUTUAL;
 import static org.sopt.app.application.poke.PokeInfo.NEW_FRIEND_NO_MUTUAL;
 import static org.sopt.app.application.poke.PokeInfo.NEW_FRIEND_ONE_MUTUAL;
-import static org.sopt.app.domain.entity.QUser.*;
 
 import java.util.*;
 import lombok.RequiredArgsConstructor;
@@ -57,20 +56,13 @@ public class PokeFacade {
     }
 
     @Transactional(readOnly = true)
-    public SimplePokeProfile getMostRecentPokeMeHistory(Long userId) {
-        List<Long> pokeMeUserIds = pokeHistoryService.getPokeMeUserIds(userId);
-        Optional<PokeHistory> mostRecentPokeMeHistory = pokeMeUserIds.stream()
-            .filter(userService::isUserExist)
-            .map(pokeMeUserId ->
-                    pokeHistoryService.getAllLatestPokeHistoryFromTo(pokeMeUserId, userId).stream()
-                        .findFirst().orElse(null)
-            )
-            .filter(Objects::nonNull)
-            .filter(pokeHistory -> !pokeHistory.getIsReply())
-            .max(Comparator.comparing(PokeHistory::getCreatedAt));
-        return mostRecentPokeMeHistory
+    public SimplePokeProfile getRandomUnRepliedPokeMeHistory(Long userId) {
+        return pokeHistoryService.getRandomUnRepliedPokeMeHistory(userId)
             .map(pokeHistory -> getPokeHistoryProfile(
-                userId, pokeHistory.getPokerId(), pokeHistory.getId()))
+                userId,
+                pokeHistory.getPokerId(),
+                pokeHistory.getId()
+            ))
             .orElse(null);
     }
 

--- a/src/main/java/org/sopt/app/interfaces/postgres/PokeHistoryRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/PokeHistoryRepository.java
@@ -42,4 +42,7 @@ public interface PokeHistoryRepository extends JpaRepository<PokeHistory, Long> 
     Long countByPokedIdAndIsReplyIsFalse(Long pokedId);
 
     Long countByPokerIdOrPokedId(@NotNull Long pokerId, @NotNull Long pokedId);
+
+    @Query("SELECT ph FROM PokeHistory ph WHERE ph.id IN (SELECT MAX(ph2.id) FROM PokeHistory ph2 WHERE ph2.pokedId = :userId AND ph2.isReply = false AND EXISTS (SELECT 1 FROM User u WHERE u.id = ph2.pokerId) GROUP BY ph2.pokerId) ORDER BY function('RANDOM')")
+    List<PokeHistory> findRandomUnRepliedPokeMeHistory(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/org/sopt/app/presentation/poke/PokeController.java
+++ b/src/main/java/org/sopt/app/presentation/poke/PokeController.java
@@ -84,16 +84,16 @@ public class PokeController {
         return ResponseEntity.ok(result);
     }
 
-    @Operation(summary = "누가 나를 찔렀어요 조회 - 단일")
+    @Operation(summary = "누가 나를 찔렀어요 조회 - 단일 랜덤")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "success"),
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
     @GetMapping("/to/me")
-    public ResponseEntity<SimplePokeProfile> getPokeMeMostRecent(
-            @AuthenticationPrincipal Long userId
+    public ResponseEntity<SimplePokeProfile> getRandomUnRepliedPokeMe(
+        @AuthenticationPrincipal Long userId
     ) {
-        val response = pokeFacade.getMostRecentPokeMeHistory(userId);
+        val response = pokeFacade.getRandomUnRepliedPokeMeHistory(userId);
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #719 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- /api/v2/poke/to/me API의 응답 로직을 기존 “가장 최근에 나를 찌른 1명”에서 “나를 찌른 사람들 중 아직 답장하지 않은 사람을 랜덤으로 1명 반환”하도록 변경했습니다.

기존 로직은 사용자 기준으로 최신 poke를 조회하는 방식이었으나, 요구사항 변경에 따라 미답장 poke 대상 중 랜덤 노출이 필요해 로직을 수정했습니다.

구현 과정에서 다음을 고려하였습니다.
- isReply = false 조건을 통해 답장하지 않은 poke만 필터링
- 동일 사용자가 여러 번 찌른 경우에도 공정하게 노출되도록 → pokerId 기준으로 그룹화 후 최신 poke 1건만 추출
- 탈퇴 유저가 노출되지 않도록 → User 존재 여부를 EXISTS 서브쿼리로 필터링

최종적으론 사용자 기준 최신 poke 1건씩 추출하고, 해당 사용자들 중 랜덤 1명 선택한 뒤 PageRequest.of(0,1)을 통해 1건만 반환하도록 구성했습니다.


## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->