### PR TITLE
[Feat] #726 천생연분 범위 수정 및 10콕 누락 해결

### DIFF
--- a/src/main/java/org/sopt/app/domain/enums/Friendship.java
+++ b/src/main/java/org/sopt/app/domain/enums/Friendship.java
@@ -9,10 +9,10 @@ import java.util.Arrays;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum Friendship {
-    NON_FRIEND("nonfriend","새로운 친구", 0,2),
-    NEW_FRIEND("new","친한친구",2, 5),
-    BEST_FRIEND("bestfriend","단짝친구",5,10),
-    SOULMATE("soulmate","천생연분",11,99)
+    NON_FRIEND("nonfriend","새로운 친구", 0, 2),
+    NEW_FRIEND("new","친한친구", 2, 5),
+    BEST_FRIEND("bestfriend","단짝친구", 5, 10),
+    SOULMATE("soulmate","천생연분", 10, Integer.MAX_VALUE)
     ;
 
     private final String typeFlag;
@@ -22,8 +22,8 @@ public enum Friendship {
 
     public static Friendship getFriendshipByValue(String type) {
         return Arrays.stream(values())
-                .filter(friendship -> friendship.getTypeFlag().equals(type))
-                .findFirst()
-                .orElseThrow(() -> new BadRequestException(ErrorCode.FRIENDSHIP_NOT_FOUND));
+            .filter(friendship -> friendship.getTypeFlag().equals(type))
+            .findFirst()
+            .orElseThrow(() -> new BadRequestException(ErrorCode.FRIENDSHIP_NOT_FOUND));
     }
 }

--- a/src/main/java/org/sopt/app/domain/enums/Friendship.java
+++ b/src/main/java/org/sopt/app/domain/enums/Friendship.java
@@ -11,8 +11,8 @@ import java.util.Arrays;
 public enum Friendship {
     NON_FRIEND("nonfriend","새로운 친구", 0, 2),
     NEW_FRIEND("new","친한친구", 2, 5),
-    BEST_FRIEND("bestfriend","단짝친구", 5, 10),
-    SOULMATE("soulmate","천생연분", 10, Integer.MAX_VALUE)
+    BEST_FRIEND("bestfriend","단짝친구", 5, 11),
+    SOULMATE("soulmate","천생연분", 11, Integer.MAX_VALUE)
     ;
 
     private final String typeFlag;


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #726

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 친구 관계 구간을 정의하는 `Friendship` 범위를 수정했습니다.
- 기존에는 천생연분 조건이 `11 이상 ~ 99 미만`으로 잡혀 있어서, 콕 수가 99 이상이 되면 친구 목록 조회에서 제외되는 문제가 있었습니다.
- 이 과정에서 관계 구간 사이에 비어 있는 값도 함께 확인되어, 친구 관계가 끊기지 않도록 범위를 연속적으로 이어지게 수정했습니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

- 10번 콕찌르기 부분이 누락되어있는 부분을 확인했는데, 혹시 이부분은 의도된 부분이었을까요..? 우선 함께 수정해두었습니다!