### PR TITLE
[Feat] #747: upsertSoptampUser를 admin API로 분리

### DIFF
--- a/src/main/java/org/sopt/app/application/platform/PlatformService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformService.java
@@ -99,6 +99,19 @@ public class PlatformService {
         return data;
     }
 
+    public Map<Long, PlatformUserInfoResponse> getPlatformUserInfosAsMap(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<PlatformUserInfoResponse> profiles = getPlatformUserInfosResponseSmart(userIds);
+        Map<Long, PlatformUserInfoResponse> profileMap = profiles.stream()
+            .collect(Collectors.toMap(p -> (long) p.userId(), p -> p));
+        if (!profileMap.keySet().containsAll(userIds)) {
+            throw new BadRequestException(ErrorCode.PLATFORM_USER_NOT_EXISTS);
+        }
+        return profileMap;
+    }
+
     public UserStatus getStatus(Long userId) {
         return getStatus(getPlatformUserInfoResponse(userId));
     }

--- a/src/main/java/org/sopt/app/application/platform/PlatformService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformService.java
@@ -107,6 +107,10 @@ public class PlatformService {
         Map<Long, PlatformUserInfoResponse> profileMap = profiles.stream()
             .collect(Collectors.toMap(p -> (long) p.userId(), p -> p));
         if (!profileMap.keySet().containsAll(userIds)) {
+            List<Long> missingIds = userIds.stream()
+                .filter(id -> !profileMap.containsKey(id))
+                .toList();
+            log.warn("Platform user not found for ids: {}", missingIds);
             throw new BadRequestException(ErrorCode.PLATFORM_USER_NOT_EXISTS);
         }
         return profileMap;

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -4,6 +4,7 @@ import static org.sopt.app.domain.entity.soptamp.SoptampUser.createNewSoptampUse
 import static org.sopt.app.domain.enums.SoptPart.findSoptPartByPartName;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
@@ -12,17 +13,16 @@ import org.sopt.app.application.soptamp.SoptampEvent.SoptampUserAllCacheSyncEven
 import org.sopt.app.application.soptamp.SoptampEvent.SoptampUserProfileCacheSyncEvent;
 import org.sopt.app.application.soptamp.SoptampEvent.SoptampUserScoreCacheSyncEvent;
 import org.sopt.app.application.user.UserWithdrawEvent;
-import org.sopt.app.common.config.AsyncConfig;
 import org.sopt.app.common.event.EventPublisher;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
+import org.sopt.app.domain.entity.AppjamUser;
 import org.sopt.app.domain.entity.soptamp.SoptampUser;
 import org.sopt.app.domain.enums.SoptPart;
 import org.sopt.app.interfaces.postgres.AppjamUserRepository;
 import org.sopt.app.interfaces.postgres.SoptampUserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,19 +61,26 @@ public class SoptampUserService {
 
     /* ==================== upsert 진입점 ==================== */
 
+    @Transactional(readOnly = true)
+    public List<Long> getUpsertTargetUserIds() {
+        return appjamMode
+            ? appjamUserRepository.findAll().stream().map(AppjamUser::getUserId).toList()
+            : soptampUserRepository.findAll().stream().map(SoptampUser::getUserId).toList();
+    }
+
+    @Transactional
+    public void upsertAllSoptampUsers(Map<Long, PlatformUserInfoResponse> profileMap) {
+        profileMap.forEach((userId, profile) -> upsertSoptampUser(profile, userId));
+    }
+
     // 앱잼 시즌 여부에 따라 upsert 로직 분기
-    @Async(AsyncConfig.CACHE_SYNC_EXECUTOR)
     @Transactional
     public void upsertSoptampUser(PlatformUserInfoResponse profile, Long userId) {
         if (profile == null)
             return;
 
         if (appjamMode) {
-            var latest = profile.getLatestActivity();
-            if (latest == null) {
-                return;
-            }
-            upsertSoptampUserForAppjam(profile, userId, latest);
+            upsertSoptampUserForAppjam(profile, userId, profile.getLatestActivity());
         } else {
             var latestSopt = profile.getLatestSoptActivity();
             if (latestSopt == null) {
@@ -153,7 +160,7 @@ public class SoptampUserService {
 
         String uniqueNickname = generateUniqueNicknameInternal(baseNickname, userId);
 
-        String part = latest.part() == null ? "미상" : latest.part();
+        String part = (latest == null || latest.part() == null) ? "미상" : latest.part();
         // 앱잼 시즌: 파트, Makers 무관 buildAppjamBaseNickname이 자연스럽게 처리
         registeredUser.updateChangedGenerationInfo(
                 (long) profile.lastGeneration(),
@@ -178,7 +185,7 @@ public class SoptampUserService {
                 null
             );
 
-        String part = latest.part() == null ? "미상" : latest.part();
+        String part = (latest == null || latest.part() == null) ? "미상" : latest.part();
 
         SoptampUser newSoptampUser = createNewSoptampUser(
                 userId,

--- a/src/main/java/org/sopt/app/facade/AdminSoptampFacade.java
+++ b/src/main/java/org/sopt/app/facade/AdminSoptampFacade.java
@@ -1,6 +1,10 @@
 package org.sopt.app.facade;
 
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.platform.PlatformService;
+import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
 import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.application.stamp.ClapService;
 import org.sopt.app.application.stamp.StampService;
@@ -16,6 +20,7 @@ public class AdminSoptampFacade {
     private final SoptampUserService soptampUserService;
     private final ClapService clapService;
     private final ClapMilestoneGuard clapMilestoneGuard;
+    private final PlatformService platformService;
 
     @Transactional
     public void clearSoptampData(boolean stamp, boolean soptampUser) {
@@ -37,5 +42,11 @@ public class AdminSoptampFacade {
     @Transactional
     public void initRankCache() {
         soptampUserService.initSoptampRankCache();
+    }
+
+    public void upsertAllSoptampUsers() {
+        List<Long> targetUserIds = soptampUserService.getUpsertTargetUserIds();
+        Map<Long, PlatformUserInfoResponse> profileMap = platformService.getPlatformUserInfosAsMap(targetUserIds);
+        soptampUserService.upsertAllSoptampUsers(profileMap);
     }
 }

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -25,7 +25,6 @@ import org.sopt.app.application.playground.PlaygroundPopularPostRefreshEvent;
 import org.sopt.app.application.playground.PlaygroundRecentPostRefreshEvent;
 import org.sopt.app.application.playground.dto.PlaygroundPopularPost;
 import org.sopt.app.application.playground.dto.PlaygroundRecentPost;
-import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.common.config.OperationConfig;
 import org.sopt.app.common.config.OperationConfigCategory;
 import org.sopt.app.common.event.EventPublisher;
@@ -49,7 +48,6 @@ public class HomeFacade {
     private final MeetingService meetingService;
     private final OperationConfigService operationConfigService;
     private final PlatformService platformService;
-    private final SoptampUserService soptampUserService;
     private final EventPublisher eventPublisher;
 
     // TODO : deprecated 된것으로 인지
@@ -74,10 +72,8 @@ public class HomeFacade {
         if(userId == null){
             return this.getOnlyAppServiceInfo();
         }
-        // TODO : 추후 유저 생성 api response 변경해 생성 api 쪽에서 soptamp user upsert 하도록 변경
         PlatformUserInfoResponse platformUserInfo = platformService.getPlatformUserInfoResponse(userId);
         UserStatus status = platformService.getStatus(platformUserInfo);
-        soptampUserService.upsertSoptampUser(platformUserInfo, userId);
 
         List<CompletableFuture<AppServiceEntryStatusResponse>> futures = appServiceService.getAllAppService().stream()
             .filter(appServiceInfo -> isServiceVisibleToUser(appServiceInfo, status))

--- a/src/main/java/org/sopt/app/presentation/admin/AdminSoptampController.java
+++ b/src/main/java/org/sopt/app/presentation/admin/AdminSoptampController.java
@@ -12,6 +12,7 @@ import org.sopt.app.facade.AdminSoptampFacade;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -71,6 +72,21 @@ public class AdminSoptampController {
     ) {
         validateAdmin(password);
         adminSoptampFacade.initRankCache();
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "솝탬프 유저 일괄 upsert")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "401", description = "token error", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @PostMapping("/upsert")
+    public ResponseEntity<Void> upsertAllSoptampUsers(
+        @RequestParam(name = "password") String password
+    ) {
+        validateAdmin(password);
+        adminSoptampFacade.upsertAllSoptampUsers();
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closes #747

## Work Description ✏️

- `HomeFacade.checkAppServiceEntryStatus`에서 `upsertSoptampUser` 호출 제거
- `POST /api/v2/admin/soptamp/upsert` 어드민 API 추가
  - appjamMode=true: AppjamUser 기준 (OB 포함 앱잼 참여자 전원)
  - appjamMode=false: 기존 SoptampUser 기준 (기수 변경 마이그레이션)
- 외부 API 호출(플랫폼 배치 1회)과 DB 작업(단일 트랜잭션)을 분리해 원자성 보장
- 앱잼 시즌 OB 유저 `getLatestActivity() == null`이어도 SoptampUser 생성/마이그레이션 되도록 수정
- `@Async` 제거 (홈 API 레이지 트리거 방식 → 어드민 배치 방식으로 전환)

## Related ScreenShot 📷

N/A

## To Reviewers 📢

기존 코드에서 appjam 모드일 때 `getLatestActivity()`가 null이면 early return 하고 있었는데,

```java
var latest = profile.getLatestActivity();
if (latest == null) {
    return;  // 기존 코드
}
```

`latest`는 실제로 `part` 추출에만 쓰이고, null이면 어차피 `"미상"` fallback 처리가 되기 때문에 early return이 불필요하다고 판단해서 제거했습니다.

OB 유저처럼 `getLatestActivity()`가 null일 수 있는 케이스에서도 SoptampUser가 정상 생성/마이그레이션 되어야한다고 생각해서 이렇게 진행하였는데, 제가 히스토리 체크가 미흡했던 부분이 있을 것같아 혹시 이 null 체크가 의도적으로 있던 건지(ex. 활동 이력 없는 유저는 의도적으로 제외하려 했던 것인지) 확인해주시면 좋을 것같습니다 🙇‍♀️