### PR TITLE
[Feat] #734: 인증/Playground 외부 API 의존성 분리

### DIFF
--- a/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
+++ b/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
@@ -21,12 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AppjamRankService {
 	private final StampRepository stampRepository;
 	private final AppjamUserRepository appjamUserRepository;
     private final SoptampUserRepository soptampUserRepository;
 
+	@Transactional(readOnly = true)
 	public AppjamRankInfo.RankAggregate findRecentTeamRanks(Pageable pageable) {
 
 		List<Stamp> latestStamps = stampRepository.findDisplayedLatestStamps(pageable);
@@ -64,6 +64,7 @@ public class AppjamRankService {
 		);
 	}
 
+	@Transactional(readOnly = true)
 	public List<StampRepositoryCustom.AppjamTodayRankSource> findTodayUserRankSources(
 		LocalDateTime todayStart,
 		LocalDateTime tomorrowStart
@@ -71,10 +72,12 @@ public class AppjamRankService {
 		return stampRepository.findTodayUserRankSources(todayStart, tomorrowStart);
 	}
 
+	@Transactional(readOnly = true)
 	public List<AppjamUser> findAllAppjamUsers() {
 		return appjamUserRepository.findAll();
 	}
 
+	@Transactional(readOnly = true)
 	public Map<Long, Long> findTotalPointsByUserIds(Collection<Long> userIds) {
 		if (userIds == null || userIds.isEmpty()) {
 			return Map.of();
@@ -88,6 +91,7 @@ public class AppjamRankService {
 			));
 	}
 
+	@Transactional(readOnly = true)
 	public Optional<AppjamUser> findAppjamUserByUserId(Long userId) {
 		return appjamUserRepository.findByUserId(userId);
 	}

--- a/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
+++ b/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
@@ -17,9 +17,11 @@ import org.sopt.app.interfaces.postgres.StampRepository;
 import org.sopt.app.interfaces.postgres.StampRepositoryCustom;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AppjamRankService {
 	private final StampRepository stampRepository;
 	private final AppjamUserRepository appjamUserRepository;

--- a/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
+++ b/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
@@ -64,7 +64,6 @@ public class AppjamRankService {
 		);
 	}
 
-	@Transactional(readOnly = true)
 	public List<StampRepositoryCustom.AppjamTodayRankSource> findTodayUserRankSources(
 		LocalDateTime todayStart,
 		LocalDateTime tomorrowStart
@@ -72,12 +71,10 @@ public class AppjamRankService {
 		return stampRepository.findTodayUserRankSources(todayStart, tomorrowStart);
 	}
 
-	@Transactional(readOnly = true)
 	public List<AppjamUser> findAllAppjamUsers() {
 		return appjamUserRepository.findAll();
 	}
 
-	@Transactional(readOnly = true)
 	public Map<Long, Long> findTotalPointsByUserIds(Collection<Long> userIds) {
 		if (userIds == null || userIds.isEmpty()) {
 			return Map.of();
@@ -91,7 +88,6 @@ public class AppjamRankService {
 			));
 	}
 
-	@Transactional(readOnly = true)
 	public Optional<AppjamUser> findAppjamUserByUserId(Long userId) {
 		return appjamUserRepository.findByUserId(userId);
 	}

--- a/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
+++ b/src/main/java/org/sopt/app/application/appjamrank/AppjamRankService.java
@@ -64,6 +64,7 @@ public class AppjamRankService {
 		);
 	}
 
+	// 단순 단일 조회 — @Transactional 생략
 	public List<StampRepositoryCustom.AppjamTodayRankSource> findTodayUserRankSources(
 		LocalDateTime todayStart,
 		LocalDateTime tomorrowStart
@@ -71,10 +72,12 @@ public class AppjamRankService {
 		return stampRepository.findTodayUserRankSources(todayStart, tomorrowStart);
 	}
 
+	// 단순 단일 조회 — @Transactional 생략
 	public List<AppjamUser> findAllAppjamUsers() {
 		return appjamUserRepository.findAll();
 	}
 
+	// 단순 단일 조회 — @Transactional 생략
 	public Map<Long, Long> findTotalPointsByUserIds(Collection<Long> userIds) {
 		if (userIds == null || userIds.isEmpty()) {
 			return Map.of();
@@ -88,6 +91,7 @@ public class AppjamRankService {
 			));
 	}
 
+	// 단순 단일 조회 — @Transactional 생략
 	public Optional<AppjamUser> findAppjamUserByUserId(Long userId) {
 		return appjamUserRepository.findByUserId(userId);
 	}

--- a/src/main/java/org/sopt/app/application/appjamuser/AppjamUserService.java
+++ b/src/main/java/org/sopt/app/application/appjamuser/AppjamUserService.java
@@ -9,6 +9,7 @@ import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.enums.TeamNumber;
 import org.sopt.app.interfaces.postgres.AppjamUserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,24 +17,28 @@ public class AppjamUserService {
 
     private final AppjamUserRepository appjamUserRepository;
 
+    @Transactional(readOnly = true)
     public AppjamUserStatus getAppjamUserStatus(Long userId) {
         return appjamUserRepository.findByUserId(userId)
             .map(AppjamUserStatus::appjamJoined)
             .orElseGet(AppjamUserStatus::appjamNotJoined);
     }
 
+    @Transactional(readOnly = true)
     public TeamSummary getTeamSummaryByTeamNumber(TeamNumber teamNumber) {
         val appjamUser = appjamUserRepository.findTopByTeamNumberOrderById(teamNumber)
             .orElseThrow(() -> new NotFoundException(ErrorCode.TEAM_NOT_FOUND));
         return TeamSummary.from(appjamUser);
     }
 
+    @Transactional(readOnly = true)
     public TeamSummary getTeamSummaryByUserId(Long userId) {
         return appjamUserRepository.findByUserId(userId)
             .map(TeamSummary::from)
             .orElseGet(TeamSummary::empty);
     }
 
+    @Transactional(readOnly = true)
     public boolean isAppjamParticipant(Long userId) {
         return appjamUserRepository.existsByUserId(userId);
     }

--- a/src/main/java/org/sopt/app/application/appservice/AppServiceService.java
+++ b/src/main/java/org/sopt/app/application/appservice/AppServiceService.java
@@ -7,6 +7,7 @@ import org.sopt.app.application.appservice.dto.AppServiceInfo;
 import org.sopt.app.domain.entity.AppService;
 import org.sopt.app.interfaces.postgres.AppServiceRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +15,7 @@ public class AppServiceService {
 
     private final AppServiceRepository appServiceRepository;
 
+    @Transactional(readOnly = true)
     public List<AppServiceInfo> getAllAppService() {
         return appServiceRepository.findAll().stream()
             .filter(appService -> {
@@ -29,6 +31,7 @@ public class AppServiceService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
     public AppServiceInfo getAppService(String serviceName) {
         return AppServiceInfo.of(appServiceRepository.findByServiceName(serviceName));
     }

--- a/src/main/java/org/sopt/app/application/fortune/FortuneService.java
+++ b/src/main/java/org/sopt/app/application/fortune/FortuneService.java
@@ -66,6 +66,7 @@ public class FortuneService {
         userFortuneRepository.deleteAllByUserIdInQuery(event.getUserId());
     }
 
+    @Transactional(readOnly = true)
     public boolean isExistTodayFortune(final Long userId) {
         return userFortuneRepository.findByUserId(userId)
                 .map(userFortune -> userFortune.getCheckedAt().equals(CurrentDate.now()))

--- a/src/main/java/org/sopt/app/application/friend/FriendService.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendService.java
@@ -186,7 +186,6 @@ public class FriendService {
         return friends.isEmpty();
     }
 
-    @Transactional(readOnly = true)
     public Set<Long> findAllFriendIdsByUserId(Long userId) {
         return friendRepository.findAllOfFriendIdsByUserId(userId);
     }

--- a/src/main/java/org/sopt/app/application/friend/FriendService.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendService.java
@@ -26,13 +26,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class FriendService {
 
     private final Random random = new Random();
     private final FriendRepository friendRepository;
     private final AnonymousNameGenerator anonymousNameGenerator;
 
+    @Transactional(readOnly = true)
     public List<Friend> findAllFriendsByFriendship(Long userId, Integer lowerLimit, Integer upperLimit) {
         HashMap<Long, Integer> map = getPokeCountMap(userId);
 
@@ -47,6 +47,7 @@ public class FriendService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public int findAllFriendSizeByFriendship(Long userId, Integer lowerLimit, Integer upperLimit) {
         HashMap<Long, Integer> map = getPokeCountMap(userId);
 
@@ -79,6 +80,7 @@ public class FriendService {
         return map;
     }
 
+    @Transactional(readOnly = true)
     public Page<Friend> findAllFriendsByFriendship(
             Long userId, Integer lowerLimit, Integer upperLimit, Pageable pageable
     ) {
@@ -111,12 +113,14 @@ public class FriendService {
         friendship.addPokeCount();
     }
 
+    @Transactional(readOnly = true)
     public boolean isFriendEachOther(Long pokerId, Long pokedId) {
         Optional<Friend> pokerToPokedRelation = friendRepository.findByUserIdAndFriendUserId(pokerId, pokedId);
         Optional<Friend> pokedToPokerRelation = friendRepository.findByUserIdAndFriendUserId(pokedId, pokerId);
         return pokerToPokedRelation.isPresent() && pokedToPokerRelation.isPresent();
     }
 
+    @Transactional(readOnly = true)
     public Relationship getRelationInfo(Long pokerId, Long pokedId) {
         Optional<Friend> friendshipFromPokerToPoked = friendRepository.findByUserIdAndFriendUserId(pokerId, pokedId);
         Optional<Friend> friendshipFromPokedToPoker = friendRepository.findByUserIdAndFriendUserId(pokedId, pokerId);
@@ -149,6 +153,7 @@ public class FriendService {
         return Friendship.NON_FRIEND.getFriendshipName();
     }
 
+    @Transactional(readOnly = true)
     public List<Long> getMutualFriendIds(Long pokerId, Long pokedId) {
         Set<Long> pokerFriendIds = friendRepository.findAllOfFriendIdsByUserId(pokerId);
         Set<Long> pokedFriendIds = friendRepository.findAllOfFriendIdsByUserId(pokedId);
@@ -157,6 +162,7 @@ public class FriendService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public Long getPokeFriendIdRandomly(Long userId) {
         val friendIdsPokeMe = friendRepository.findAllByFriendUserId(userId).stream()
                 .map(Friend::getUserId)
@@ -171,6 +177,7 @@ public class FriendService {
         return friends.get(random.nextInt(friends.size())).getFriendUserId();
     }
 
+    @Transactional(readOnly = true)
     public boolean getIsNewUser(Long userId) {
         val friendUserPokeMe = friendRepository.findAllByFriendUserId(userId).stream()
                 .map(Friend::getUserId)
@@ -179,10 +186,12 @@ public class FriendService {
         return friends.isEmpty();
     }
 
+    @Transactional(readOnly = true)
     public Set<Long> findAllFriendIdsByUserId(Long userId) {
         return friendRepository.findAllOfFriendIdsByUserId(userId);
     }
 
+    @Transactional(readOnly = true)
     public int sumPokeCountByFriendship(Long userId, Integer lowerLimit, Integer upperLimit) {
         HashMap<Long, Integer> map = getPokeCountMap(userId);
 

--- a/src/main/java/org/sopt/app/application/friend/FriendService.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendService.java
@@ -22,9 +22,11 @@ import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FriendService {
 
     private final Random random = new Random();
@@ -91,6 +93,7 @@ public class FriendService {
     }
 
 
+    @Transactional
     public void registerFriendshipOf(Long userId, Long friendId) {
         Friend createdRelationUserToFriend = Friend.builder()
                 .userId(userId)
@@ -101,6 +104,7 @@ public class FriendService {
         friendRepository.save(createdRelationUserToFriend);
     }
 
+    @Transactional
     public void applyPokeCount(Long pokerId, Long pokedId) {
         Friend friendship = friendRepository.findByUserIdAndFriendUserId(pokerId, pokedId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.FRIENDSHIP_NOT_FOUND));
@@ -188,6 +192,7 @@ public class FriendService {
             .sum();
     }
 
+    @Transactional
     @EventListener(UserWithdrawEvent.class)
     public void handleUserWithdrawEvent(final UserWithdrawEvent event) {
         friendRepository.deleteAllByFriendUserIdInQuery(event.getUserId());

--- a/src/main/java/org/sopt/app/application/friend/FriendService.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendService.java
@@ -186,6 +186,7 @@ public class FriendService {
         return friends.isEmpty();
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public Set<Long> findAllFriendIdsByUserId(Long userId) {
         return friendRepository.findAllOfFriendIdsByUserId(userId);
     }

--- a/src/main/java/org/sopt/app/application/mission/MissionService.java
+++ b/src/main/java/org/sopt/app/application/mission/MissionService.java
@@ -88,6 +88,7 @@ public class MissionService {
                 .getTitle();
     }
 
+    @Transactional(readOnly = true)
     public MissionInfo.Level getMissionLevelById(Long missionId) {
         val mission = missionRepository.findById(missionId).orElseThrow(
             () -> new NotFoundException(ErrorCode.MISSION_NOT_FOUND));
@@ -95,6 +96,7 @@ public class MissionService {
         return MissionInfo.Level.of(mission.getLevel());
     }
 
+    @Transactional(readOnly = true)
     public Mission getMissionById(Long missionId) {
         val mission = missionRepository.findById(missionId).orElseThrow(
             () -> new NotFoundException(ErrorCode.MISSION_NOT_FOUND)

--- a/src/main/java/org/sopt/app/application/platform/PlatformService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformService.java
@@ -129,8 +129,11 @@ public class PlatformService {
     }
 
     public List<Long> getMemberGenerationList(Long userId) {
-        return getPlatformUserInfoResponse(userId)
-                .soptActivities().stream()
+        return getMemberGenerationList(getPlatformUserInfoResponse(userId));
+    }
+
+    public List<Long> getMemberGenerationList(PlatformUserInfoResponse platformUserInfoResponse) {
+        return platformUserInfoResponse.soptActivities().stream()
                 .map(PlatformUserInfoResponse.SoptActivities::generation)
                 .map(Integer::longValue)
                 .distinct()

--- a/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PokeHistoryService {
 
     private final PokeHistoryRepository pokeHistoryRepository;
@@ -82,6 +83,7 @@ public class PokeHistoryService {
         pokeHistoryRepository.deleteAllByPokedIdInQuery(event.getUserId());
     }
 
+    @Transactional(readOnly = true)
     public Long getUnRepliedPokeMeSize(Long userId) {
         return pokeHistoryRepository.countByPokedIdAndIsReplyIsFalse(userId);
     }

--- a/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
@@ -21,7 +21,6 @@ public class PokeHistoryService {
 
     private final PokeHistoryRepository pokeHistoryRepository;
 
-    @Transactional(readOnly = true)
     public List<PokeHistoryInfo> getAllOfPokeBetween(Long userId, Long friendId) {
         val pokeHistoryList = pokeHistoryRepository.findAllWithFriendOrderByCreatedAtDescIsReplyFalse(userId, friendId);
 
@@ -30,14 +29,12 @@ public class PokeHistoryService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public Optional<PokeHistory> getRandomUnRepliedPokeMeHistory(Long userId) {
         return pokeHistoryRepository.findRandomUnRepliedPokeMeHistory(userId, PageRequest.of(0, 1))
             .stream()
             .findFirst();
     }
 
-    @Transactional(readOnly = true)
     public List<Long> getPokeMeUserIds(Long userId) {
         return pokeHistoryRepository.findAllByPokedId(userId).stream()
                 .map(PokeHistory::getPokerId)
@@ -45,12 +42,10 @@ public class PokeHistoryService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public List<PokeHistory> getAllLatestPokeHistoryFromTo(Long pokerId, Long pokedId) {
         return pokeHistoryRepository.findAllByPokerIdAndPokedIdOrderByCreatedAtDesc(pokerId, pokedId);
     }
 
-    @Transactional(readOnly = true)
     public Page<PokeHistory> getAllLatestPokeHistoryIn(List<Long> targetHistoryIds, Pageable pageable) {
         if (targetHistoryIds == null || targetHistoryIds.isEmpty()) {
             return Page.empty(pageable);
@@ -58,7 +53,6 @@ public class PokeHistoryService {
         return pokeHistoryRepository.findAllByIdIsInOrderByCreatedAtDesc(targetHistoryIds, pageable);
     }
 
-    @Transactional(readOnly = true)
     public void checkDuplicate(Long pokerUserId, Long pokedUserId) {
         val pokeHistory = pokeHistoryRepository.findAllByPokerIdAndPokedIdAndIsReplyIsFalse(pokerUserId, pokedUserId);
         if (!pokeHistory.isEmpty()) {
@@ -66,7 +60,6 @@ public class PokeHistoryService {
         }
     }
 
-    @Transactional(readOnly = true)
     public Map<Long, Boolean> getAllPokeHistoryMap(Long userId) {
         val pokeHistories = pokeHistoryRepository.findAllByPokerIdAndIsReply(userId, false);
         HashMap<Long, Boolean> pokeHistoryMap = new HashMap<>();
@@ -77,7 +70,6 @@ public class PokeHistoryService {
     }
 
     // isReply 여부에 관계 없이 전부 조회
-    @Transactional(readOnly = true)
     public List<PokeHistoryInfo> getAllPokeHistoryByUsers(Long userId, Long friendUserId) {
         val pokeHistories = pokeHistoryRepository.findAllPokeHistoryByUsers(userId, friendUserId);
         return pokeHistories.stream().map(PokeHistoryInfo::from).toList();
@@ -90,7 +82,6 @@ public class PokeHistoryService {
         pokeHistoryRepository.deleteAllByPokedIdInQuery(event.getUserId());
     }
 
-    @Transactional(readOnly = true)
     public Long getUnRepliedPokeMeSize(Long userId) {
         return pokeHistoryRepository.countByPokedIdAndIsReplyIsFalse(userId);
     }

--- a/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
@@ -21,6 +21,7 @@ public class PokeHistoryService {
 
     private final PokeHistoryRepository pokeHistoryRepository;
 
+    // 단순 단일 조회 — @Transactional 생략
     public List<PokeHistoryInfo> getAllOfPokeBetween(Long userId, Long friendId) {
         val pokeHistoryList = pokeHistoryRepository.findAllWithFriendOrderByCreatedAtDescIsReplyFalse(userId, friendId);
 
@@ -29,12 +30,14 @@ public class PokeHistoryService {
                 .toList();
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public Optional<PokeHistory> getRandomUnRepliedPokeMeHistory(Long userId) {
         return pokeHistoryRepository.findRandomUnRepliedPokeMeHistory(userId, PageRequest.of(0, 1))
             .stream()
             .findFirst();
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public List<Long> getPokeMeUserIds(Long userId) {
         return pokeHistoryRepository.findAllByPokedId(userId).stream()
                 .map(PokeHistory::getPokerId)
@@ -42,10 +45,12 @@ public class PokeHistoryService {
                 .toList();
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public List<PokeHistory> getAllLatestPokeHistoryFromTo(Long pokerId, Long pokedId) {
         return pokeHistoryRepository.findAllByPokerIdAndPokedIdOrderByCreatedAtDesc(pokerId, pokedId);
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public Page<PokeHistory> getAllLatestPokeHistoryIn(List<Long> targetHistoryIds, Pageable pageable) {
         if (targetHistoryIds == null || targetHistoryIds.isEmpty()) {
             return Page.empty(pageable);
@@ -53,6 +58,7 @@ public class PokeHistoryService {
         return pokeHistoryRepository.findAllByIdIsInOrderByCreatedAtDesc(targetHistoryIds, pageable);
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public void checkDuplicate(Long pokerUserId, Long pokedUserId) {
         val pokeHistory = pokeHistoryRepository.findAllByPokerIdAndPokedIdAndIsReplyIsFalse(pokerUserId, pokedUserId);
         if (!pokeHistory.isEmpty()) {
@@ -60,6 +66,7 @@ public class PokeHistoryService {
         }
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public Map<Long, Boolean> getAllPokeHistoryMap(Long userId) {
         val pokeHistories = pokeHistoryRepository.findAllByPokerIdAndIsReply(userId, false);
         HashMap<Long, Boolean> pokeHistoryMap = new HashMap<>();
@@ -69,7 +76,7 @@ public class PokeHistoryService {
         return pokeHistoryMap;
     }
 
-    // isReply 여부에 관계 없이 전부 조회
+    // isReply 여부에 관계 없이 전부 조회 — @Transactional 생략
     public List<PokeHistoryInfo> getAllPokeHistoryByUsers(Long userId, Long friendUserId) {
         val pokeHistories = pokeHistoryRepository.findAllPokeHistoryByUsers(userId, friendUserId);
         return pokeHistories.stream().map(PokeHistoryInfo::from).toList();
@@ -82,6 +89,7 @@ public class PokeHistoryService {
         pokeHistoryRepository.deleteAllByPokedIdInQuery(event.getUserId());
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public Long getUnRepliedPokeMeSize(Long userId) {
         return pokeHistoryRepository.countByPokedIdAndIsReplyIsFalse(userId);
     }

--- a/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeHistoryService.java
@@ -17,11 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class PokeHistoryService {
 
     private final PokeHistoryRepository pokeHistoryRepository;
 
+    @Transactional(readOnly = true)
     public List<PokeHistoryInfo> getAllOfPokeBetween(Long userId, Long friendId) {
         val pokeHistoryList = pokeHistoryRepository.findAllWithFriendOrderByCreatedAtDescIsReplyFalse(userId, friendId);
 
@@ -30,12 +30,14 @@ public class PokeHistoryService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public Optional<PokeHistory> getRandomUnRepliedPokeMeHistory(Long userId) {
         return pokeHistoryRepository.findRandomUnRepliedPokeMeHistory(userId, PageRequest.of(0, 1))
             .stream()
             .findFirst();
     }
 
+    @Transactional(readOnly = true)
     public List<Long> getPokeMeUserIds(Long userId) {
         return pokeHistoryRepository.findAllByPokedId(userId).stream()
                 .map(PokeHistory::getPokerId)
@@ -43,10 +45,12 @@ public class PokeHistoryService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<PokeHistory> getAllLatestPokeHistoryFromTo(Long pokerId, Long pokedId) {
         return pokeHistoryRepository.findAllByPokerIdAndPokedIdOrderByCreatedAtDesc(pokerId, pokedId);
     }
 
+    @Transactional(readOnly = true)
     public Page<PokeHistory> getAllLatestPokeHistoryIn(List<Long> targetHistoryIds, Pageable pageable) {
         if (targetHistoryIds == null || targetHistoryIds.isEmpty()) {
             return Page.empty(pageable);
@@ -54,6 +58,7 @@ public class PokeHistoryService {
         return pokeHistoryRepository.findAllByIdIsInOrderByCreatedAtDesc(targetHistoryIds, pageable);
     }
 
+    @Transactional(readOnly = true)
     public void checkDuplicate(Long pokerUserId, Long pokedUserId) {
         val pokeHistory = pokeHistoryRepository.findAllByPokerIdAndPokedIdAndIsReplyIsFalse(pokerUserId, pokedUserId);
         if (!pokeHistory.isEmpty()) {
@@ -61,6 +66,7 @@ public class PokeHistoryService {
         }
     }
 
+    @Transactional(readOnly = true)
     public Map<Long, Boolean> getAllPokeHistoryMap(Long userId) {
         val pokeHistories = pokeHistoryRepository.findAllByPokerIdAndIsReply(userId, false);
         HashMap<Long, Boolean> pokeHistoryMap = new HashMap<>();
@@ -71,6 +77,7 @@ public class PokeHistoryService {
     }
 
     // isReply 여부에 관계 없이 전부 조회
+    @Transactional(readOnly = true)
     public List<PokeHistoryInfo> getAllPokeHistoryByUsers(Long userId, Long friendUserId) {
         val pokeHistories = pokeHistoryRepository.findAllPokeHistoryByUsers(userId, friendUserId);
         return pokeHistories.stream().map(PokeHistoryInfo::from).toList();

--- a/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
@@ -8,9 +8,11 @@ import org.sopt.app.domain.entity.poke.PokeMessage;
 import org.sopt.app.domain.enums.PokeMessageType;
 import org.sopt.app.interfaces.postgres.PokeMessageRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PokeMessageService {
 
     private static final int MESSAGES_QUANTITY_AT_ONCE = 4;

--- a/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
@@ -8,7 +8,6 @@ import org.sopt.app.domain.entity.poke.PokeMessage;
 import org.sopt.app.domain.enums.PokeMessageType;
 import org.sopt.app.interfaces.postgres.PokeMessageRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +28,6 @@ public class PokeMessageService {
         return MESSAGES_HEADER_FOR_POKE;
     }
 
-    @Transactional(readOnly = true)
     public List<PokeMessage> pickRandomMessageByTypeOf(String type) {
         PokeMessageType messageType = PokeMessageType.ofParam(type);
         val messages = messageRepository.findAllByType(messageType);

--- a/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class PokeMessageService {
 
     private static final int MESSAGES_QUANTITY_AT_ONCE = 4;
@@ -30,6 +29,7 @@ public class PokeMessageService {
         return MESSAGES_HEADER_FOR_POKE;
     }
 
+    @Transactional(readOnly = true)
     public List<PokeMessage> pickRandomMessageByTypeOf(String type) {
         PokeMessageType messageType = PokeMessageType.ofParam(type);
         val messages = messageRepository.findAllByType(messageType);

--- a/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeMessageService.java
@@ -28,6 +28,7 @@ public class PokeMessageService {
         return MESSAGES_HEADER_FOR_POKE;
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public List<PokeMessage> pickRandomMessageByTypeOf(String type) {
         PokeMessageType messageType = PokeMessageType.ofParam(type);
         val messages = messageRepository.findAllByType(messageType);

--- a/src/main/java/org/sopt/app/application/poke/PokeService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeService.java
@@ -63,6 +63,7 @@ public class PokeService {
                 .build());
     }
 
+    @Transactional(readOnly = true)
     public Long getUserPokeCount(Long userId) {
         return historyRepository.countByPokerIdOrPokedId(userId, userId);
     }

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SoptampUserFinder {
 
     private final SoptampUserRepository soptampUserRepository;
@@ -51,7 +52,6 @@ public class SoptampUserFinder {
         return SoptampUserInfo.of(soptampUser);
     }
 
-    @Transactional(readOnly = true)
     public Map<Long, SoptampUserInfo> findUserInfosByIdsAsMap(List<Long> userIds) {
 
         return soptampUserRepository.findAllByUserIdIn(userIds).stream()

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
@@ -13,7 +13,6 @@ import org.sopt.app.domain.enums.Part;
 import org.sopt.app.interfaces.postgres.SoptampUserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +24,6 @@ public class SoptampUserFinder {
     @Value("${sopt.current.generation}")
     private Long currentGeneration;
 
-    @Transactional(readOnly = true)
     public List<SoptampUserInfo> findAllOfCurrentGeneration() {
         return soptampUserRepository.findAllByGeneration(currentGeneration)
                 .stream()
@@ -33,7 +31,6 @@ public class SoptampUserFinder {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public List<SoptampUserInfo> findAllByPartAndCurrentGeneration(Part part) {
         return soptampUserRepository.findAllByNicknameStartingWithAndGeneration(part.getPartName(), currentGeneration)
                 .stream()
@@ -41,21 +38,18 @@ public class SoptampUserFinder {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public SoptampUserInfo findByNickname(String nickname) {
         SoptampUser soptampUser = soptampUserRepository.findUserByNickname(nickname)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
         return SoptampUserInfo.of(soptampUser);
     }
 
-    @Transactional(readOnly = true)
     public SoptampUserInfo findById(Long userId) {
         SoptampUser soptampUser = soptampUserRepository.findByUserId(userId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
         return SoptampUserInfo.of(soptampUser);
     }
 
-    @Transactional(readOnly = true)
     public Map<Long, SoptampUserInfo> findUserInfosByIdsAsMap(List<Long> userIds) {
 
         return soptampUserRepository.findAllByUserIdIn(userIds).stream()

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
@@ -24,6 +24,7 @@ public class SoptampUserFinder {
     @Value("${sopt.current.generation}")
     private Long currentGeneration;
 
+    // 단순 단일 조회 — @Transactional 생략
     public List<SoptampUserInfo> findAllOfCurrentGeneration() {
         return soptampUserRepository.findAllByGeneration(currentGeneration)
                 .stream()
@@ -31,6 +32,7 @@ public class SoptampUserFinder {
                 .toList();
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public List<SoptampUserInfo> findAllByPartAndCurrentGeneration(Part part) {
         return soptampUserRepository.findAllByNicknameStartingWithAndGeneration(part.getPartName(), currentGeneration)
                 .stream()
@@ -38,18 +40,21 @@ public class SoptampUserFinder {
                 .toList();
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public SoptampUserInfo findByNickname(String nickname) {
         SoptampUser soptampUser = soptampUserRepository.findUserByNickname(nickname)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
         return SoptampUserInfo.of(soptampUser);
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public SoptampUserInfo findById(Long userId) {
         SoptampUser soptampUser = soptampUserRepository.findByUserId(userId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
         return SoptampUserInfo.of(soptampUser);
     }
 
+    // 단순 단일 조회 — @Transactional 생략
     public Map<Long, SoptampUserInfo> findUserInfosByIdsAsMap(List<Long> userIds) {
 
         return soptampUserRepository.findAllByUserIdIn(userIds).stream()

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserFinder.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class SoptampUserFinder {
 
     private final SoptampUserRepository soptampUserRepository;
@@ -26,6 +25,7 @@ public class SoptampUserFinder {
     @Value("${sopt.current.generation}")
     private Long currentGeneration;
 
+    @Transactional(readOnly = true)
     public List<SoptampUserInfo> findAllOfCurrentGeneration() {
         return soptampUserRepository.findAllByGeneration(currentGeneration)
                 .stream()
@@ -33,6 +33,7 @@ public class SoptampUserFinder {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<SoptampUserInfo> findAllByPartAndCurrentGeneration(Part part) {
         return soptampUserRepository.findAllByNicknameStartingWithAndGeneration(part.getPartName(), currentGeneration)
                 .stream()
@@ -40,18 +41,21 @@ public class SoptampUserFinder {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public SoptampUserInfo findByNickname(String nickname) {
         SoptampUser soptampUser = soptampUserRepository.findUserByNickname(nickname)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
         return SoptampUserInfo.of(soptampUser);
     }
 
+    @Transactional(readOnly = true)
     public SoptampUserInfo findById(Long userId) {
         SoptampUser soptampUser = soptampUserRepository.findByUserId(userId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
         return SoptampUserInfo.of(soptampUser);
     }
 
+    @Transactional(readOnly = true)
     public Map<Long, SoptampUserInfo> findUserInfosByIdsAsMap(List<Long> userIds) {
 
         return soptampUserRepository.findAllByUserIdIn(userIds).stream()

--- a/src/main/java/org/sopt/app/application/stamp/ClapService.java
+++ b/src/main/java/org/sopt/app/application/stamp/ClapService.java
@@ -81,10 +81,12 @@ public class ClapService {
 			.sum();
 	}
 
+    @Transactional(readOnly = true)
     public Optional<Clap> getClap(Long userId, Long stampId) {
         return clapRepository.findByUserIdAndStampId(userId, stampId);
     }
 
+    @Transactional(readOnly = true)
     public int getUserClapCount(Long userId, Long stampId) {
         Optional<Clap> clap = getClap(userId, stampId);
 

--- a/src/main/java/org/sopt/app/facade/AppjamRankFacade.java
+++ b/src/main/java/org/sopt/app/facade/AppjamRankFacade.java
@@ -18,7 +18,6 @@ import org.sopt.app.interfaces.postgres.StampRepositoryCustom;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +26,6 @@ public class AppjamRankFacade {
 	private final PlaygroundAuthService playgroundAuthService;
 	private final AppjamRankService appjamRankService;
 
-	@Transactional(readOnly = true)
 	public AppjamRankInfo.RankList findRecentTeamRanks(int size) {
 		Pageable pageable = PageRequest.of(0, size);
 
@@ -60,7 +58,6 @@ public class AppjamRankFacade {
 	 * 오늘 팀 랭킹 (캐시 없이 DB 기반)
 	 * - 전체 팀을 항상 보여주기 위해 effectiveSize는 teamCount 이상 보장
 	 */
-	@Transactional(readOnly = true)
 	public AppjamRankInfo.TodayTeamRankList findTodayTeamRanks(int size) {
 		LocalDateTime todayStart = CurrentDate.now().atStartOfDay();
 		LocalDateTime tomorrowStart = todayStart.plusDays(1);
@@ -99,7 +96,6 @@ public class AppjamRankFacade {
 		);
 	}
 
-	@Transactional(readOnly = true)
 	public Integer findMyTeamRank(final Long userId) {
 		AppjamUser myAppjamUser = appjamRankService.findAppjamUserByUserId(userId).orElse(null);
 		if (myAppjamUser == null || myAppjamUser.getTeamNumber() == null) {

--- a/src/main/java/org/sopt/app/facade/AppjamtampFacade.java
+++ b/src/main/java/org/sopt/app/facade/AppjamtampFacade.java
@@ -19,7 +19,6 @@ import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.presentation.appjamtamp.AppjamtampRequest.RegisterStampRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +33,6 @@ public class AppjamtampFacade {
     private final SoptampUserService soptampUserService;
     private final MissionService missionService;
 
-    @Transactional(readOnly = true)
     public AppjamtampView getAppjamtamps(Long requestUserId, Long missionId, String nickname) {
         val owner = soptampUserFinder.findByNickname(nickname);
         val ownerUserId = owner.getUserId();
@@ -56,7 +54,6 @@ public class AppjamtampFacade {
         );
     }
 
-    @Transactional
     public StampInfo.StampWithProfile uploadStamp(Long userId, RegisterStampRequest registerStampRequest) {
         val appjamUserStatus = appjamUserService.getAppjamUserStatus(userId);
         if (!appjamUserStatus.isAppjamJoined()) {

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -32,7 +32,6 @@ import org.sopt.app.presentation.home.response.FloatingButtonResponse;
 import org.sopt.app.presentation.home.response.HomeDescriptionResponse;
 import org.sopt.app.presentation.home.response.ReviewFormResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -58,16 +57,15 @@ public class HomeFacade {
 //        return descriptionService.getMainDescription(userActiveInfo.status());
 //    }
 
-    @Transactional(readOnly = true)
     public HomeDescriptionResponse getHomeMainDescription(Long userId) {
-        int duration = ActivityDurationCalculator.calculate(platformService.getMemberGenerationList(userId));
+        PlatformUserInfoResponse platformUserInfoResponse = platformService.getPlatformUserInfoResponse(userId);
+        int duration = ActivityDurationCalculator.calculate(platformService.getMemberGenerationList(platformUserInfoResponse));
         return HomeDescriptionResponse.of(
-                wrapWithTag(platformService.getPlatformUserInfoResponse(userId).name(), "b"),
+                wrapWithTag(platformUserInfoResponse.name(), "b"),
                 duration
         );
     }
 
-    @Transactional
     public List<AppServiceEntryStatusResponse> checkAppServiceEntryStatus(Long userId) {
         if(userId == null){
             return this.getOnlyAppServiceInfo();
@@ -125,7 +123,6 @@ public class HomeFacade {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public FloatingButtonResponse getFloatingButtonInfo(Long userId) {
         boolean isActive = false;
         if (userId != null) {
@@ -150,7 +147,6 @@ public class HomeFacade {
 
     }
 
-    @Transactional(readOnly = true)
     public ReviewFormResponse getReviewFormInfo(Long userId) {
         boolean isActive = false;
         if (userId != null) {

--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -40,7 +40,6 @@ public class PokeFacade {
     private final PokeMessageService pokeMessageService;
     private final PlatformService platformService;
 
-    @Transactional(readOnly = true)
     public List<PokeMessage> getPokingMessages(String type) {
         val messages = pokeMessageService.pickRandomMessageByTypeOf(type);
         val fixedMessage = pokeMessageService.getFixedMessage();
@@ -55,7 +54,6 @@ public class PokeFacade {
         return pokeMessageService.getMessagesHeaderComment(type);
     }
 
-    @Transactional(readOnly = true)
     public SimplePokeProfile getRandomUnRepliedPokeMeHistory(Long userId) {
         return pokeHistoryService.getRandomUnRepliedPokeMeHistory(userId)
             .map(pokeHistory -> getPokeHistoryProfile(
@@ -66,7 +64,6 @@ public class PokeFacade {
             .orElse(null);
     }
 
-    @Transactional(readOnly = true)
     public PokeToMeHistoryList getAllPokeMeHistory(Long userId, Pageable pageable) {
         List<Long> pokeMeUserIds = pokeHistoryService.getPokeMeUserIds(userId);
         List<Long> latestHistoryIds = pokeMeUserIds.stream()
@@ -121,7 +118,6 @@ public class PokeFacade {
         }
     }
 
-    @Transactional(readOnly = true)
     public List<SimplePokeProfile> getFriend(Long userId) {
         // 나와 친구인 사용자들 중 랜덤으로 1명 뽑기
         val friendId = friendService.getPokeFriendIdRandomly(userId);
@@ -150,7 +146,7 @@ public class PokeFacade {
                         platformUserInfoResponse.profileImage(),
                         platformUserInfoResponse.name(),
                         "",
-					    Long.valueOf(platformUserInfoResponse.lastGeneration()),
+                        Long.valueOf(platformUserInfoResponse.lastGeneration()),
                         soptActivities.part(),
                         friendRelationInfo.getPokeNum(),
                         friendRelationInfo.getRelationName(),
@@ -195,7 +191,6 @@ public class PokeFacade {
         }
     }
 
-    @Transactional(readOnly = true)
     public List<SimplePokeProfile> getTwoFriendByFriendship(Long userId, Friendship friendship) {
         val friendsOfFriendship = friendService.findAllFriendsByFriendship(
                 userId, friendship.getLowerLimit(), friendship.getUpperLimit());
@@ -214,13 +209,11 @@ public class PokeFacade {
             .toList();
     }
 
-    @Transactional(readOnly = true)
     public int getFriendSizeByFriendship(Long userId, Friendship friendship) {
         return friendService.findAllFriendsByFriendship(
                 userId, friendship.getLowerLimit(), friendship.getUpperLimit()).size();
     }
 
-    @Transactional(readOnly = true)
     public EachRelationFriendList getAllFriendByFriendship(Long userId, Friendship friendship, Pageable pageable) {
         val friends = friendService.findAllFriendsByFriendship(
                 userId, friendship.getLowerLimit(), friendship.getUpperLimit(), pageable);

--- a/src/main/java/org/sopt/app/facade/SoptampFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptampFacade.java
@@ -94,7 +94,6 @@ public class SoptampFacade {
                 stamp, requestUserClapCount, Objects.equals(requestUserId, soptampUserId), owner.getNickname());
     }
 
-    @Transactional(readOnly = true)
     public ClapResponse.ClapUsersPage getClapUsersPage(Long userId, Long stampId, Pageable pageable) {
         stampService.checkOwnedStamp(stampId, userId);
 

--- a/src/main/java/org/sopt/app/facade/UserFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserFacade.java
@@ -43,7 +43,6 @@ public class UserFacade {
     private final UserService userService;
     private final AppjamUserService appjamUserService;
 
-    @Transactional(readOnly = true)
     public MainView getMainViewInfo(Long userId) {
         if(userId == null) {
             return MainView.unauthenticatedMainView();
@@ -51,16 +50,15 @@ public class UserFacade {
         PlatformUserInfoResponse platformUserInfoResponse = platformService.getPlatformUserInfoResponse(userId);
         PlaygroundProfileInfo.MainViewUser mainViewUser = PlaygroundProfileInfo.MainViewUser.builder()
             .name(platformUserInfoResponse.name())
-            .status(platformService.getStatus(userId))
+            .status(platformService.getStatus(platformUserInfoResponse))
             .profileImage(platformUserInfoResponse.profileImage())
-            .generationList(platformService.getMemberGenerationList(userId).stream().toList())
+            .generationList(platformService.getMemberGenerationList(platformUserInfoResponse))
             .build();
 
         boolean mainViewNotification = notificationService.getNotificationConfirmStatus(userId);
         return userResponseMapper.ofMainView(PlaygroundProfileInfo.MainView.of(mainViewUser), Operation.defaultOperation(), mainViewNotification);
     }
 
-    @Transactional(readOnly = true)
     @Deprecated
     public List<AppService> getAppServiceInfo() {
         return appServiceService.getAllAppService().stream()
@@ -78,7 +76,6 @@ public class UserFacade {
         userService.deleteUser(userId);
     }
 
-    @Transactional(readOnly = true)
     public UserResponse.MySoptLog getMySoptLog(Long userId) {
         UserStatus userStatus = platformService.getStatus(userId);
         boolean isActive = (userStatus == UserStatus.ACTIVE);


### PR DESCRIPTION
## Related issue 🛠

- closes #734

## Work Description ✏️

`@Transactional` 컨텍스트 안에서 외부 API(PlatformService, PlaygroundAuthService)를 호출하면 DB 커넥션을 점유한 채 HTTP 응답을 대기하게 됩니다. 커넥션 풀이 부족한 상황(출석 피크 타임 등)에서 풀 고갈로 이어질 수 있어, 외부 API 호출과 트랜잭션 경계를 분리했습니다.

### 변경 내용

**1. Service 레이어 — `@Transactional` 메서드 레벨 적용**

Facade의 트랜잭션을 제거하면서 Service 메서드가 각자 트랜잭션을 갖도록 보완했습니다.
클래스 레벨 대신 메서드 레벨로 명시적으로 선언합니다.

- 메서드 레벨 `@Transactional(readOnly = true)` 추가: `FriendService`(10개), `PokeHistoryService`(8개), `PokeMessageService`(1개), `SoptampUserFinder`(5개), `AppjamRankService`(5개)
- 메서드 레벨 추가: `AppjamUserService`(4개), `MissionService`(2개), `ClapService`(2개), `FortuneService`, `PokeService`
- 쓰기 메서드: `FriendService.registerFriendshipOf()`, `applyPokeCount()`, `handleUserWithdrawEvent()` 등은 기존 `@Transactional` 유지

**2. PlatformService — 중복 외부 API 호출 제거**

동일 요청 내에서 `getPlatformUserInfoResponse()`를 여러 번 호출하던 곳을 이미 받아온 응답을 재사용하도록 오버로드 추가:
- `getMemberGenerationList(PlatformUserInfoResponse)` 오버로드 추가
- `HomeFacade.getHomeMainDescription()`: 2회 → 1회
- `UserFacade.getMainViewInfo()`: 3회 → 1회

**3. Facade 레이어 — `@Transactional` 제거**

외부 API 호출이 포함된 메서드에서 `@Transactional`을 제거하여 커넥션 점유 없이 외부 API를 호출하도록 변경했습니다.

| Facade | 제거된 메서드 | 비고 |
|---|---|---|
| `HomeFacade` | `getHomeMainDescription`, `checkAppServiceEntryStatus`, `getFloatingButtonInfo`, `getReviewFormInfo` | |
| `UserFacade` | `getMainViewInfo`, `getMySoptLog`, `getAppServiceInfo` | `createUser`, `deleteUser`는 유지 |
| `PokeFacade` | `getPokingMessages`, `getRandomUnRepliedPokeMeHistory`, `getAllPokeMeHistory`, `getFriend`, `getTwoFriendByFriendship`, `getFriendSizeByFriendship`, `getAllFriendByFriendship` | `pokeFriend`는 유지 |
| `AppjamtampFacade` | `getAppjamtamps`, `uploadStamp` | |
| `SoptampFacade` | `getClapUsersPage` | |
| `AppjamRankFacade` | `findRecentTeamRanks`, `findTodayTeamRanks`, `findMyTeamRank` | |

## To Reviewers 📢

- `@Transactional`이 없는 Facade 메서드는 각 Service 메서드가 메서드 레벨에서 자신의 트랜잭션을 직접 갖도록 수정하였습니다.
- 외부 API를 호출하지 않는 메서드(`pokeFriend`, `createUser` 등)는 기존대로 `@Transactional` 유지
- `RankFacade`의 `@Transactional(readOnly = true)`는 외부 API 없이 순수 DB 조회만 하므로 유지