### PR TITLE
 [Refactor] #748: 인증 서버 유저 데이터 캐싱 도입

### DIFF
--- a/src/main/java/org/sopt/app/application/platform/PlatformService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class PlatformService {
 
     private final PlatformClient platformClient;
+    private final PlatformUserCacheService platformUserCacheService;
 
     @Value("${external.auth.api-key}")
     private String apiKey;
@@ -38,6 +39,13 @@ public class PlatformService {
     private static final int URL_QUERY_LENGTH_THRESHOLD = 1200;
 
     public PlatformUserInfoResponse getPlatformUserInfoResponse(Long userId) {
+        return platformUserCacheService.getPlatformUserInfo(
+                userId,
+                () -> fetchFromPlatform(userId)
+        );
+    }
+
+    private PlatformUserInfoResponse fetchFromPlatform(Long userId) {
         final Map<String, String> headers = createAuthorizationHeader();
         final Map<String, String> params = createQueryParams(Collections.singletonList(userId));
         PlatformUserInfoWrapper platformUserInfoWrapper = platformClient.getPlatformUserInfo(headers, params);

--- a/src/main/java/org/sopt/app/application/platform/PlatformUserCacheService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformUserCacheService.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+import org.sopt.app.common.cache.CachePolicy;
 import org.sopt.app.common.cache.ResilientCacheTemplate;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
@@ -18,12 +19,20 @@ public class PlatformUserCacheService {
     private static final Duration PHYSICAL_TTL = Duration.ofHours(6);
 
     private final ResilientCacheTemplate resilientCacheTemplate;
-    private final boolean asyncRefreshEnabled;
+    private final CachePolicy userCachePolicy;
 
     // AWS Lambda 프로필에서는 동기 갱신으로 진행하기 위함
     public PlatformUserCacheService(ResilientCacheTemplate resilientCacheTemplate, Environment environment) {
         this.resilientCacheTemplate = resilientCacheTemplate;
-        this.asyncRefreshEnabled = !environment.acceptsProfiles(Profiles.of("lambda"));
+
+        // 람다 프로필 여부에 따라 비동기 갱신
+        boolean isAsync = !environment.acceptsProfiles(Profiles.of("lambda"));
+
+        this.userCachePolicy = CachePolicy.of(
+            LOGICAL_TTL_MS,
+            PHYSICAL_TTL,
+            isAsync
+        );
     }
 
     public PlatformUserInfoResponse getPlatformUserInfo(Long userId, Supplier<PlatformUserInfoResponse> fetcher) {
@@ -32,9 +41,7 @@ public class PlatformUserCacheService {
         return resilientCacheTemplate.get(
             cacheKey,
             PlatformUserInfoResponse.class,
-            LOGICAL_TTL_MS,
-            PHYSICAL_TTL,
-            asyncRefreshEnabled,
+            userCachePolicy,
             fetcher
         );
     }

--- a/src/main/java/org/sopt/app/application/platform/PlatformUserCacheService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformUserCacheService.java
@@ -1,0 +1,41 @@
+package org.sopt.app.application.platform;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+import org.sopt.app.common.cache.ResilientCacheTemplate;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class PlatformUserCacheService {
+
+    private static final String CACHE_KEY_PREFIX = "platformUserInfo::";
+    private static final long LOGICAL_TTL_MS = 1000 * 60 * 5; // 5분
+    private static final Duration PHYSICAL_TTL = Duration.ofHours(6);
+
+    private final ResilientCacheTemplate resilientCacheTemplate;
+    private final boolean asyncRefreshEnabled;
+
+    // AWS Lambda 프로필에서는 동기 갱신으로 진행하기 위함
+    public PlatformUserCacheService(ResilientCacheTemplate resilientCacheTemplate, Environment environment) {
+        this.resilientCacheTemplate = resilientCacheTemplate;
+        this.asyncRefreshEnabled = !environment.acceptsProfiles(Profiles.of("lambda"));
+    }
+
+    public PlatformUserInfoResponse getPlatformUserInfo(Long userId, Supplier<PlatformUserInfoResponse> fetcher) {
+        String cacheKey = CACHE_KEY_PREFIX + userId.toString();
+
+        return resilientCacheTemplate.get(
+            cacheKey,
+            PlatformUserInfoResponse.class,
+            LOGICAL_TTL_MS,
+            PHYSICAL_TTL,
+            asyncRefreshEnabled,
+            fetcher
+        );
+    }
+}

--- a/src/main/java/org/sopt/app/common/cache/CachePolicy.java
+++ b/src/main/java/org/sopt/app/common/cache/CachePolicy.java
@@ -7,8 +7,8 @@ import java.time.Duration;
  * @param logicalTtlMs 논리 만료 시간 (밀리세컨드) - 비동기 갱신을 위함
  * @param physicalTtl 물리적 만료 시간 - Redis TTL
  * @param asyncRefreshEnabled 비동기 갱신 여부 - 람다와 인스턴스 환경 분리를 위함
- * @param lockTtl 락 대기 시간
- * @param maxWaitTime 요청 대기 시간
+ * @param lockTtl Redis 락 유지 시간
+ * @param maxWaitTime 락 || 걍신 대기 시간
  */
 public record CachePolicy(
     long logicalTtlMs,

--- a/src/main/java/org/sopt/app/common/cache/CachePolicy.java
+++ b/src/main/java/org/sopt/app/common/cache/CachePolicy.java
@@ -1,0 +1,34 @@
+package org.sopt.app.common.cache;
+
+import java.time.Duration;
+
+/**
+ *
+ * @param logicalTtlMs 논리 만료 시간 (밀리세컨드) - 비동기 갱신을 위함
+ * @param physicalTtl 물리적 만료 시간 - Redis TTL
+ * @param asyncRefreshEnabled 비동기 갱신 여부 - 람다와 인스턴스 환경 분리를 위함
+ * @param lockTtl 락 대기 시간
+ * @param maxWaitTime 요청 대기 시간
+ */
+public record CachePolicy(
+    long logicalTtlMs,
+    Duration physicalTtl,
+    boolean asyncRefreshEnabled,
+    Duration lockTtl,
+    Duration maxWaitTime
+) {
+
+    public static CachePolicy of(
+        long logicalTtlMs,
+        Duration physicalTtl,
+        boolean async
+    ) {
+        return new CachePolicy(
+            logicalTtlMs,
+            physicalTtl,
+            async,
+            Duration.ofSeconds(5),
+            Duration.ofSeconds(3)
+        );
+    }
+}

--- a/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
@@ -35,8 +35,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
 
     private static final String LOCK_PREFIX = "lock:cache:";
     private static final String REFRESH_MARKER_PREFIX = "refresh_marker:cache:";
-    private static final long LOCK_TTL_SECOND = 5;
-    private static final long MAX_WAIT_MS = 3000;
+
     private static final long BASE_SLEEP_MS = 50;
     private static final long MAX_JITTER_MS = 50;
 
@@ -44,6 +43,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
         "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
         Long.class
     );
+
 
     // Redis에 저장할 데이터 형태. data + 저장 시간을 묶어서 처리
     public record CacheWrapper<T>(T data, Long requestedAt) {}
@@ -53,7 +53,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
      * 논리 TTL이 만료됐더라도, 우선 stale한 데이터를 반환함.
      */
     @Override
-    public <T> T get(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, boolean asyncRefreshEnabled, Supplier<T> fetcher) {
+    public <T> T get(String key, Class<T> type, CachePolicy policy, Supplier<T> fetcher) {
 
         JavaType wrapperType = objectMapper.getTypeFactory().constructParametricType(CacheWrapper.class, type);
 
@@ -61,19 +61,19 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
         CacheWrapper<T> staleData = null;
 
         if(isValid(cachedData)){
-            if(isFresh(cachedData, logicalTtlMs)){
+            if(isFresh(cachedData, policy.logicalTtlMs())){
                 return cachedData.data();
             }
 
             staleData = cachedData;
 
-            if(asyncRefreshEnabled){
-                dispatchAsyncRefresh(key, type, logicalTtlMs, physicalTtl, fetcher, wrapperType);
+            if(policy.asyncRefreshEnabled()){
+                dispatchAsyncRefresh(key, policy, fetcher, wrapperType);
                 return cachedData.data();
             }
         }
 
-        return blockingGet(key, type, logicalTtlMs, physicalTtl, fetcher, staleData, wrapperType);
+        return blockingGet(key, policy, fetcher, staleData, wrapperType);
     }
 
     private <T> CacheWrapper<T> readCache(String key, JavaType wrapperType) {
@@ -91,27 +91,27 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     /**
      * stale 데이터도 없는 경우 or AWS Lambda 환경인 경우.
      */
-    private <T> T blockingGet(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, Supplier<T> fetcher, CacheWrapper<T> staleData, JavaType wrapperType) {
+    private <T> T blockingGet(String key, CachePolicy policy, Supplier<T> fetcher, CacheWrapper<T> staleData, JavaType wrapperType) {
         String lockKey = LOCK_PREFIX + key;
         String lockValue = UUID.randomUUID().toString();
         long startTime = System.currentTimeMillis();
 
         // 총 경과 시간이 MAX_WAIT_MS 를 넘지 않는 동안 반복
-        while (System.currentTimeMillis() - startTime < MAX_WAIT_MS) {
+        while (System.currentTimeMillis() - startTime < policy.maxWaitTime().toMillis()) {
 
             CacheWrapper<T> wrapper = readCache(key, wrapperType);
             if (isValid(wrapper)) {
-                if (isFresh(wrapper, logicalTtlMs)) return wrapper.data();
+                if (isFresh(wrapper, policy.logicalTtlMs())) return wrapper.data();
                 if (staleData == null) staleData = wrapper;
             }
 
-            if (tryAcquireLock(lockKey, lockValue)) {
+            if (tryAcquireLock(lockKey, lockValue, policy.lockTtl())) {
                 try {
                     CacheWrapper<T> doubleChecked = readCache(key, wrapperType);
-                    if (isValid(doubleChecked) && isFresh(doubleChecked, logicalTtlMs)) {
+                    if (isValid(doubleChecked) && isFresh(doubleChecked, policy.logicalTtlMs())) {
                         return doubleChecked.data();
                     }
-                    return fetchAndCache(key, physicalTtl, fetcher, wrapperType);
+                    return fetchAndCache(key, policy.physicalTtl(), fetcher, wrapperType);
                 } finally {
                     releaseLock(lockKey, lockValue);
                 }
@@ -139,16 +139,16 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
         }
     }
 
-    private boolean tryAcquireLock(String lockKey, String lockValue) {
-        return Boolean.TRUE.equals(stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, Duration.ofSeconds(LOCK_TTL_SECOND)));
+    private boolean tryAcquireLock(String lockKey, String lockValue, Duration lockTtl) {
+        return Boolean.TRUE.equals(stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, lockTtl));
     }
 
     /**
      * 비동기적으로 이미 누군가 락을 잡고 작업 중이라면 패스, 그렇지 않다면 락을 잡고 데이터 갱신
      */
-    private <T> void dispatchAsyncRefresh(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
+    private <T> void dispatchAsyncRefresh(String key, CachePolicy policy, Supplier<T> fetcher, JavaType wrapperType) {
         String markerKey = REFRESH_MARKER_PREFIX + key;
-        Boolean markerAcquired = stringRedisTemplate.opsForValue().setIfAbsent(markerKey, "1", Duration.ofSeconds(LOCK_TTL_SECOND));
+        Boolean markerAcquired = stringRedisTemplate.opsForValue().setIfAbsent(markerKey, "1", policy.lockTtl());
         if (!Boolean.TRUE.equals(markerAcquired)) return;
 
         Executor executor = executorProvider.getIfAvailable();
@@ -165,15 +165,15 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
                 String lockValue = UUID.randomUUID().toString();
 
                 // 충돌 방지를 위한 더블 체크
-                Boolean lockAcquired = stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, Duration.ofSeconds(LOCK_TTL_SECOND));
+                Boolean lockAcquired = stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, policy.lockTtl());
                 if (!Boolean.TRUE.equals(lockAcquired)) return; // fail fast
 
                 try {
                     CacheWrapper<T> doubleChecked = readCache(key, wrapperType);
-                    if (isValid(doubleChecked) && isFresh(doubleChecked, logicalTtlMs)) {
+                    if (isValid(doubleChecked) && isFresh(doubleChecked, policy.logicalTtlMs())) {
                         return;
                     }
-                    fetchAndCache(key, physicalTtl, fetcher, wrapperType);
+                    fetchAndCache(key, policy.physicalTtl(), fetcher, wrapperType);
                 } catch (Exception e) {
                     log.error("비동기 캐시 갱신 실패. Key: {}", key, e);
                 } finally {

--- a/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
@@ -120,7 +120,10 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
             sleepWithJitter();
         }
 
-        if (staleData != null) return staleData.data();
+        if (staleData != null) {
+            log.warn("캐시 갱신 락 획득 대기 시간이 초과되어 Stale 데이터를 반환합니다. (Key: {})", key);
+            return staleData.data();
+        }
         throw new BaseException("캐시 갱신을 위한 락 획득 시간 초과", ErrorCode.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,9 +36,10 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     // 시스템 제어를 위한 상수들 (외부 주입 불필요)
     private static final String LOCK_PREFIX = "lock:cache:";
     private static final String REFRESH_MARKER_PREFIX = "refresh_marker:cache:";
-    private static final long LOCK_TTL_SECOND = 8;
-    private static final long RETRY_INTERVAL_MS = 500;
+    private static final long LOCK_TTL_SECOND = 5;
     private static final long MAX_WAIT_MS = 3000;
+    private static final long BASE_SLEEP_MS = 50;
+    private static final long MAX_JITTER_MS = 50;
 
     private static final RedisScript<Long> RELEASE_LOCK_SCRIPT = new DefaultRedisScript<>(
         "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
@@ -67,12 +69,12 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
             staleData = cachedData;
 
             if(asyncRefreshEnabled){
-                triggerAsyncRefresh(key, type, physicalTtl, fetcher, wrapperType);
+                dispatchAsyncRefresh(key, type, physicalTtl, fetcher, wrapperType);
                 return cachedData.data();
             }
         }
 
-        return getWithLockAndRefresh(key, type, logicalTtlMs, physicalTtl, fetcher, staleData, wrapperType);
+        return blockingGet(key, type, logicalTtlMs, physicalTtl, fetcher, staleData, wrapperType);
     }
 
     private <T> CacheWrapper<T> readCache(String key, JavaType wrapperType) {
@@ -90,12 +92,13 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     /**
      * stale 데이터도 없는 경우 or AWS Lambda 환경인 경우.
      */
-    private <T> T getWithLockAndRefresh(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, Supplier<T> fetcher, CacheWrapper<T> staleData, JavaType wrapperType) {
+    private <T> T blockingGet(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, Supplier<T> fetcher, CacheWrapper<T> staleData, JavaType wrapperType) {
         String lockKey = LOCK_PREFIX + key;
         String lockValue = UUID.randomUUID().toString();
-        int maxRetryCount = (int) (MAX_WAIT_MS / RETRY_INTERVAL_MS);
+        long startTime = System.currentTimeMillis();
 
-        for (int i = 0; i < maxRetryCount; i++) {
+        // 총 경과 시간이 MAX_WAIT_MS 를 넘지 않는 동안 반복
+        while (System.currentTimeMillis() - startTime < MAX_WAIT_MS) {
 
             CacheWrapper<T> wrapper = readCache(key, wrapperType);
             if (isValid(wrapper)) {
@@ -103,32 +106,34 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
                 if (staleData == null) staleData = wrapper;
             }
 
-            // 락 획득 시도
             if (tryAcquireLock(lockKey, lockValue)) {
                 try {
-                    // 락 획득 직후 더블 체크
                     CacheWrapper<T> doubleChecked = readCache(key, wrapperType);
                     if (isValid(doubleChecked) && isFresh(doubleChecked, logicalTtlMs)) {
                         return doubleChecked.data();
                     }
-
                     return fetchAndCache(key, physicalTtl, fetcher, wrapperType);
                 } finally {
                     releaseLock(lockKey, lockValue);
                 }
             }
 
-            sleepWithoutInterrupt(); // 락 획득 실패 시 대기
+            sleepWithJitter();
         }
 
         if (staleData != null) return staleData.data();
         throw new BaseException("캐시 갱신을 위한 락 획득 시간 초과", ErrorCode.INTERNAL_SERVER_ERROR);
     }
 
-    // sleep을 처리하는 헬퍼 메서드
-    private void sleepWithoutInterrupt() {
+    /**
+     * 스레드 sleep 시간에 jitter를 두어 부하 분산
+     */
+    private void sleepWithJitter() {
         try {
-            Thread.sleep(RETRY_INTERVAL_MS);
+            long jitter = ThreadLocalRandom.current().nextLong(MAX_JITTER_MS);
+            long sleepTime = BASE_SLEEP_MS + jitter;
+
+            Thread.sleep(sleepTime);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new BaseException("락 대기 중 인터럽트가 발생했습니다.", ErrorCode.INTERNAL_SERVER_ERROR);
@@ -142,7 +147,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     /**
      * 비동기적으로 이미 누군가 락을 잡고 작업 중이라면 패스, 그렇지 않다면 락을 잡고 데이터 갱신
      */
-    private <T> void triggerAsyncRefresh(String key, Class<T> type, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
+    private <T> void dispatchAsyncRefresh(String key, Class<T> type, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
         String markerKey = REFRESH_MARKER_PREFIX + key;
         Boolean markerAcquired = stringRedisTemplate.opsForValue().setIfAbsent(markerKey, "1", Duration.ofSeconds(LOCK_TTL_SECOND));
         if (!Boolean.TRUE.equals(markerAcquired)) return;

--- a/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
@@ -1,0 +1,213 @@
+package org.sopt.app.common.cache;
+
+import static org.sopt.app.common.config.AsyncConfig.CACHE_SYNC_EXECUTOR;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.common.exception.BaseException;
+import org.sopt.app.common.response.ErrorCode;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Qualifier(CACHE_SYNC_EXECUTOR)
+    private final ObjectProvider<Executor> executorProvider;
+
+    // 시스템 제어를 위한 상수들 (외부 주입 불필요)
+    private static final String LOCK_PREFIX = "lock:cache:";
+    private static final String REFRESH_MARKER_PREFIX = "refresh_marker:cache:";
+    private static final long LOCK_TTL_SECOND = 8;
+    private static final long RETRY_INTERVAL_MS = 500;
+    private static final long MAX_WAIT_MS = 3000;
+
+    private static final RedisScript<Long> RELEASE_LOCK_SCRIPT = new DefaultRedisScript<>(
+        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+        Long.class
+    );
+
+    // Redis에 저장할 데이터 형태. data + 저장 시간을 묶어서 처리
+    public record CacheWrapper<T>(T data, Long createdAt) {}
+
+    /**
+     * 데이터가 존재할 경우, 논리 TTL에 따라 반환 only, 혹은 반환 후 비동기 갱신 작업을 수행.
+     * 논리 TTL이 만료됐더라도, 우선 stale한 데이터를 반환함.
+     */
+    @Override
+    public <T> T get(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, boolean asyncRefreshEnabled, Supplier<T> fetcher) {
+
+        JavaType wrapperType = objectMapper.getTypeFactory().constructParametricType(CacheWrapper.class, type);
+
+        CacheWrapper<T> cachedData = readCache(key, wrapperType);
+        CacheWrapper<T> staleData = null;
+
+        if(isValid(cachedData)){
+            if(isFresh(cachedData, logicalTtlMs)){
+                return cachedData.data();
+            }
+
+            staleData = cachedData;
+
+            if(asyncRefreshEnabled){
+                triggerAsyncRefresh(key, type, physicalTtl, fetcher, wrapperType);
+                return cachedData.data();
+            }
+        }
+
+        return getWithLockAndRefresh(key, type, logicalTtlMs, physicalTtl, fetcher, staleData, wrapperType);
+    }
+
+    private <T> CacheWrapper<T> readCache(String key, JavaType wrapperType) {
+        String cachedData = stringRedisTemplate.opsForValue().get(key);
+        if (cachedData == null) return null;
+
+        try {
+            return objectMapper.readValue(cachedData, wrapperType);
+        } catch (Exception e) {
+            log.error("캐시 역직렬화 실패 (키: {})", key, e);
+            return null;
+        }
+    }
+
+    /**
+     * stale 데이터도 없는 경우 or AWS Lambda 환경인 경우.
+     */
+    private <T> T getWithLockAndRefresh(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, Supplier<T> fetcher, CacheWrapper<T> staleData, JavaType wrapperType) {
+        String lockKey = LOCK_PREFIX + key;
+        String lockValue = UUID.randomUUID().toString();
+        int maxRetryCount = (int) (MAX_WAIT_MS / RETRY_INTERVAL_MS);
+
+        for (int i = 0; i < maxRetryCount; i++) {
+
+            CacheWrapper<T> wrapper = readCache(key, wrapperType);
+            if (isValid(wrapper)) {
+                if (isFresh(wrapper, logicalTtlMs)) return wrapper.data();
+                if (staleData == null) staleData = wrapper;
+            }
+
+            // 락 획득 시도
+            if (tryAcquireLock(lockKey, lockValue)) {
+                try {
+                    // 락 획득 직후 더블 체크
+                    CacheWrapper<T> doubleChecked = readCache(key, wrapperType);
+                    if (isValid(doubleChecked) && isFresh(doubleChecked, logicalTtlMs)) {
+                        return doubleChecked.data();
+                    }
+
+                    return fetchAndCache(key, physicalTtl, fetcher, wrapperType);
+                } finally {
+                    releaseLock(lockKey, lockValue);
+                }
+            }
+
+            sleepWithoutInterrupt(); // 락 획득 실패 시 대기
+        }
+
+        if (staleData != null) return staleData.data();
+        throw new BaseException("캐시 갱신을 위한 락 획득 시간 초과", ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    // sleep을 처리하는 헬퍼 메서드
+    private void sleepWithoutInterrupt() {
+        try {
+            Thread.sleep(RETRY_INTERVAL_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BaseException("락 대기 중 인터럽트가 발생했습니다.", ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private boolean tryAcquireLock(String lockKey, String lockValue) {
+        return Boolean.TRUE.equals(stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, Duration.ofSeconds(LOCK_TTL_SECOND)));
+    }
+
+    /**
+     * 비동기적으로 이미 누군가 락을 잡고 작업 중이라면 패스, 그렇지 않다면 락을 잡고 데이터 갱신
+     */
+    private <T> void triggerAsyncRefresh(String key, Class<T> type, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
+        String markerKey = REFRESH_MARKER_PREFIX + key;
+        Boolean markerAcquired = stringRedisTemplate.opsForValue().setIfAbsent(markerKey, "1", Duration.ofSeconds(LOCK_TTL_SECOND));
+        if (!Boolean.TRUE.equals(markerAcquired)) return;
+
+        executorProvider.ifAvailable(executor -> {
+            try {
+                executor.execute(() -> {
+                    String lockKey = LOCK_PREFIX + key;
+                    String lockValue = UUID.randomUUID().toString();
+
+                    // 충돌 방지를 위한 더블 체크
+                    Boolean lockAcquired = stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, Duration.ofSeconds(LOCK_TTL_SECOND));
+                    if (!Boolean.TRUE.equals(lockAcquired)) return; // fail fast
+
+                    try {
+                        fetchAndCache(key, physicalTtl, fetcher, wrapperType);
+                    } catch (Exception e) {
+                        log.error("비동기 캐시 갱신 실패. Key: {}", key, e);
+                    } finally {
+                        releaseLock(lockKey, lockValue);
+                    }
+                });
+            } catch (Exception e) {
+                log.error("비동기 작업 풀에 갱신 작업을 등록하지 못했습니다.", e);
+            }
+        });
+    }
+
+    private <T> T fetchAndCache(String key, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
+        T data = fetcher.get(); // 외부에서 데이터를 가져옴
+        long newCreatedAt = System.currentTimeMillis();
+        CacheWrapper<T> wrapper = new CacheWrapper<>(data, newCreatedAt);
+
+        try {
+            String existingData = stringRedisTemplate.opsForValue().get(key);
+            if (existingData != null) {
+                try {
+                    CacheWrapper<T> existingWrapper = objectMapper.readValue(existingData, wrapperType);
+                    if (existingWrapper.createdAt() != null && existingWrapper.createdAt() >= newCreatedAt) {
+                        return data;
+                    }
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+            stringRedisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(wrapper), physicalTtl);
+        } catch (Exception e) {
+            log.error("데이터 직렬화 및 레디스 저장 실패. key: {}", key, e);
+        }
+        return data;
+    }
+
+    private void releaseLock(String lockKey, String lockValue) {
+        try {
+            stringRedisTemplate.execute(RELEASE_LOCK_SCRIPT, Collections.singletonList(lockKey), lockValue);
+        } catch (Exception e) {
+            log.error("레디스 락 해제 실패. Key: {}",lockKey, e);
+        }
+    }
+
+    private <T> boolean isValid(CacheWrapper<T> wrapper) {
+        return wrapper != null && wrapper.data() != null && wrapper.createdAt() != null;
+    }
+
+    private <T> boolean isFresh(CacheWrapper<T> wrapper, long logicalTtlMs) {
+        return System.currentTimeMillis() - wrapper.createdAt() < logicalTtlMs;
+    }
+}

--- a/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
@@ -1,6 +1,6 @@
 package org.sopt.app.common.cache;
 
-import static org.sopt.app.common.config.AsyncConfig.CACHE_SYNC_EXECUTOR;
+import static org.sopt.app.common.config.AsyncConfig.CACHE_REFRESH_EXECUTOR;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,7 +30,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;
 
-    @Qualifier(CACHE_SYNC_EXECUTOR)
+    @Qualifier(CACHE_REFRESH_EXECUTOR)
     private final ObjectProvider<Executor> executorProvider;
 
     private static final String LOCK_PREFIX = "lock:cache:";
@@ -121,7 +121,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
         }
 
         if (staleData != null) {
-            log.warn("캐시 갱신 락 획득 대기 시간이 초과되어 Stale 데이터를 반환합니다. (Key: {})", key);
+            log.warn("캐시 갱신 락 획득 대기 시간이 초과되어 Stale 데이터를 반환. (Key: {})", key);
             return staleData.data();
         }
         throw new BaseException("캐시 갱신을 위한 락 획득 시간 초과", ErrorCode.INTERNAL_SERVER_ERROR);
@@ -138,7 +138,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
             Thread.sleep(sleepTime);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new BaseException("락 대기 중 인터럽트가 발생했습니다.", ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new BaseException("락 대기 중 인터럽트 발생.", ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -157,7 +157,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
         Executor executor = executorProvider.getIfAvailable();
 
         if (executor == null) {
-            log.error("비동기 캐시 갱신을 위한 Executor가 존재하지 않습니다. (Key: {})", key);
+            log.error("비동기 캐시 갱신을 위한 Executor가 존재하지 않음. Key: {}", key);
             stringRedisTemplate.delete(markerKey); // 묶여있던 마커를 풀어줌
             return;
         }
@@ -183,8 +183,11 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
                     releaseLock(lockKey, lockValue);
                 }
             });
+        } catch (java.util.concurrent.RejectedExecutionException e) {
+            log.warn("스레드 풀 큐가 꽉 차서 캐시 갱신 작업 스킵. Key: {}", key);
+            stringRedisTemplate.delete(markerKey);
         } catch (Exception e) {
-            log.error("비동기 작업 큐가 꽉 차서 작업을 등록하지 못했습니다.", e);
+            log.error("비동기 작업 큐가 꽉 차서 작업 등록 실패.", e);
             stringRedisTemplate.delete(markerKey);
         }
 

--- a/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
@@ -33,7 +33,6 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     @Qualifier(CACHE_SYNC_EXECUTOR)
     private final ObjectProvider<Executor> executorProvider;
 
-    // 시스템 제어를 위한 상수들 (외부 주입 불필요)
     private static final String LOCK_PREFIX = "lock:cache:";
     private static final String REFRESH_MARKER_PREFIX = "refresh_marker:cache:";
     private static final long LOCK_TTL_SECOND = 5;
@@ -47,7 +46,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     );
 
     // Redis에 저장할 데이터 형태. data + 저장 시간을 묶어서 처리
-    public record CacheWrapper<T>(T data, Long createdAt) {}
+    public record CacheWrapper<T>(T data, Long requestedAt) {}
 
     /**
      * 데이터가 존재할 경우, 논리 TTL에 따라 반환 only, 혹은 반환 후 비동기 갱신 작업을 수행.
@@ -69,7 +68,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
             staleData = cachedData;
 
             if(asyncRefreshEnabled){
-                dispatchAsyncRefresh(key, type, physicalTtl, fetcher, wrapperType);
+                dispatchAsyncRefresh(key, type, logicalTtlMs, physicalTtl, fetcher, wrapperType);
                 return cachedData.data();
             }
         }
@@ -147,46 +146,59 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     /**
      * 비동기적으로 이미 누군가 락을 잡고 작업 중이라면 패스, 그렇지 않다면 락을 잡고 데이터 갱신
      */
-    private <T> void dispatchAsyncRefresh(String key, Class<T> type, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
+    private <T> void dispatchAsyncRefresh(String key, Class<T> type, long logicalTtlMs, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
         String markerKey = REFRESH_MARKER_PREFIX + key;
         Boolean markerAcquired = stringRedisTemplate.opsForValue().setIfAbsent(markerKey, "1", Duration.ofSeconds(LOCK_TTL_SECOND));
         if (!Boolean.TRUE.equals(markerAcquired)) return;
 
-        executorProvider.ifAvailable(executor -> {
-            try {
-                executor.execute(() -> {
-                    String lockKey = LOCK_PREFIX + key;
-                    String lockValue = UUID.randomUUID().toString();
+        Executor executor = executorProvider.getIfAvailable();
 
-                    // 충돌 방지를 위한 더블 체크
-                    Boolean lockAcquired = stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, Duration.ofSeconds(LOCK_TTL_SECOND));
-                    if (!Boolean.TRUE.equals(lockAcquired)) return; // fail fast
+        if (executor == null) {
+            log.error("비동기 캐시 갱신을 위한 Executor가 존재하지 않습니다. (Key: {})", key);
+            stringRedisTemplate.delete(markerKey); // 묶여있던 마커를 풀어줌
+            return;
+        }
 
-                    try {
-                        fetchAndCache(key, physicalTtl, fetcher, wrapperType);
-                    } catch (Exception e) {
-                        log.error("비동기 캐시 갱신 실패. Key: {}", key, e);
-                    } finally {
-                        releaseLock(lockKey, lockValue);
+        try {
+            executor.execute(() -> {
+                String lockKey = LOCK_PREFIX + key;
+                String lockValue = UUID.randomUUID().toString();
+
+                // 충돌 방지를 위한 더블 체크
+                Boolean lockAcquired = stringRedisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, Duration.ofSeconds(LOCK_TTL_SECOND));
+                if (!Boolean.TRUE.equals(lockAcquired)) return; // fail fast
+
+                try {
+                    CacheWrapper<T> doubleChecked = readCache(key, wrapperType);
+                    if (isValid(doubleChecked) && isFresh(doubleChecked, logicalTtlMs)) {
+                        return;
                     }
-                });
-            } catch (Exception e) {
-                log.error("비동기 작업 풀에 갱신 작업을 등록하지 못했습니다.", e);
-            }
-        });
+                    fetchAndCache(key, physicalTtl, fetcher, wrapperType);
+                } catch (Exception e) {
+                    log.error("비동기 캐시 갱신 실패. Key: {}", key, e);
+                } finally {
+                    releaseLock(lockKey, lockValue);
+                }
+            });
+        } catch (Exception e) {
+            log.error("비동기 작업 큐가 꽉 차서 작업을 등록하지 못했습니다.", e);
+            stringRedisTemplate.delete(markerKey);
+        }
+
     }
 
     private <T> T fetchAndCache(String key, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
+        long requestAt = System.currentTimeMillis();
+
         T data = fetcher.get(); // 외부에서 데이터를 가져옴
-        long newCreatedAt = System.currentTimeMillis();
-        CacheWrapper<T> wrapper = new CacheWrapper<>(data, newCreatedAt);
+        CacheWrapper<T> wrapper = new CacheWrapper<>(data, requestAt);
 
         try {
             String existingData = stringRedisTemplate.opsForValue().get(key);
             if (existingData != null) {
                 try {
                     CacheWrapper<T> existingWrapper = objectMapper.readValue(existingData, wrapperType);
-                    if (existingWrapper.createdAt() != null && existingWrapper.createdAt() >= newCreatedAt) {
+                    if (existingWrapper.requestedAt() != null && existingWrapper.requestedAt() >= requestAt) {
                         return data;
                     }
                 } catch (Exception e) {
@@ -209,10 +221,10 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     }
 
     private <T> boolean isValid(CacheWrapper<T> wrapper) {
-        return wrapper != null && wrapper.data() != null && wrapper.createdAt() != null;
+        return wrapper != null && wrapper.data() != null && wrapper.requestedAt() != null;
     }
 
     private <T> boolean isFresh(CacheWrapper<T> wrapper, long logicalTtlMs) {
-        return System.currentTimeMillis() - wrapper.createdAt() < logicalTtlMs;
+        return System.currentTimeMillis() - wrapper.requestedAt() < logicalTtlMs;
     }
 }

--- a/src/main/java/org/sopt/app/common/cache/ResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/ResilientCacheTemplate.java
@@ -1,6 +1,5 @@
 package org.sopt.app.common.cache;
 
-import java.time.Duration;
 import java.util.function.Supplier;
 
 public interface ResilientCacheTemplate {
@@ -8,17 +7,13 @@ public interface ResilientCacheTemplate {
     /**
      * @param key 캐시 식별 키
      * @param type 반환받을 객체의 타입 클래스
-     * @param logicalTtlMs 논리 만료 시간 (밀리세컨드) - 비동기 갱신을 위함
-     * @param physicalTtl 물리적 만료 시간 - Redis TTL
-     * @param asyncRefreshEnabled 비동기 갱신 여부 - 람다와 인스턴스 환경 분리를 위함
+     * @param policy 캐시 정책
      * @param fetcher 캐시 미스 시 데이터를 가져올 공급자(Supplier)
      */
     <T> T get(
         String key,
         Class<T> type,
-        long logicalTtlMs,
-        Duration physicalTtl,
-        boolean asyncRefreshEnabled,
+        CachePolicy policy,
         Supplier<T> fetcher
     );
 }

--- a/src/main/java/org/sopt/app/common/cache/ResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/ResilientCacheTemplate.java
@@ -1,0 +1,24 @@
+package org.sopt.app.common.cache;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+public interface ResilientCacheTemplate {
+
+    /**
+     * @param key 캐시 식별 키
+     * @param type 반환받을 객체의 타입 클래스
+     * @param logicalTtlMs 논리 만료 시간 (밀리세컨드) - 비동기 갱신을 위함
+     * @param physicalTtl 물리적 만료 시간 - Redis TTL
+     * @param asyncRefreshEnabled 비동기 갱신 여부 - 람다와 인스턴스 환경 분리를 위함
+     * @param fetcher 캐시 미스 시 데이터를 가져올 공급자(Supplier)
+     */
+    <T> T get(
+        String key,
+        Class<T> type,
+        long logicalTtlMs,
+        Duration physicalTtl,
+        boolean asyncRefreshEnabled,
+        Supplier<T> fetcher
+    );
+}

--- a/src/main/java/org/sopt/app/common/config/AsyncConfig.java
+++ b/src/main/java/org/sopt/app/common/config/AsyncConfig.java
@@ -14,17 +14,31 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class AsyncConfig {
 
     public static final String CACHE_SYNC_EXECUTOR = "cacheSyncTaskExecutor";
+    public static final String CACHE_REFRESH_EXECUTOR = "cacheRefreshExecutor";
 
     @Bean(name = CACHE_SYNC_EXECUTOR)
     public Executor cacheSyncTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(5);
         executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(50);
+        executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("CacheSync-");
 
         // 큐가 꽉 차면, 이벤트를 발행한 메인 스레드가 직접 동기적으로 처리함
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = CACHE_REFRESH_EXECUTOR)
+    public Executor cacheRefreshExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("CacheRefresh-");
+
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
         executor.initialize();
         return executor;
     }

--- a/src/test/java/org/sopt/app/application/platform/PlatformServiceTest.java
+++ b/src/test/java/org/sopt/app/application/platform/PlatformServiceTest.java
@@ -1,0 +1,112 @@
+package org.sopt.app.application.platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+import org.sopt.app.application.platform.dto.PlatformUserInfoWrapper;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformServiceTest {
+
+    @Mock
+    private PlatformClient platformClient;
+    @Mock
+    private PlatformUserCacheService platformUserCacheService;
+
+    @InjectMocks
+    private PlatformService platformService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(platformService, "apiKey", "test-api-key");
+        ReflectionTestUtils.setField(platformService, "serviceName", "test-service");
+        ReflectionTestUtils.setField(platformService, "currentGeneration", 34L);
+    }
+
+    @Test
+    @DisplayName("유저 정보 조회 시 캐시 핸들러를 호출한다")
+    void SUCCESS_getPlatformUserInfoResponse_CallsCacheHandler() {
+        // given
+        Long userId = 1L;
+        PlatformUserInfoResponse expectedData = new PlatformUserInfoResponse(1, "testUser", null, null, null, null, 34, List.of());
+
+        when(platformUserCacheService.getPlatformUserInfo(
+                eq(userId),
+                any(Supplier.class)
+        )).thenReturn(expectedData);
+
+        // when
+        PlatformUserInfoResponse actualResponse = platformService.getPlatformUserInfoResponse(userId);
+
+        // then
+        assertThat(actualResponse).isNotNull();
+        assertThat(actualResponse.name()).isEqualTo(expectedData.name());
+        verify(platformUserCacheService, times(1)).getPlatformUserInfo(
+                eq(userId),
+                any(Supplier.class)
+        );
+    }
+
+    @Test
+    @DisplayName("캐시 미스 시 외부 API를 호출하여 데이터를 가져온다")
+    void SUCCESS_getPlatformUserInfoResponse_CacheMiss_FetchesFromPlatform() {
+        // given
+        Long userId = 1L;
+        PlatformUserInfoResponse expectedResponse = new PlatformUserInfoResponse(1, "testUser", null, null, null, null, 34, List.of());
+        PlatformUserInfoWrapper wrapper = new PlatformUserInfoWrapper(List.of(expectedResponse));
+
+        when(platformUserCacheService.getPlatformUserInfo(
+                eq(userId),
+                any(Supplier.class)
+        )).thenAnswer(invocation -> {
+            Supplier<PlatformUserInfoResponse> fetcher = invocation.getArgument(1);
+            return fetcher.get();
+        });
+
+        when(platformClient.getPlatformUserInfo(any(), any())).thenReturn(wrapper);
+
+        // when
+        PlatformUserInfoResponse actualResponse = platformService.getPlatformUserInfoResponse(userId);
+
+        // then
+        assertThat(actualResponse).isNotNull();
+        assertThat(actualResponse.name()).isEqualTo(expectedResponse.name());
+        verify(platformClient, times(1)).getPlatformUserInfo(any(), any());
+    }
+
+    @Test
+    @DisplayName("유저 기수 목록 조회 시 PlatformUserInfoResponse의 extractGenerationList를 호출한다")
+    void SUCCESS_getMemberGenerationList_DelegatesToResponse() {
+        // given
+        Long userId = 1L;
+        PlatformUserInfoResponse profile = new PlatformUserInfoResponse(1, "testUser", null, null, null, null, 34, List.of(
+                new PlatformUserInfoResponse.SoptActivities(1, 34, "Server", "Team", true),
+                new PlatformUserInfoResponse.SoptActivities(2, 33, "Server", "Team", true)
+        ));
+        when(platformUserCacheService.getPlatformUserInfo(any(), any())).thenReturn(profile);
+
+        // when
+        List<Long> generations = platformService.getMemberGenerationList(userId);
+
+        // then
+        assertThat(generations).hasSize(2);
+        assertThat(generations.get(0)).isEqualTo(34L);
+        assertThat(generations.get(1)).isEqualTo(33L);
+    }
+}
+

--- a/src/test/java/org/sopt/app/application/platform/PlatformUserCacheServiceTest.java
+++ b/src/test/java/org/sopt/app/application/platform/PlatformUserCacheServiceTest.java
@@ -1,0 +1,80 @@
+package org.sopt.app.application.platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Supplier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+import org.sopt.app.common.cache.CachePolicy;
+import org.sopt.app.common.cache.ResilientCacheTemplate;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformUserCacheServiceTest {
+
+    @Mock
+    private ResilientCacheTemplate resilientCacheTemplate;
+    @Mock
+    private Environment environment;
+
+    private PlatformUserCacheService platformUserCacheService;
+
+    private final Long userId = 1L;
+    private final String expectedKey = "platformUserInfo::1";
+
+    @Test
+    @DisplayName("SUCCESS_플랫폼 유저 정보 조회 시 템플릿으로 위임 확인")
+    void SUCCESS_getPlatformUserInfo_DelegatesToTemplate() {
+        // given
+        when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(false); // 람다 환경이 아님 -> 비동기 처리 활성화
+        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment);
+
+        PlatformUserInfoResponse expectedResponse = new PlatformUserInfoResponse(1, "test", null, null, null, null, 34, null);
+        Supplier<PlatformUserInfoResponse> fetcher = () -> expectedResponse;
+
+        when(resilientCacheTemplate.get(eq(expectedKey), eq(PlatformUserInfoResponse.class), any(CachePolicy.class), eq(fetcher)))
+            .thenReturn(expectedResponse);
+
+        // when
+        PlatformUserInfoResponse result = platformUserCacheService.getPlatformUserInfo(userId, fetcher);
+
+        // then
+        assertThat(result).isEqualTo(expectedResponse);
+
+        ArgumentCaptor<CachePolicy> policyCaptor = ArgumentCaptor.forClass(CachePolicy.class);
+        verify(resilientCacheTemplate).get(eq(expectedKey), eq(PlatformUserInfoResponse.class), policyCaptor.capture(), eq(fetcher));
+
+        CachePolicy capturedPolicy = policyCaptor.getValue();
+        assertThat(capturedPolicy.asyncRefreshEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_람다 프로필일 때 동기 리프레시 설정 확인")
+    void SUCCESS_getPlatformUserInfo_LambdaProfile_SyncRefresh() {
+        // given
+        when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(true); // 람다 환경임 -> 비동기 처리 비활성화
+        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment);
+
+        Supplier<PlatformUserInfoResponse> fetcher = () -> null;
+
+        // when
+        platformUserCacheService.getPlatformUserInfo(userId, fetcher);
+
+        // then
+        ArgumentCaptor<CachePolicy> policyCaptor = ArgumentCaptor.forClass(CachePolicy.class);
+        verify(resilientCacheTemplate).get(eq(expectedKey), eq(PlatformUserInfoResponse.class), policyCaptor.capture(), eq(fetcher));
+
+        CachePolicy capturedPolicy = policyCaptor.getValue();
+        assertThat(capturedPolicy.asyncRefreshEnabled()).isFalse();
+    }
+}

--- a/src/test/java/org/sopt/app/application/playground/PlaygroundPostRefreshServiceTest.java
+++ b/src/test/java/org/sopt/app/application/playground/PlaygroundPostRefreshServiceTest.java
@@ -1,0 +1,117 @@
+package org.sopt.app.application.playground;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.appservice.OperationConfigService;
+import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
+import org.sopt.app.application.playground.dto.PlaygroundRecentPostDto;
+import org.sopt.app.common.config.OperationConfig;
+import org.sopt.app.common.config.OperationConfigCategory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class PlaygroundPostRefreshServiceTest {
+
+    @Mock
+    private PlaygroundAuthService playgroundAuthService;
+    @Mock
+    private PlaygroundPostCacheService playgroundPostCacheService;
+    @Mock
+    private OperationConfigService operationConfigService;
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    @Mock
+    private OperationConfig operationConfig;
+
+    @InjectMocks
+    private PlaygroundPostRefreshService playgroundPostRefreshService;
+
+    @Test
+    @DisplayName("최신 게시글 갱신 - 락 획득 성공 시 캐시 갱신 수행")
+    void SUCCESS_refreshRecentPosts() {
+        // given
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(true);
+        when(operationConfigService.getOperationConfigByOperationConfigType(OperationConfigCategory.PLAYGROUND_POST)).thenReturn(List.of(operationConfig));
+        when(operationConfig.getKey()).thenReturn("자유.imageUrl");
+        when(operationConfig.getValue()).thenReturn("http://image.url");
+
+        PlaygroundRecentPostDto postDto = new PlaygroundRecentPostDto(
+            1L, 1L, "profile", "name", "33,서버", "자유", "제목", "내용", "link", "2024-05-14 00:00:00.000000"
+        );
+        when(playgroundAuthService.getPlaygroundRecentPosts()).thenReturn(List.of(postDto));
+
+        // when
+        playgroundPostRefreshService.refreshRecentPosts();
+
+        // then
+        verify(playgroundAuthService, times(1)).getPlaygroundRecentPosts();
+        verify(playgroundPostCacheService, times(1)).cacheRecentPosts(any());
+    }
+
+    @Test
+    @DisplayName("최신 게시글 갱신 - 락 획득 실패 시 캐시 갱신 미수행")
+    void FAIL_refreshRecentPosts_LockAcquisition() {
+        // given
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(false);
+
+        // when
+        playgroundPostRefreshService.refreshRecentPosts();
+
+        // then
+        verify(playgroundAuthService, never()).getPlaygroundRecentPosts();
+        verify(playgroundPostCacheService, never()).cacheRecentPosts(any());
+    }
+
+    @Test
+    @DisplayName("인기 게시글 갱신 - 락 획득 성공 시 캐시 갱신 수행")
+    void SUCCESS_refreshPopularPosts() {
+        // given
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(true);
+        
+        PlaygroundPopularPost popularPost = new PlaygroundPopularPost(
+            1L, 1L, "profile", "name", "33,서버", 1, "자유", "제목", "내용", "link"
+        );
+        when(playgroundAuthService.getPlaygroundPopularPosts()).thenReturn(List.of(popularPost));
+
+        // when
+        playgroundPostRefreshService.refreshPopularPosts();
+
+        // then
+        verify(playgroundAuthService, times(1)).getPlaygroundPopularPosts();
+        verify(playgroundPostCacheService, times(1)).cachePopularPosts(any());
+    }
+
+    @Test
+    @DisplayName("인기 게시글 갱신 - 락 획득 실패 시 캐시 갱신 미수행")
+    void FAIL_refreshPopularPosts_LockAcquisition() {
+        // given
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(false);
+
+        // when
+        playgroundPostRefreshService.refreshPopularPosts();
+
+        // then
+        verify(playgroundAuthService, never()).getPlaygroundPopularPosts();
+        verify(playgroundPostCacheService, never()).cachePopularPosts(any());
+    }
+}

--- a/src/test/java/org/sopt/app/common/cache/RedisResilientCacheTemplateTest.java
+++ b/src/test/java/org/sopt/app/common/cache/RedisResilientCacheTemplateTest.java
@@ -1,0 +1,328 @@
+package org.sopt.app.common.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.time.Duration;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.common.exception.BaseException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisResilientCacheTemplateTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private ObjectProvider<Executor> executorProvider;
+    @Mock
+    private Executor executor;
+    @Mock
+    private TypeFactory typeFactory;
+    @Mock
+    private JavaType javaType;
+
+    private RedisResilientCacheTemplate cacheTemplate;
+
+    private final String key = "testKey";
+    private final String lockKey = "lock:cache:testKey";
+    private final String markerKey = "refresh_marker:cache:testKey";
+    private final CachePolicy policy = CachePolicy.of(1000L, Duration.ofHours(1), true);
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(objectMapper.getTypeFactory()).thenReturn(typeFactory);
+        lenient().when(typeFactory.constructParametricType(eq(RedisResilientCacheTemplate.CacheWrapper.class), any(Class.class)))
+            .thenReturn(javaType);
+        
+        cacheTemplate = new RedisResilientCacheTemplate(stringRedisTemplate, objectMapper, executorProvider);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_fresh 캐시 히트 시 즉시 데이터 반환")
+    void SUCCESS_get_FreshCacheHit() throws Exception {
+        // given
+        String cachedJson = "{\"data\":\"value\",\"requestedAt\":" + System.currentTimeMillis() + "}";
+        when(valueOperations.get(key)).thenReturn(cachedJson);
+        
+        RedisResilientCacheTemplate.CacheWrapper<String> wrapper = new RedisResilientCacheTemplate.CacheWrapper<>("value", System.currentTimeMillis());
+        when(objectMapper.readValue(eq(cachedJson), eq(javaType))).thenReturn(wrapper);
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched");
+
+        // then
+        assertThat(result).isEqualTo("value");
+        verify(valueOperations, never()).setIfAbsent(anyString(), anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_오래된 캐시 히트 시 데이터 반환 및 비동기 갱신 수행")
+    void SUCCESS_get_StaleHit_AsyncRefresh() throws Exception {
+        // given
+        // 논리적 TTL이 만료된 데이터를 반환하고, 백그라운드에서 갱신 작업을 예약함
+        long staleTime = System.currentTimeMillis() - 2000L; // 정책의 논리적 TTL은 1000ms
+        String cachedJson = "{\"data\":\"stale\",\"requestedAt\":" + staleTime + "}";
+        when(valueOperations.get(key)).thenReturn(cachedJson);
+        
+        RedisResilientCacheTemplate.CacheWrapper<String> wrapper = new RedisResilientCacheTemplate.CacheWrapper<>("stale", staleTime);
+        when(objectMapper.readValue(eq(cachedJson), eq(javaType))).thenReturn(wrapper);
+        
+        when(valueOperations.setIfAbsent(eq(markerKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(executorProvider.getIfAvailable()).thenReturn(executor);
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched");
+
+        // then
+        assertThat(result).isEqualTo("stale");
+        verify(executor).execute(any(Runnable.class));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_캐시 미스 시 락을 획득하고 데이터를 직접 조회")
+    void SUCCESS_get_CacheMiss_BlockingGet() throws Exception {
+        // given
+        when(valueOperations.get(key)).thenReturn(null);
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(objectMapper.writeValueAsString(any())).thenReturn("new-json");
+
+        Supplier<String> fetcher = () -> "fetched";
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, fetcher);
+
+        // then
+        assertThat(result).isEqualTo("fetched");
+        verify(valueOperations).set(eq(key), eq("new-json"), eq(policy.physicalTtl()));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_락 획득 타임아웃 발생 시 오래된 데이터라도 반환")
+    void SUCCESS_get_Timeout_ReturnStale() throws Exception {
+        // given
+        // 락 획득에 실패하더라도 캐시에 데이터가 있다면 최악의 상황을 피해 오래된 데이터라도 반환함
+        long staleTime = System.currentTimeMillis() - 2000L;
+        String cachedJson = "{\"data\":\"stale\",\"requestedAt\":" + staleTime + "}";
+        
+        // 초기 확인 시 오래된 데이터 반환
+        // 루프 확인 시 오래된 데이터 반환
+        when(valueOperations.get(key)).thenReturn(cachedJson);
+        
+        RedisResilientCacheTemplate.CacheWrapper<String> wrapper = new RedisResilientCacheTemplate.CacheWrapper<>("stale", staleTime);
+        when(objectMapper.readValue(eq(cachedJson), eq(javaType))).thenReturn(wrapper);
+        
+        // 락 획득 항상 실패
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(false);
+
+        CachePolicy shortWaitPolicy = new CachePolicy(1000L, Duration.ofHours(1), false, Duration.ofSeconds(10), Duration.ofMillis(200));
+
+        // when
+        String result = cacheTemplate.get(key, String.class, shortWaitPolicy, () -> "fetched");
+
+        // then
+        assertThat(result).isEqualTo("stale");
+        verify(valueOperations, atLeastOnce()).setIfAbsent(eq(lockKey), anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("FAIL_락 획득 타임아웃 및 캐시 데이터 부재 시 예외 발생")
+    void FAIL_get_Timeout_NoStale_ThrowException() throws Exception {
+        // given
+        when(valueOperations.get(key)).thenReturn(null);
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(false);
+
+        CachePolicy shortWaitPolicy = new CachePolicy(1000L, Duration.ofHours(1), false, Duration.ofSeconds(10), Duration.ofMillis(100));
+
+        // when & then
+        assertThatThrownBy(() -> cacheTemplate.get(key, String.class, shortWaitPolicy, () -> "fetched"))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("락 획득 시간 초과");
+    }
+
+    @Test
+    @DisplayName("SUCCESS_역직렬화 실패 시 캐시 미스로 간주하고 데이터 재조회")
+    void SUCCESS_get_DeserializationFailure_TreatAsMiss() throws Exception {
+        // given
+        // 캐시 데이터가 오염되었을 경우 예외를 던지는 대신 미스로 처리하여 자가 치유함
+        when(valueOperations.get(key)).thenReturn("corrupted");
+        when(objectMapper.readValue(anyString(), eq(javaType))).thenThrow(new RuntimeException("Jackson error"));
+        
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(objectMapper.writeValueAsString(any())).thenReturn("new-json");
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched");
+
+        // then
+        assertThat(result).isEqualTo("fetched");
+        verify(valueOperations).set(eq(key), eq("new-json"), eq(policy.physicalTtl()));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_블로킹 조회 중 다른 스레드가 캐시를 채우면 해당 데이터 반환")
+    void SUCCESS_get_BlockingGet_DoubleCheck() throws Exception {
+        // given
+        // 락을 획득한 직후 캐시를 다시 확인(Double-check)하여 중복 조회를 방지함
+        when(valueOperations.get(key)).thenReturn(null); // 초기 확인
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        
+        // 락 획득 후, 다른 확인에서 신선한 데이터 반환
+        long freshTime = System.currentTimeMillis();
+        String freshJson = "{\"data\":\"fresh\",\"requestedAt\":" + freshTime + "}";
+        RedisResilientCacheTemplate.CacheWrapper<String> freshWrapper = new RedisResilientCacheTemplate.CacheWrapper<>("fresh", freshTime);
+        
+        when(valueOperations.get(key))
+            .thenReturn(null) // get() 내 readCache
+            .thenReturn(null) // blockingGet() 루프 내 readCache
+            .thenReturn(freshJson); // 락 획득 후 blockingGet() 내 readCache
+            
+        when(objectMapper.readValue(eq(freshJson), eq(javaType))).thenReturn(freshWrapper);
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched");
+
+        // then
+        assertThat(result).isEqualTo("fresh");
+        verify(valueOperations, never()).set(eq(key), anyString(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_비동기 갱신 중 이미 캐시가 갱신되었다면 작업 종료")
+    void SUCCESS_dispatchAsyncRefresh_DoubleCheck_Fresh_Exit() throws Exception {
+        // given
+        long staleTime = System.currentTimeMillis() - 2000L;
+        RedisResilientCacheTemplate.CacheWrapper<String> staleWrapper = new RedisResilientCacheTemplate.CacheWrapper<>("stale", staleTime);
+        when(valueOperations.get(key)).thenReturn("stale-json");
+        when(objectMapper.readValue(eq("stale-json"), eq(javaType))).thenReturn(staleWrapper);
+        
+        when(valueOperations.setIfAbsent(eq(markerKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(executorProvider.getIfAvailable()).thenReturn(executor);
+        
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        cacheTemplate.get(key, String.class, policy, () -> "fetched");
+        
+        verify(executor).execute(runnableCaptor.capture());
+        Runnable asyncTask = runnableCaptor.getValue();
+
+        // 비동기 작업을 위한 락 획득 성공 모킹
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        
+        // 비동기 작업 중 더블 체크 시 신선한 캐시 모킹
+        long freshTime = System.currentTimeMillis();
+        RedisResilientCacheTemplate.CacheWrapper<String> freshWrapper = new RedisResilientCacheTemplate.CacheWrapper<>("fresh", freshTime);
+        when(valueOperations.get(key)).thenReturn("fresh-json");
+        when(objectMapper.readValue(eq("fresh-json"), eq(javaType))).thenReturn(freshWrapper);
+
+        Supplier<String> fetcher = mock(Supplier.class);
+
+        // when
+        asyncTask.run();
+
+        // then
+        verify(fetcher, never()).get();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_이미 갱신 마커가 존재하면 비동기 갱신 요청 무시")
+    void SUCCESS_dispatchAsyncRefresh_MarkerExists_Exit() throws Exception {
+        // given
+        long staleTime = System.currentTimeMillis() - 2000L;
+        RedisResilientCacheTemplate.CacheWrapper<String> staleWrapper = new RedisResilientCacheTemplate.CacheWrapper<>("stale", staleTime);
+        when(valueOperations.get(key)).thenReturn("stale-json");
+        when(objectMapper.readValue(eq("stale-json"), eq(javaType))).thenReturn(staleWrapper);
+        
+        // 마커 획득 실패
+        when(valueOperations.setIfAbsent(eq(markerKey), anyString(), any(Duration.class))).thenReturn(false);
+
+        // when
+        cacheTemplate.get(key, String.class, policy, () -> "fetched");
+
+        // then
+        verify(executorProvider, never()).getIfAvailable();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_비동기 갱신 중 락 획득 실패 시 작업 종료")
+    void SUCCESS_dispatchAsyncRefresh_LockContention_Exit() throws Exception {
+        // given
+        long staleTime = System.currentTimeMillis() - 2000L;
+        RedisResilientCacheTemplate.CacheWrapper<String> staleWrapper = new RedisResilientCacheTemplate.CacheWrapper<>("stale", staleTime);
+        when(valueOperations.get(key)).thenReturn("stale-json");
+        when(objectMapper.readValue(eq("stale-json"), eq(javaType))).thenReturn(staleWrapper);
+        
+        when(valueOperations.setIfAbsent(eq(markerKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(executorProvider.getIfAvailable()).thenReturn(executor);
+        
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        cacheTemplate.get(key, String.class, policy, () -> "fetched");
+        
+        verify(executor).execute(runnableCaptor.capture());
+        Runnable asyncTask = runnableCaptor.getValue();
+
+        // 비동기 작업을 위한 락 획득 실패 모킹
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(false);
+
+        Supplier<String> fetcher = mock(Supplier.class);
+
+        // when
+        asyncTask.run();
+
+        // then
+        verify(fetcher, never()).get();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_데이터 저장 전 최신 데이터 존재 여부를 확인하여 덮어쓰기 방지")
+    void SUCCESS_fetchAndCache_Fencing_PreventStaleOverwrite() throws Exception {
+        // given
+        // Java 레벨의 펜싱(Fencing) 메커니즘을 통해 더 최신 데이터가 이미 캐시에 있다면 덮어쓰지 않음
+        when(valueOperations.get(key)).thenReturn(null);
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        
+        // fetchAndCache 중 Redis 다시 확인
+        long newerTime = System.currentTimeMillis() + 1000L;
+        RedisResilientCacheTemplate.CacheWrapper<String> newerWrapper = new RedisResilientCacheTemplate.CacheWrapper<>("newer", newerTime);
+        when(valueOperations.get(key))
+            .thenReturn(null) // get() 내 readCache
+            .thenReturn(null) // blockingGet() 루프 내 readCache
+            .thenReturn(null) // 락 획득 후 blockingGet() 내 readCache
+            .thenReturn("newer-json"); // fetchAndCache() 펜싱 체크 내 readCache
+            
+        when(objectMapper.readValue(eq("newer-json"), eq(javaType))).thenReturn(newerWrapper);
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched");
+
+        // then
+        assertThat(result).isEqualTo("fetched");
+        verify(valueOperations, never()).set(eq(key), anyString(), any(Duration.class));
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #748

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 작업 목표
  - 응답 속도 향상 
  - 인증 서버로의 부하 감소 
  - 인증 서버와의 결합도 낮추기


- 트래픽 스파이크 시 동일 유저에 대한 중복 인증 요청이 급증하여 원본 서버에 심각한 병목 발생.
- 캐시 만료 시 수많은 요청이 동시에 DB를 찌르는 Cache Stampede 위험성 존재.

### 핵심 구현 사항 

1. **Logical/Physical TTL 분리 및 비동기 갱신 (가용성 극대화)**
    - 논리적 만료가 지나도 물리적 만료 전이라면, 기존 데이터를 사용자에게 즉시 반환함
    - 사용자는 지연을 겪지 않고, 캐시 갱신은 백그라운드 스레드에서 조용히 처리됨
2. **분산 락 & Jitter (스파이크 방어)**
    - Redis 락을 통해 단 1개의 스레드만 외부 API를 호출하도록 통제
    - 락 획득 대기 시간에 Jitter(무작위 지연, 50~100ms)를 부여해, 대기 스레드들이 동시에 깨어나 Redis에 요청을 보내는 것을 방지
3. **TOCTOU 방어**
    - 느린 요청이 뒤늦게 끝나 최신 캐시를 과거 데이터로 덮어쓰는 동시성 이슈를 막기 위해, 호출 시간 기준으로 업데이트 여부 결정
4. **Lambda 환경 맞춤형 자동 스위칭**
    - DEV 환경에서 운용 중인 AWS Lambda 특성을 고려하여, 람다 환경에서는 비동기 갱신을 끄고 안전한 블로킹 방식으로 동작하도록 설계

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->