### PR TITLE
[Fix] #737: ClapEventListener 외부 API 호출 문제 해결

### DIFF
--- a/src/main/java/org/sopt/app/application/stamp/ClapEventListener.java
+++ b/src/main/java/org/sopt/app/application/stamp/ClapEventListener.java
@@ -149,14 +149,14 @@ public class ClapEventListener {
 
         public OwnerInfo getOwnerInfo() {
             if(this.ownerInfo == null){
-                this.ownerInfo = fetchOwnerInfo(getEvent());
+                this.ownerInfo = loadOwnerInfo(getEvent());
             }
             return this.ownerInfo;
         }
 
         public MissionInfo getMissionInfo() {
             if(this.missionInfo == null){
-                this.missionInfo = fetchMissionInfo(getEvent());
+                this.missionInfo = loadMissionInfo(getEvent());
             }
             return this.missionInfo;
         }
@@ -194,7 +194,7 @@ public class ClapEventListener {
         }
 
 
-        private OwnerInfo fetchOwnerInfo(ClapEvent clapEvent) {
+        private OwnerInfo loadOwnerInfo(ClapEvent clapEvent) {
             val ownerProfile = platformService.getPlatformUserInfoResponse(clapEvent.getOwnerUserId());
             String ownerName = ownerProfile.name();
             String ownerPartName = Optional.ofNullable(ownerProfile.getLatestActivity())
@@ -206,7 +206,7 @@ public class ClapEventListener {
             return new OwnerInfo(ownerName, ownerPart, nickname);
         }
 
-        private MissionInfo fetchMissionInfo(ClapEvent clapEvent){
+        private MissionInfo loadMissionInfo(ClapEvent clapEvent){
             Long missionId = stampService.getMissionIdByStampId(clapEvent.getStampId());
             Mission mission = missionService.getMissionById(missionId);
 

--- a/src/main/java/org/sopt/app/application/stamp/ClapEventListener.java
+++ b/src/main/java/org/sopt/app/application/stamp/ClapEventListener.java
@@ -3,8 +3,6 @@ package org.sopt.app.application.stamp;
 import org.sopt.app.domain.entity.soptamp.Mission;
 import org.sopt.app.domain.enums.SoptPart;
 import org.sopt.app.interfaces.postgres.ClapMilestoneGuard;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +44,6 @@ public class ClapEventListener {
     private String baseURI;
 
     @Async
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onClap(ClapEvent event) {
         final int oldClapTotal = event.getOldClapTotal();
@@ -152,14 +149,14 @@ public class ClapEventListener {
 
         public OwnerInfo getOwnerInfo() {
             if(this.ownerInfo == null){
-                return fetchOwnerInfo(getEvent());
+                this.ownerInfo = fetchOwnerInfo(getEvent());
             }
             return this.ownerInfo;
         }
 
         public MissionInfo getMissionInfo() {
             if(this.missionInfo == null){
-                return fetchMissionInfo(getEvent());
+                this.missionInfo = fetchMissionInfo(getEvent());
             }
             return this.missionInfo;
         }


### PR DESCRIPTION
## Related issue 🛠

- closes #737

## Work Description ✏️

### 변경 내용

**1. `@Transactional(REQUIRES_NEW)` 제거**

`onClap`에 `@Transactional(REQUIRES_NEW)`가 선언되어 있어, 메서드 진입 시 DB 커넥션을 획득한 채 외부 API(`PlatformService`)를 호출하는 동안 커넥션을 점유하는 문제가 있었습니다.

**2. `AlarmData` 캐싱 버그 수정**

`getOwnerInfo()`, `getMissionInfo()`에서 fetch 결과를 필드에 저장하지 않아, 같은 `onClap` 실행 내에서 여러 getter를 호출할 때마다 외부 API / DB를 반복 조회하는 버그를 수정했습니다.

```java
// before — this.ownerInfo에 저장 안 해서 매번 재호출
if (this.ownerInfo == null) {
    return fetchOwnerInfo(getEvent());
}

// after
if (this.ownerInfo == null) {
    this.ownerInfo = fetchOwnerInfo(getEvent());
}
return this.ownerInfo;
```

---

## 고민한 부분 🤔

### `@Transactional(REQUIRES_NEW)` 제거의 트레이드오프

**제거 전 동작:**
```
REQUIRES_NEW 트랜잭션 시작
  ├─ tryMarkFirstHit() → 마일스톤 hit 표시 (REQUIRED로 외부 트랜잭션에 참여)
  └─ send() 실패 → 트랜잭션 롤백 → hit 표시도 함께 롤백
```

**제거 후 동작:**
```
tryMarkFirstHit() → 자체 트랜잭션으로 즉시 커밋
send() 실패 → hit는 이미 커밋 → 해당 마일스톤 알림 영구 미발송
```

다만 실질적인 영향은 제한적이라 판단했습니다.
- `@Async`라 예외가 호출부에 전파되지 않아 자동 재시도 메커니즘이 없음
- `crossed()` 특성상 이미 threshold를 넘은 상태에서 다음 이벤트가 재트리거하기 어려움
- 커넥션 풀 고갈 위험이 더 크고 실질적인 문제

혹시 어느 방향이 괜찮을까요? 고민이 됩니다 🤔

## To Reviewers 📢