### PR TITLE
[Feat] #728: playground 조회 실패시 redis 캐싱 처리

### DIFF
--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -66,20 +66,10 @@ public class PlaygroundAuthService {
     }
 
     public List<PlaygroundRecentPost> getPlaygroundRecentPosts() {
-        try {
-            return playgroundClient.getPlaygroundRecentPosts();
-        } catch (Exception e) {
-            log.warn("Playground 최근 게시글 조회 실패, 빈 리스트 반환", e);
-            return List.of();
-        }
+        return playgroundClient.getPlaygroundRecentPosts();
     }
 
     public List<PlaygroundPopularPost> getPlaygroundPopularPosts() {
-        try {
-            return playgroundClient.getPlaygroundPopularPosts();
-        } catch (Exception e) {
-            log.warn("Playground 인기 게시글 조회 실패, 빈 리스트 반환", e);
-            return List.of();
-        }
+        return playgroundClient.getPlaygroundPopularPosts();
     }
 }

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPostCacheService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPostCacheService.java
@@ -1,0 +1,76 @@
+package org.sopt.app.application.playground;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlaygroundPostCacheService {
+
+    private static final String RECENT_POSTS_KEY = "playground:recent_posts";
+    private static final String POPULAR_POSTS_KEY = "playground:popular_posts";
+    private static final long CACHE_TTL_SECONDS = 3600L; // 1시간
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public Optional<List<PlaygroundRecentPost>> getCachedRecentPosts() {
+        try {
+            String cached = stringRedisTemplate.opsForValue().get(RECENT_POSTS_KEY);
+            if (cached == null) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(cached, new TypeReference<>() {}));
+        } catch (Exception e) {
+            log.warn("Redis 최근 게시글 캐시 조회 실패", e);
+            return Optional.empty();
+        }
+    }
+
+    public void cacheRecentPosts(List<PlaygroundRecentPost> posts) {
+        try {
+            stringRedisTemplate.opsForValue().set(
+                RECENT_POSTS_KEY,
+                objectMapper.writeValueAsString(posts),
+                CACHE_TTL_SECONDS, TimeUnit.SECONDS
+            );
+        } catch (Exception e) {
+            log.warn("Redis 최근 게시글 캐시 저장 실패", e);
+        }
+    }
+
+    public Optional<List<PlaygroundPopularPost>> getCachedPopularPosts() {
+        try {
+            String cached = stringRedisTemplate.opsForValue().get(POPULAR_POSTS_KEY);
+            if (cached == null) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(cached, new TypeReference<>() {}));
+        } catch (Exception e) {
+            log.warn("Redis 인기 게시글 캐시 조회 실패", e);
+            return Optional.empty();
+        }
+    }
+
+    public void cachePopularPosts(List<PlaygroundPopularPost> posts) {
+        try {
+            stringRedisTemplate.opsForValue().set(
+                POPULAR_POSTS_KEY,
+                objectMapper.writeValueAsString(posts),
+                CACHE_TTL_SECONDS, TimeUnit.SECONDS
+            );
+        } catch (Exception e) {
+            log.warn("Redis 인기 게시글 캐시 저장 실패", e);
+        }
+    }
+}

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.application.appservice.AppServiceBadgeService;
 import org.sopt.app.application.appservice.AppServiceName;
 import org.sopt.app.application.appservice.AppServiceService;
@@ -18,6 +19,7 @@ import org.sopt.app.application.meeting.MeetingService;
 import org.sopt.app.application.platform.PlatformService;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
 import org.sopt.app.application.playground.PlaygroundAuthService;
+import org.sopt.app.application.playground.PlaygroundPostCacheService;
 import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
 import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
 import org.sopt.app.application.soptamp.SoptampUserService;
@@ -32,12 +34,14 @@ import org.sopt.app.presentation.home.response.ReviewFormResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HomeFacade {
 
     private final DescriptionService descriptionService;
     private final PlaygroundAuthService playgroundAuthService;
+    private final PlaygroundPostCacheService playgroundPostCacheService;
     private final AppServiceService appServiceService;
     private final AppServiceBadgeService appServiceBadgeService;
     private final MeetingService meetingService;
@@ -173,24 +177,38 @@ public class HomeFacade {
         List<OperationConfig> configList = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.PLAYGROUND_POST);
         Map<String, String> imageConfigMap = PlaygroundRecentPost.toImageConfigMap(configList);
 
-        return playgroundAuthService.getPlaygroundRecentPosts().stream()
-            .map(post -> PlaygroundRecentPost.from(
-                post.playgroundPostId(),
-                post.userId(),
-                post.profileImage(),
-                post.name(),
-                post.generationAndPart(),
-                post.category(),
-                post.title(),
-                post.content(),
-                post.webLink(),
-                post.createdAt(),
-                imageConfigMap
-            ))
-            .toList();
+        try {
+            List<PlaygroundRecentPost> posts = playgroundAuthService.getPlaygroundRecentPosts().stream()
+                .map(post -> PlaygroundRecentPost.from(
+                    post.playgroundPostId(),
+                    post.userId(),
+                    post.profileImage(),
+                    post.name(),
+                    post.generationAndPart(),
+                    post.category(),
+                    post.title(),
+                    post.content(),
+                    post.webLink(),
+                    post.createdAt(),
+                    imageConfigMap
+                ))
+                .toList();
+            playgroundPostCacheService.cacheRecentPosts(posts);
+            return posts;
+        } catch (Exception e) {
+            log.warn("Playground 최근 게시글 조회 실패, 캐시 반환 시도", e);
+            return playgroundPostCacheService.getCachedRecentPosts().orElse(List.of());
+        }
     }
 
     public List<PlaygroundPopularPost> getPlaygroundPopularPosts(Long userId) {
-        return playgroundAuthService.getPlaygroundPopularPosts();
+        try {
+            List<PlaygroundPopularPost> posts = playgroundAuthService.getPlaygroundPopularPosts();
+            playgroundPostCacheService.cachePopularPosts(posts);
+            return posts;
+        } catch (Exception e) {
+            log.warn("Playground 인기 게시글 조회 실패, 캐시 반환 시도", e);
+            return playgroundPostCacheService.getCachedPopularPosts().orElse(List.of());
+        }
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #728

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- Playground 최근/인기 게시글 조회 실패 시 Redis 캐시 데이터를 활용하도록 개선했습니다.
- 기존에는 Playground API 호출 실패 시 빈 리스트(List.of())를 반환했지만, 이번 변경으로 마지막 정상 응답 데이터를 최대 1시간 동안 Redis에 저장 후 fallback 데이터로 사용하도록 수정했습니다.
- PlaygroundPostCacheService를 추가해 최근/인기 게시글 캐시 저장 및 조회 로직을 분리했습니다.
- Redis 조회/저장 로직은 모두 try-catch 처리하여 Redis 장애가 홈 API 전체 장애로 전파되지 않도록 구성했습니다.
- PlaygroundAuthService에서는 Feign 예외를 직접 처리하지 않고 상위(HomeFacade)로 전달하도록 변경했습니다.
- HomeFacade에서는
  - Playground API 호출 성공 시 → 응답 가공 후 Redis 캐시 저장
  - Playground API 호출 실패 시 → Redis 캐시 조회 후 반환
  - 캐시도 없을 경우 → 빈 리스트 반환 흐름으로 처리하도록 수정했습니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->