### PR TITLE
[Perf] #739: 플레이그라운드 게시글 조회 캐싱 및 최적화

### DIFF
--- a/src/main/java/org/sopt/app/application/notification/NotificationService.java
+++ b/src/main/java/org/sopt/app/application/notification/NotificationService.java
@@ -87,11 +87,7 @@ public class NotificationService {
 
     @Transactional(readOnly = true)
     public boolean getNotificationConfirmStatus(Long userId) {
-        val notificationList = notificationRepository.findAllByUserId(userId);
-        val unreadNotificationList = notificationList.stream()
-                .filter(notification -> !notification.getIsRead())
-                .toList();
-        return unreadNotificationList.isEmpty();
+        return !notificationRepository.existsByUserIdAndIsReadFalse(userId);
     }
 
     @EventListener(UserWithdrawEvent.class)

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundAuthService.java
@@ -10,6 +10,7 @@ import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.OwnPlaygroundProfile;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
 import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPostDto;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
@@ -65,7 +66,7 @@ public class PlaygroundAuthService {
         return playgroundClient.getPlayGroundProfile(userId);
     }
 
-    public List<PlaygroundRecentPost> getPlaygroundRecentPosts() {
+    public List<PlaygroundRecentPostDto> getPlaygroundRecentPosts() {
         return playgroundClient.getPlaygroundRecentPosts();
     }
 

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundClient.java
@@ -8,7 +8,7 @@ import org.sopt.app.application.playground.dto.PlayGroundUserSoptLevelResponse;
 import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.OwnPlaygroundProfile;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.PlaygroundProfile;
-import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPostDto;
 import org.sopt.app.application.playground.dto.PlaygroundUserFindCondition;
 import org.sopt.app.application.playground.dto.RecommendedFriendInfo.PlaygroundUserIds;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -48,7 +48,7 @@ public interface PlaygroundClient {
 
     // headermap 제외
     @RequestLine("GET /internal/api/v1/community/posts/latest")
-    List<PlaygroundRecentPost> getPlaygroundRecentPosts();
+    List<PlaygroundRecentPostDto> getPlaygroundRecentPosts();
 
     // headermap 제외
     @RequestLine("GET /internal/api/v1/community/posts/popular")

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPopularPostRefreshEvent.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPopularPostRefreshEvent.java
@@ -1,0 +1,6 @@
+package org.sopt.app.application.playground;
+
+import org.sopt.app.common.event.Event;
+
+public class PlaygroundPopularPostRefreshEvent extends Event {
+}

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPostCacheService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPostCacheService.java
@@ -19,7 +19,7 @@ public class PlaygroundPostCacheService {
 
     private static final String RECENT_POSTS_KEY = "playground:recent_posts";
     private static final String POPULAR_POSTS_KEY = "playground:popular_posts";
-    private static final long CACHE_TTL_SECONDS = 3600L; // 1시간
+    private static final long CACHE_TTL_SECONDS = 3600L * 24; // 24시간
 
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPostEventListener.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPostEventListener.java
@@ -1,0 +1,26 @@
+package org.sopt.app.application.playground;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.common.config.AsyncConfig;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlaygroundPostEventListener {
+
+    private final PlaygroundPostRefreshService playgroundPostRefreshService;
+
+    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
+    @EventListener(PlaygroundRecentPostRefreshEvent.class)
+    public void handleRecentPostRefreshEvent(PlaygroundRecentPostRefreshEvent event) {
+        playgroundPostRefreshService.refreshRecentPosts();
+    }
+
+    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
+    @EventListener(PlaygroundPopularPostRefreshEvent.class)
+    public void handlePopularPostRefreshEvent(PlaygroundPopularPostRefreshEvent event) {
+        playgroundPostRefreshService.refreshPopularPosts();
+    }
+}

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPostRefreshService.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPostRefreshService.java
@@ -1,0 +1,68 @@
+package org.sopt.app.application.playground;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.application.appservice.OperationConfigService;
+import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
+import org.sopt.app.common.config.OperationConfig;
+import org.sopt.app.common.config.OperationConfigCategory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlaygroundPostRefreshService {
+
+    private static final String LOCKED_STATUS = "LOCKED";
+    private static final int RECENT_LOCK_MINUTE = 5;
+    private static final int POPULAR_LOCK_MINUTE = 5;
+    private static final String RECENT_LOCK_KEY = "playground:recent_posts_refresh_lock";
+    private static final String POPULAR_LOCK_KEY = "playground:popular_posts_refresh_lock";
+
+    private final PlaygroundAuthService playgroundAuthService;
+    private final PlaygroundPostCacheService playgroundPostCacheService;
+    private final OperationConfigService operationConfigService;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void refreshRecentPosts() {
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(RECENT_LOCK_KEY, LOCKED_STATUS, Duration.ofMinutes(RECENT_LOCK_MINUTE));
+        if (!Boolean.TRUE.equals(acquired)) {
+            log.error("Playground 최신 게시글 캐시 갱신 락 획득 실패");
+            return;
+        }
+
+        try {
+            List<OperationConfig> configList = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.PLAYGROUND_POST);
+            Map<String, String> imageConfigMap = PlaygroundRecentPost.toImageConfigMap(configList);
+
+            List<PlaygroundRecentPost> posts = playgroundAuthService.getPlaygroundRecentPosts().stream()
+                .map(post -> PlaygroundRecentPost.of(post, imageConfigMap))
+                .toList();
+            playgroundPostCacheService.cacheRecentPosts(posts);
+            log.info("Playground 최신 게시글 캐시 갱신 완료");
+        } catch (Exception e) {
+            log.error("Playground 최신 게시글 캐시 갱신 중 오류 발생", e);
+        }
+    }
+
+    public void refreshPopularPosts() {
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(POPULAR_LOCK_KEY, LOCKED_STATUS, Duration.ofMinutes(POPULAR_LOCK_MINUTE));
+        if (!Boolean.TRUE.equals(acquired)) {
+            log.error("Playground 인기 게시글 캐시 갱신 락 획득 실패");
+            return;
+        }
+
+        try {
+            List<PlaygroundPopularPost> posts = playgroundAuthService.getPlaygroundPopularPosts();
+            playgroundPostCacheService.cachePopularPosts(posts);
+            log.info("Playground 인기 게시글 캐시 갱신 완료");
+        } catch (Exception e) {
+            log.error("Playground 인기 게시글 캐시 갱신 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPostScheduler.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPostScheduler.java
@@ -1,19 +1,7 @@
 package org.sopt.app.application.playground;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.app.application.appservice.OperationConfigService;
-import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
-import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
-import org.sopt.app.common.config.AsyncConfig;
-import org.sopt.app.common.config.OperationConfig;
-import org.sopt.app.common.config.OperationConfigCategory;
-import org.springframework.context.event.EventListener;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -22,70 +10,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PlaygroundPostScheduler {
 
-    private static final String LOCKED_STATUS = "LOCKED";
-    private static final int RECENT_LOCK_MINUTE = 5;
-    private static final int POPULAR_LOCK_MINUTE = 5;
-    private static final String RECENT_LOCK_KEY = "playground:recent_posts_refresh_lock";
-    private static final String POPULAR_LOCK_KEY = "playground:popular_posts_refresh_lock";
-    private final PlaygroundAuthService playgroundAuthService;
-    private final PlaygroundPostCacheService playgroundPostCacheService;
-    private final OperationConfigService operationConfigService;
-    private final StringRedisTemplate stringRedisTemplate;
+    private final PlaygroundPostRefreshService playgroundPostRefreshService;
 
     @Scheduled(cron = "0 0 * * * *")
     public void refreshPlaygroundPosts() {
         log.info("Playground 게시글 캐시 갱신 시작");
-        refreshRecentPosts();
-        refreshPopularPosts();
-        log.info("Playground 게시글 캐시 갱신 완료");
-    }
-
-    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
-    @EventListener(PlaygroundRecentPostRefreshEvent.class)
-    public void handleRecentPostRefreshEvent(PlaygroundRecentPostRefreshEvent event) {
-        refreshRecentPosts();
-    }
-
-    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
-    @EventListener(PlaygroundPopularPostRefreshEvent.class)
-    public void handlePopularPostRefreshEvent(PlaygroundPopularPostRefreshEvent event) {
-        refreshPopularPosts();
-    }
-
-    private void refreshRecentPosts() {
-        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(RECENT_LOCK_KEY, LOCKED_STATUS, Duration.ofMinutes(RECENT_LOCK_MINUTE));
-        if (!Boolean.TRUE.equals(acquired)) {
-            log.error("Playground 최신 게시글 캐시 갱신 락 획득 실패");
-            return;
-        }
-
-        try {
-            List<OperationConfig> configList = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.PLAYGROUND_POST);
-            Map<String, String> imageConfigMap = PlaygroundRecentPost.toImageConfigMap(configList);
-
-            List<PlaygroundRecentPost> posts = playgroundAuthService.getPlaygroundRecentPosts().stream()
-                .map(post -> PlaygroundRecentPost.of(post, imageConfigMap))
-                .toList();
-            playgroundPostCacheService.cacheRecentPosts(posts);
-            log.info("Playground 최신 게시글 캐시 갱신 완료");
-        } catch (Exception e) {
-            log.error("Playground 최신 게시글 캐시 갱신 중 오류 발생", e);
-        }
-    }
-
-    private void refreshPopularPosts() {
-        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(POPULAR_LOCK_KEY, LOCKED_STATUS, Duration.ofMinutes(POPULAR_LOCK_MINUTE));
-        if (!Boolean.TRUE.equals(acquired)) {
-            log.error("Playground 인기 게시글 캐시 갱신 락 획득 실패");
-            return;
-        }
-
-        try {
-            List<PlaygroundPopularPost> posts = playgroundAuthService.getPlaygroundPopularPosts();
-            playgroundPostCacheService.cachePopularPosts(posts);
-            log.info("Playground 인기 게시글 캐시 갱신 완료");
-        } catch (Exception e) {
-            log.error("Playground 인기 게시글 캐시 갱신 중 오류 발생", e);
-        }
+        playgroundPostRefreshService.refreshRecentPosts();
+        playgroundPostRefreshService.refreshPopularPosts();
     }
 }

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPostScheduler.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPostScheduler.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.application.appservice.OperationConfigService;
 import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
 import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
-import org.sopt.app.application.playground.dto.PlaygroundRecentPostDto;
 import org.sopt.app.common.config.AsyncConfig;
 import org.sopt.app.common.config.OperationConfig;
 import org.sopt.app.common.config.OperationConfigCategory;
@@ -23,6 +22,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PlaygroundPostScheduler {
 
+    private static final String LOCKED_STATUS = "LOCKED";
+    private static final int RECENT_LOCK_MINUTE = 5;
+    private static final int POPULAR_LOCK_MINUTE = 5;
     private static final String RECENT_LOCK_KEY = "playground:recent_posts_refresh_lock";
     private static final String POPULAR_LOCK_KEY = "playground:popular_posts_refresh_lock";
     private final PlaygroundAuthService playgroundAuthService;
@@ -51,9 +53,9 @@ public class PlaygroundPostScheduler {
     }
 
     private void refreshRecentPosts() {
-        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(RECENT_LOCK_KEY, "locked", Duration.ofMinutes(5));
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(RECENT_LOCK_KEY, LOCKED_STATUS, Duration.ofMinutes(RECENT_LOCK_MINUTE));
         if (!Boolean.TRUE.equals(acquired)) {
-            log.debug("Playground 최신 게시글 캐시 갱신 락 획득 실패");
+            log.error("Playground 최신 게시글 캐시 갱신 락 획득 실패");
             return;
         }
 
@@ -72,9 +74,9 @@ public class PlaygroundPostScheduler {
     }
 
     private void refreshPopularPosts() {
-        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(POPULAR_LOCK_KEY, "locked", Duration.ofMinutes(5));
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(POPULAR_LOCK_KEY, LOCKED_STATUS, Duration.ofMinutes(POPULAR_LOCK_MINUTE));
         if (!Boolean.TRUE.equals(acquired)) {
-            log.debug("Playground 인기 게시글 캐시 갱신 락 획득 실패");
+            log.error("Playground 인기 게시글 캐시 갱신 락 획득 실패");
             return;
         }
 

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundPostScheduler.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundPostScheduler.java
@@ -1,0 +1,89 @@
+package org.sopt.app.application.playground;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.application.appservice.OperationConfigService;
+import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPostDto;
+import org.sopt.app.common.config.AsyncConfig;
+import org.sopt.app.common.config.OperationConfig;
+import org.sopt.app.common.config.OperationConfigCategory;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlaygroundPostScheduler {
+
+    private static final String RECENT_LOCK_KEY = "playground:recent_posts_refresh_lock";
+    private static final String POPULAR_LOCK_KEY = "playground:popular_posts_refresh_lock";
+    private final PlaygroundAuthService playgroundAuthService;
+    private final PlaygroundPostCacheService playgroundPostCacheService;
+    private final OperationConfigService operationConfigService;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void refreshPlaygroundPosts() {
+        log.info("Playground 게시글 캐시 갱신 시작");
+        refreshRecentPosts();
+        refreshPopularPosts();
+        log.info("Playground 게시글 캐시 갱신 완료");
+    }
+
+    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
+    @EventListener(PlaygroundRecentPostRefreshEvent.class)
+    public void handleRecentPostRefreshEvent(PlaygroundRecentPostRefreshEvent event) {
+        refreshRecentPosts();
+    }
+
+    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
+    @EventListener(PlaygroundPopularPostRefreshEvent.class)
+    public void handlePopularPostRefreshEvent(PlaygroundPopularPostRefreshEvent event) {
+        refreshPopularPosts();
+    }
+
+    private void refreshRecentPosts() {
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(RECENT_LOCK_KEY, "locked", Duration.ofMinutes(5));
+        if (!Boolean.TRUE.equals(acquired)) {
+            log.debug("Playground 최신 게시글 캐시 갱신 락 획득 실패");
+            return;
+        }
+
+        try {
+            List<OperationConfig> configList = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.PLAYGROUND_POST);
+            Map<String, String> imageConfigMap = PlaygroundRecentPost.toImageConfigMap(configList);
+
+            List<PlaygroundRecentPost> posts = playgroundAuthService.getPlaygroundRecentPosts().stream()
+                .map(post -> PlaygroundRecentPost.of(post, imageConfigMap))
+                .toList();
+            playgroundPostCacheService.cacheRecentPosts(posts);
+            log.info("Playground 최신 게시글 캐시 갱신 완료");
+        } catch (Exception e) {
+            log.error("Playground 최신 게시글 캐시 갱신 중 오류 발생", e);
+        }
+    }
+
+    private void refreshPopularPosts() {
+        Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(POPULAR_LOCK_KEY, "locked", Duration.ofMinutes(5));
+        if (!Boolean.TRUE.equals(acquired)) {
+            log.debug("Playground 인기 게시글 캐시 갱신 락 획득 실패");
+            return;
+        }
+
+        try {
+            List<PlaygroundPopularPost> posts = playgroundAuthService.getPlaygroundPopularPosts();
+            playgroundPostCacheService.cachePopularPosts(posts);
+            log.info("Playground 인기 게시글 캐시 갱신 완료");
+        } catch (Exception e) {
+            log.error("Playground 인기 게시글 캐시 갱신 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/org/sopt/app/application/playground/PlaygroundRecentPostRefreshEvent.java
+++ b/src/main/java/org/sopt/app/application/playground/PlaygroundRecentPostRefreshEvent.java
@@ -1,0 +1,6 @@
+package org.sopt.app.application.playground;
+
+import org.sopt.app.common.event.Event;
+
+public class PlaygroundRecentPostRefreshEvent extends Event {
+}

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPost.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPost.java
@@ -1,18 +1,15 @@
 package org.sopt.app.application.playground.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
-
 import org.sopt.app.common.config.OperationConfig;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record PlaygroundRecentPost(
 	@JsonProperty("id") Long playgroundPostId,
@@ -36,34 +33,44 @@ public record PlaygroundRecentPost(
 		"솝티클", "에 직무 인사이트 써봐!"
 	);
 
-	public static PlaygroundRecentPost from(
-		Long postId, Long userId, String profileImage, String name, String generationAndPart,
-		String category, String title, String content, String webLink, String createdAt,
-		Map<String, String> imageConfigMap
-	) {
-		boolean isOutdated = isOutdated(createdAt);
+    public static PlaygroundRecentPost of(
+        PlaygroundRecentPostDto response,
+        Map<String, String> imageConfigMap
+    ) {
+        boolean isOutdated = isOutdated(response.createdAt());
 
-		if (isOutdated) {
-			String defaultMessage = CATEGORY_MESSAGES.getOrDefault(category, "플레이그라운드에 새 글 올려봐!");
-			String image = imageConfigMap.getOrDefault(category + ".imageUrl", imageConfigMap.get("unknown.imageUrl"));
-			return new PlaygroundRecentPost(
-				null,
-				null,
-				image,
-				null,
-				null,
-				category,
-				"아직 최신글이 없어요",
-				defaultMessage,
-				trimWebLink(webLink),
-				createdAt,
-				true
-			);
-		}
+        if (isOutdated) {
+            String defaultMessage = CATEGORY_MESSAGES.getOrDefault(response.category(), "플레이그라운드에 새 글 올려봐!");
+            String image = imageConfigMap.getOrDefault(response.category() + ".imageUrl", imageConfigMap.get("unknown.imageUrl"));
+            return new PlaygroundRecentPost(
+                null,
+                null,
+                image,
+                null,
+                null,
+                response.category(),
+                "아직 최신글이 없어요",
+                defaultMessage,
+                trimWebLink(response.webLink()),
+                response.createdAt(),
+                true
+            );
+        }
 
-		return new PlaygroundRecentPost(
-			postId, userId, profileImage, name, generationAndPart, category, title, content, webLink, createdAt, false);
-	}
+        return new PlaygroundRecentPost(
+            response.id(),
+            response.userId(),
+            response.profileImage(),
+            response.name(),
+            response.generationAndPart(),
+            response.category(),
+            response.title(),
+            response.content(),
+            response.webLink(),
+            response.createdAt(),
+            false
+        );
+    }
 
 	private static boolean isOutdated(String createdAt) {
 		try {

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPostDto.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundRecentPostDto.java
@@ -1,0 +1,18 @@
+package org.sopt.app.application.playground.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
+
+public record PlaygroundRecentPostDto(
+    @JsonProperty("id") Long id,
+    @Nullable Long userId,
+    String profileImage,
+    String name,
+    String generationAndPart,
+    String category,
+    String title,
+    String content,
+    String webLink,
+    String createdAt
+) {
+}

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -4,6 +4,7 @@ import static org.sopt.app.common.utils.HtmlTagWrapper.wrapWithTag;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,13 +19,15 @@ import org.sopt.app.application.meeting.MeetingResponse;
 import org.sopt.app.application.meeting.MeetingService;
 import org.sopt.app.application.platform.PlatformService;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
-import org.sopt.app.application.playground.PlaygroundAuthService;
 import org.sopt.app.application.playground.PlaygroundPostCacheService;
+import org.sopt.app.application.playground.PlaygroundPopularPostRefreshEvent;
+import org.sopt.app.application.playground.PlaygroundRecentPostRefreshEvent;
 import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
 import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
 import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.common.config.OperationConfig;
 import org.sopt.app.common.config.OperationConfigCategory;
+import org.sopt.app.common.event.EventPublisher;
 import org.sopt.app.common.utils.ActivityDurationCalculator;
 import org.sopt.app.domain.enums.UserStatus;
 import org.sopt.app.presentation.home.MeetingParamRequest;
@@ -39,7 +42,6 @@ import org.springframework.stereotype.Service;
 public class HomeFacade {
 
     private final DescriptionService descriptionService;
-    private final PlaygroundAuthService playgroundAuthService;
     private final PlaygroundPostCacheService playgroundPostCacheService;
     private final AppServiceService appServiceService;
     private final AppServiceBadgeService appServiceBadgeService;
@@ -47,6 +49,7 @@ public class HomeFacade {
     private final OperationConfigService operationConfigService;
     private final PlatformService platformService;
     private final SoptampUserService soptampUserService;
+    private final EventPublisher eventPublisher;
 
     // TODO : deprecated 된것으로 인지
 //    @Transactional(readOnly = true)
@@ -170,41 +173,22 @@ public class HomeFacade {
     }
 
     public List<PlaygroundRecentPost> getPlaygroundRecentPosts(Long userId) {
-        List<OperationConfig> configList = operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.PLAYGROUND_POST);
-        Map<String, String> imageConfigMap = PlaygroundRecentPost.toImageConfigMap(configList);
-
-        try {
-            List<PlaygroundRecentPost> posts = playgroundAuthService.getPlaygroundRecentPosts().stream()
-                .map(post -> PlaygroundRecentPost.from(
-                    post.playgroundPostId(),
-                    post.userId(),
-                    post.profileImage(),
-                    post.name(),
-                    post.generationAndPart(),
-                    post.category(),
-                    post.title(),
-                    post.content(),
-                    post.webLink(),
-                    post.createdAt(),
-                    imageConfigMap
-                ))
-                .toList();
-            playgroundPostCacheService.cacheRecentPosts(posts);
-            return posts;
-        } catch (Exception e) {
-            log.warn("Playground 최근 게시글 조회 실패, 캐시 반환 시도", e);
-            return playgroundPostCacheService.getCachedRecentPosts().orElse(List.of());
+        Optional<List<PlaygroundRecentPost>> cachedPosts = playgroundPostCacheService.getCachedRecentPosts();
+        if (cachedPosts.isPresent()) {
+            return cachedPosts.get();
         }
+
+        eventPublisher.raise(new PlaygroundRecentPostRefreshEvent());
+        return List.of();
     }
 
     public List<PlaygroundPopularPost> getPlaygroundPopularPosts(Long userId) {
-        try {
-            List<PlaygroundPopularPost> posts = playgroundAuthService.getPlaygroundPopularPosts();
-            playgroundPostCacheService.cachePopularPosts(posts);
-            return posts;
-        } catch (Exception e) {
-            log.warn("Playground 인기 게시글 조회 실패, 캐시 반환 시도", e);
-            return playgroundPostCacheService.getCachedPopularPosts().orElse(List.of());
+        Optional<List<PlaygroundPopularPost>> cachedPosts = playgroundPostCacheService.getCachedPopularPosts();
+        if (cachedPosts.isPresent()) {
+            return cachedPosts.get();
         }
+
+        eventPublisher.raise(new PlaygroundPopularPostRefreshEvent());
+        return List.of();
     }
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/NotificationRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/NotificationRepository.java
@@ -17,6 +17,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findAllByUserIdAndCategory(Long userId, Pageable pageable, NotificationCategory category);
 
+    boolean existsByUserIdAndIsReadFalse(Long userId);
+
     Optional<Notification> findByNotificationIdAndUserId(String notificationId, Long userId);
 
     @Query("DELETE FROM Notification n WHERE n.userId = :userId")

--- a/src/test/java/org/sopt/app/facade/HomeFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/HomeFacadeTest.java
@@ -1,65 +1,122 @@
-// package org.sopt.app.facade;
-//
-// import static org.mockito.ArgumentMatchers.anyLong;
-// import static org.mockito.ArgumentMatchers.anyString;
-//
-// import org.junit.jupiter.api.Assertions;
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.extension.ExtendWith;
-// import org.mockito.InjectMocks;
-// import org.mockito.Mock;
-// import org.mockito.Mockito;
-// import org.mockito.junit.jupiter.MockitoExtension;
-// import org.sopt.app.application.playground.dto.PlaygroundProfileInfo.UserActiveInfo;
-// import org.sopt.app.application.playground.PlaygroundAuthService;
-// import org.sopt.app.application.description.DescriptionInfo;
-// import org.sopt.app.application.description.DescriptionInfo.MainDescription;
-// import org.sopt.app.application.description.DescriptionService;
-// import org.sopt.app.domain.entity.User;
-// import org.sopt.app.domain.enums.UserStatus;
-//
-// @ExtendWith(MockitoExtension.class)
-// class HomeFacadeTest {
-//
-//     @Mock
-//     private DescriptionService descriptionService;
-//
-//     @Mock
-//     private PlaygroundAuthService playgroundAuthService;
-//
-//     @InjectMocks
-//     private HomeFacade homeFacade;
-//
-//     @Test
-//     @DisplayName("SUCCESS_활동 유저 메인 문구 조회")
-//     void SUCCESS_getMainDescriptionForUserActive() {
-//         User user = User.builder().playgroundId(1L).playgroundToken("token").build();
-//         UserStatus userStatus = UserStatus.ACTIVE;
-//         Mockito.when(playgroundAuthService.getPlaygroundUserActiveInfo(anyString(), anyLong()))
-//                 .thenReturn(new UserActiveInfo(34L, userStatus));
-//         Mockito.when(descriptionService.getMainDescription(userStatus))
-//                 .thenReturn(DescriptionInfo.MainDescription.builder().topDescription("activeTop")
-//                         .bottomDescription("activeBottom").build());
-//
-//         MainDescription result = homeFacade.getMainDescriptionForUser(user);
-//         Assertions.assertEquals("activeTop", result.getTopDescription());
-//         Assertions.assertEquals("activeBottom", result.getBottomDescription());
-//     }
-//
-//     @Test
-//     @DisplayName("SUCCESS_비활동 유저 메인 문구 조회")
-//     void SUCCESS_getMainDescriptionForUserInactive() {
-//         User user = User.builder().playgroundId(1L).playgroundToken("token").build();
-//         UserStatus userStatus = UserStatus.INACTIVE;
-//         Mockito.when(playgroundAuthService.getPlaygroundUserActiveInfo(anyString(), anyLong()))
-//                 .thenReturn(new UserActiveInfo(29L, userStatus));
-//         Mockito.when(descriptionService.getMainDescription(userStatus))
-//                 .thenReturn(DescriptionInfo.MainDescription.builder().topDescription("inactiveTop")
-//                         .bottomDescription("inactiveBottom").build());
-//
-//         MainDescription result = homeFacade.getMainDescriptionForUser(user);
-//         Assertions.assertEquals("inactiveTop", result.getTopDescription());
-//         Assertions.assertEquals("inactiveBottom", result.getBottomDescription());
-//     }
-// }
+package org.sopt.app.facade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.appservice.AppServiceBadgeService;
+import org.sopt.app.application.appservice.AppServiceService;
+import org.sopt.app.application.appservice.OperationConfigService;
+import org.sopt.app.application.description.DescriptionService;
+import org.sopt.app.application.meeting.MeetingService;
+import org.sopt.app.application.platform.PlatformService;
+import org.sopt.app.application.playground.PlaygroundPopularPostRefreshEvent;
+import org.sopt.app.application.playground.PlaygroundPostCacheService;
+import org.sopt.app.application.playground.PlaygroundRecentPostRefreshEvent;
+import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
+import org.sopt.app.application.soptamp.SoptampUserService;
+import org.sopt.app.common.event.EventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class HomeFacadeTest {
+
+    @Mock
+    private DescriptionService descriptionService;
+    @Mock
+    private PlaygroundPostCacheService playgroundPostCacheService;
+    @Mock
+    private AppServiceService appServiceService;
+    @Mock
+    private AppServiceBadgeService appServiceBadgeService;
+    @Mock
+    private MeetingService meetingService;
+    @Mock
+    private OperationConfigService operationConfigService;
+    @Mock
+    private PlatformService platformService;
+    @Mock
+    private SoptampUserService soptampUserService;
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @InjectMocks
+    private HomeFacade homeFacade;
+
+    @Test
+    @DisplayName("최근 게시글 조회 시 캐시가 있으면 캐시된 데이터를 반환한다")
+    void getPlaygroundRecentPosts_returnsCachedData_whenCacheExists() {
+        // given
+        Long userId = 1L;
+        List<PlaygroundRecentPost> cachedPosts = List.of(
+                new PlaygroundRecentPost(1L, 1L, "img", "name", "34기", "category", "title", "content", "link", "2024-05-13 00:00:00.000000", false)
+        );
+        when(playgroundPostCacheService.getCachedRecentPosts()).thenReturn(Optional.of(cachedPosts));
+
+        // when
+        List<PlaygroundRecentPost> result = homeFacade.getPlaygroundRecentPosts(userId);
+
+        // then
+        assertEquals(cachedPosts, result);
+        verify(eventPublisher, times(0)).raise(any(PlaygroundRecentPostRefreshEvent.class));
+    }
+
+    @Test
+    @DisplayName("최근 게시글 조회 시 캐시가 없으면 빈 리스트를 반환하고 이벤트를 발행한다")
+    void getPlaygroundRecentPosts_returnsEmptyListAndPublishesEvent_whenCacheIsEmpty() {
+        // given
+        Long userId = 1L;
+        when(playgroundPostCacheService.getCachedRecentPosts()).thenReturn(Optional.empty());
+
+        // when
+        List<PlaygroundRecentPost> result = homeFacade.getPlaygroundRecentPosts(userId);
+
+        // then
+        assertTrue(result.isEmpty());
+        verify(eventPublisher, times(1)).raise(any(PlaygroundRecentPostRefreshEvent.class));
+    }
+
+    @Test
+    @DisplayName("인기 게시글 조회 시 캐시가 있으면 캐시된 데이터를 반환한다")
+    void getPlaygroundPopularPosts_returnsCachedData_whenCacheExists() {
+        // given
+        Long userId = 1L;
+        List<PlaygroundPopularPost> cachedPosts = List.of(
+                new PlaygroundPopularPost(1L, 1L, "img", "name", "34기", 1, "category", "title", "content", "link")
+        );
+        when(playgroundPostCacheService.getCachedPopularPosts()).thenReturn(Optional.of(cachedPosts));
+
+        // when
+        List<PlaygroundPopularPost> result = homeFacade.getPlaygroundPopularPosts(userId);
+
+        // then
+        assertEquals(cachedPosts, result);
+        verify(eventPublisher, times(0)).raise(any(PlaygroundPopularPostRefreshEvent.class));
+    }
+
+    @Test
+    @DisplayName("인기 게시글 조회 시 캐시가 없으면 빈 리스트를 반환하고 이벤트를 발행한다")
+    void getPlaygroundPopularPosts_returnsEmptyListAndPublishesEvent_whenCacheIsEmpty() {
+        // given
+        Long userId = 1L;
+        when(playgroundPostCacheService.getCachedPopularPosts()).thenReturn(Optional.empty());
+
+        // when
+        List<PlaygroundPopularPost> result = homeFacade.getPlaygroundPopularPosts(userId);
+
+        // then
+        assertTrue(result.isEmpty());
+        verify(eventPublisher, times(1)).raise(any(PlaygroundPopularPostRefreshEvent.class));
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #739

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 플레이그라운드 게시글 조회 캐싱 및 최적화
- 최초에는 플그 게시글 조회 실패 시 메인 뷰에서 무한정 로딩이 걸렸음.
- 이에 대한 결합도를 낮추고자, 플그에 게시글 조회 요청 시 응답을 못하면 타임아웃을 짧게 잡고 빈 리스트를 반환하도록 폴백으로 처리했으나, 해당 방식의 경우 매번 조회 요청 자체는 발생하므로 플그 서버에 가해지는 부담은 동일했음 
- 또한 타임 아웃이 3초였으므로 부하테스트 시 플그 게시글 조회 API TPS가 너무 낮게 나오는 문제가 존재하여 결합도를 낮추고자 캐싱을 도입함. 단순히 서킷브레이커를 도입하는 방법도 있었지만,,, 응답의 품질, 게시글의 낮은 실시간성 중요도, 이미 서비스 내부적으로 Redis를 사용하고 있었던 점 등을 종합적으로 고려했을 때 캐싱을 통해 처리하는 방법을 선택함.
- 방법 자체는 최초 게시글 조회 시 
   1. Redis에 게시글이 존재할 경우 반환
   2. Redis에 게시글이 존재하지 않을 경우 빈 리스트 반환 후 비동기 이벤트를 발행하여 플그에서 게시글 정보를 받아와서 Redis에 적재하도록 함.  이때 Redis 분산락을 도입했는데, 이유는,,, 게시글 성격상 일정 시간 동안 등록된 글이 없으면 플그 측에서 빈 리스트를 반환함. 이 경우 실시간성에 대한 중요도가 높아져서(등록된 글을 빨리 사용자에게 보여줘야 함.) 빈 리스트를 캐싱하고 한시간마다 갱신하는 것은 좋지 않음. 따라서 빈 리스트인 경우 데이터를 캐싱하지 않는데, 그렇다고 사용자의 트래픽을 모두 게시글 조회에 그대로 보내면 서버 부하가 심해짐. 따라서 플그에 게시글 데이터를 받아오는 부분을 TTL 5분의 분산락으로 두고, 5분에 한번씩 데이터를 받아올 수 있도록 구현함.
   3. 스케줄러를 통해 1시간마다 캐싱된 게시글 데이터를 갱신
- 메인 뷰 조회 시 안 읽은 알림 여부를 확인하는 API가 있는데, 기존 구조가 모든 알림을 가져와서 메모리에서,,, 필터링 하는,,, 구조였어서 메모리 최적화를 위해 DB에서 처리하도록 변경함
- 추가로 Notification 관련해서 UserId로 조회하는 로직이 많아서 idx_user_notification(user_id, notification_id) Prod DB에 추가해둠. (이것도 약간 고민이었던게,,, 알림은 진짜 발송을 많이해서 write 비율도 적진 않은데,,, 그래도 read가 좀 더 많을 것 같아서 추가해뒀어요.)



## To Reviewers 📢

### 리뷰 & 피드백 막 주세요