### PR TITLE
[Perf] #745: app-service API 응답 성능 개선

### DIFF
--- a/src/main/java/org/sopt/app/application/appservice/AppServiceBadgeService.java
+++ b/src/main/java/org/sopt/app/application/appservice/AppServiceBadgeService.java
@@ -1,10 +1,14 @@
 package org.sopt.app.application.appservice;
 
+import static org.sopt.app.common.config.AsyncConfig.CACHE_SYNC_EXECUTOR;
+
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.appservice.dto.AppServiceBadgeInfo;
 import org.sopt.app.application.appservice.dto.AppServiceEntryStatusResponse;
 import org.sopt.app.application.appservice.dto.AppServiceInfo;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,6 +23,13 @@ public class AppServiceBadgeService {
         AppServiceBadgeManager badgeManager = getAppServiceBadgeManager(appServiceInfo);
         AppServiceBadgeInfo badgeInfo = badgeManager.acquireAppServiceBadgeInfo(userId);
         return AppServiceEntryStatusResponse.createAppServiceEntryStatus(appServiceInfo, badgeInfo);
+    }
+
+    @Async(CACHE_SYNC_EXECUTOR)
+    public CompletableFuture<AppServiceEntryStatusResponse> getAppServiceEntryStatusResponseAsync(
+            final AppServiceInfo appServiceInfo, final Long userId
+    ) {
+        return CompletableFuture.completedFuture(getAppServiceEntryStatusResponse(appServiceInfo, userId));
     }
 
     private AppServiceBadgeManager getAppServiceBadgeManager(AppServiceInfo appServiceInfo) {

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -12,6 +12,7 @@ import org.sopt.app.application.soptamp.SoptampEvent.SoptampUserAllCacheSyncEven
 import org.sopt.app.application.soptamp.SoptampEvent.SoptampUserProfileCacheSyncEvent;
 import org.sopt.app.application.soptamp.SoptampEvent.SoptampUserScoreCacheSyncEvent;
 import org.sopt.app.application.user.UserWithdrawEvent;
+import org.sopt.app.common.config.AsyncConfig;
 import org.sopt.app.common.event.EventPublisher;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
@@ -21,6 +22,7 @@ import org.sopt.app.interfaces.postgres.AppjamUserRepository;
 import org.sopt.app.interfaces.postgres.SoptampUserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +62,7 @@ public class SoptampUserService {
     /* ==================== upsert 진입점 ==================== */
 
     // 앱잼 시즌 여부에 따라 upsert 로직 분기
+    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
     @Transactional
     public void upsertSoptampUser(PlatformUserInfoResponse profile, Long userId) {
         if (profile == null)

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -5,6 +5,7 @@ import static org.sopt.app.common.utils.HtmlTagWrapper.wrapWithTag;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,13 +79,14 @@ public class HomeFacade {
         UserStatus status = platformService.getStatus(platformUserInfo);
         soptampUserService.upsertSoptampUser(platformUserInfo, userId);
 
-        List<AppServiceEntryStatusResponse> appServiceEntryStatusResponses = appServiceService.getAllAppService().stream()
+        List<CompletableFuture<AppServiceEntryStatusResponse>> futures = appServiceService.getAllAppService().stream()
             .filter(appServiceInfo -> isServiceVisibleToUser(appServiceInfo, status))
-            .map(appServiceInfo -> appServiceBadgeService.getAppServiceEntryStatusResponse(
-                appServiceInfo, userId
-            ))
+            .map(appServiceInfo -> appServiceBadgeService.getAppServiceEntryStatusResponseAsync(appServiceInfo, userId))
             .toList();
-        return appServiceEntryStatusResponses;
+
+        return futures.stream()
+            .map(CompletableFuture::join)
+            .toList();
     }
 
     private List<AppServiceEntryStatusResponse> getOnlyAppServiceInfo() {


### PR DESCRIPTION
## Related issue 🛠

- closes #745

## Work Description ✏️

`GET /api/v2/home/app-service` 응답 속도 개선

- `upsertSoptampUser` `@Async` 처리 — 응답에 포함되지 않는 부수 효과를 백그라운드로 분리해 응답 블로킹 제거
- 앱 서비스별 뱃지 조회 `CompletableFuture` 병렬화 — N개 직렬 레이턴시를 1개 레이턴시로 단축

## Related ScreenShot 📷

## To Reviewers 📢

- `upsertSoptampUser`에 `@Async` + `@Transactional` 동시 적용 → 백그라운드 스레드에서 독립 트랜잭션으로 실행됩니다
- `AppServiceBadgeService`에 async 래퍼 메서드를 추가해 `HomeFacade`가 executor를 직접 주입받지 않아도 되도록 했습니다