### PR TITLE
[Fix] #728: 홈 API 커넥션 점유 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
+++ b/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
@@ -7,6 +7,7 @@ import org.sopt.app.common.exception.NotFoundException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.interfaces.postgres.OperationConfigRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ public class OperationConfigService {
 
     private final OperationConfigRepository operationConfigRepository;
 
+    @Transactional(readOnly = true)
     public List<OperationConfig> getOperationConfigByOperationConfigType(OperationConfigCategory operationConfigCategory) {
         return operationConfigRepository.findByOperationConfigCategory(operationConfigCategory).orElseThrow(
                 () -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -66,10 +66,20 @@ public class PlaygroundAuthService {
     }
 
     public List<PlaygroundRecentPost> getPlaygroundRecentPosts() {
-        return playgroundClient.getPlaygroundRecentPosts();
+        try {
+            return playgroundClient.getPlaygroundRecentPosts();
+        } catch (Exception e) {
+            log.warn("Playground 최근 게시글 조회 실패, 빈 리스트 반환", e);
+            return List.of();
+        }
     }
 
     public List<PlaygroundPopularPost> getPlaygroundPopularPosts() {
-        return playgroundClient.getPlaygroundPopularPosts();
+        try {
+            return playgroundClient.getPlaygroundPopularPosts();
+        } catch (Exception e) {
+            log.warn("Playground 인기 게시글 조회 실패, 빈 리스트 반환", e);
+            return List.of();
+        }
     }
 }

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -169,7 +169,6 @@ public class HomeFacade {
         );
     }
 
-    @Transactional(readOnly = true)
     public List<PlaygroundRecentPost> getPlaygroundRecentPosts(Long userId) {
         List<OperationConfig> configList = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.PLAYGROUND_POST);
         Map<String, String> imageConfigMap = PlaygroundRecentPost.toImageConfigMap(configList);
@@ -191,7 +190,6 @@ public class HomeFacade {
             .toList();
     }
 
-    @Transactional(readOnly = true)
     public List<PlaygroundPopularPost> getPlaygroundPopularPosts(Long userId) {
         return playgroundAuthService.getPlaygroundPopularPosts();
     }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #728 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 홈 API에서 Playground 최근/인기 게시글 조회 시 외부 API 호출로 인해 DB 커넥션이 장시간 점유되던 구조를 개선했습니다.
- OperationConfigService에 @Transactional(readOnly = true)를 명시적으로 추가해 조회 트랜잭션 범위를 분리했습니다.
- HomeFacade#getPlaygroundRecentPosts, getPlaygroundPopularPosts의 @Transactional을 제거해 외부 API 호출 시 DB 커넥션을 점유하지 않도록 수정했습니다.
- Playground 최근/인기 게시글 조회 실패 시 빈 리스트를 반환하도록 처리해, 외부 API 장애가 홈 전체 장애로 이어지지 않도록 개선했습니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->