### PR TITLE
[Feat] #754: 솝탬프 upsert 배치 처리로 전환

### DIFF
--- a/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
+++ b/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
@@ -36,16 +36,12 @@ public class OperationConfigService {
 
     @Transactional
     public void updateSoptampBatchConfig(String cron) {
-        upsertConfig(SOPTAMP_UPSERT_CRON_KEY, cron, "솝탬프 upsert 배치 실행 cron 표현식");
-    }
-
-    private void upsertConfig(String key, String value, String description) {
         operationConfigRepository
-            .findByOperationConfigCategoryAndKey(OperationConfigCategory.SOPTAMP_BATCH, key)
+            .findByOperationConfigCategoryAndKey(OperationConfigCategory.SOPTAMP_BATCH, SOPTAMP_UPSERT_CRON_KEY)
             .ifPresentOrElse(
-                config -> config.updateValue(value),
+                config -> config.updateValue(cron),
                 () -> operationConfigRepository.save(
-                    OperationConfig.of(OperationConfigCategory.SOPTAMP_BATCH, key, value, description))
+                    OperationConfig.of(OperationConfigCategory.SOPTAMP_BATCH, SOPTAMP_UPSERT_CRON_KEY, cron, "솝탬프 upsert 배치 실행 cron 표현식"))
             );
     }
 }

--- a/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
+++ b/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
@@ -15,11 +15,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OperationConfigService {
 
+    private static final String SOPTAMP_UPSERT_CRON_KEY = "UPSERT_CRON";
+    private static final String DEFAULT_UPSERT_CRON = "0 0 3 * * *";
+
     private final OperationConfigRepository operationConfigRepository;
 
     @Transactional(readOnly = true)
     public List<OperationConfig> getOperationConfigByOperationConfigType(OperationConfigCategory operationConfigCategory) {
         return operationConfigRepository.findByOperationConfigCategory(operationConfigCategory).orElseThrow(
                 () -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public String getSoptampUpsertCron() {
+        return operationConfigRepository
+            .findByOperationConfigCategoryAndKey(OperationConfigCategory.SOPTAMP_BATCH, SOPTAMP_UPSERT_CRON_KEY)
+            .map(OperationConfig::getValue)
+            .orElse(DEFAULT_UPSERT_CRON);
+    }
+
+    @Transactional
+    public void updateSoptampBatchConfig(String cron) {
+        upsertConfig(SOPTAMP_UPSERT_CRON_KEY, cron, "솝탬프 upsert 배치 실행 cron 표현식");
+    }
+
+    private void upsertConfig(String key, String value, String description) {
+        operationConfigRepository
+            .findByOperationConfigCategoryAndKey(OperationConfigCategory.SOPTAMP_BATCH, key)
+            .ifPresentOrElse(
+                config -> config.updateValue(value),
+                () -> operationConfigRepository.save(
+                    OperationConfig.of(OperationConfigCategory.SOPTAMP_BATCH, key, value, description))
+            );
     }
 }

--- a/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
+++ b/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class OperationConfigService {
 
     private static final String SOPTAMP_UPSERT_CRON_KEY = "UPSERT_CRON";
-    private static final String DEFAULT_UPSERT_CRON = "0 0 3 * * *";
+    private static final String DEFAULT_UPSERT_CRON = "0 0 3 * * *"; // 기본값: 매일 새벽 3시
 
     private final OperationConfigRepository operationConfigRepository;
 

--- a/src/main/java/org/sopt/app/application/soptamp/AuthSoptPartMapper.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthSoptPartMapper.java
@@ -1,0 +1,62 @@
+package org.sopt.app.application.soptamp;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.sopt.app.domain.enums.SoptPart;
+
+/**
+ * auth DB의 part/role/team 코드값을 앱 도메인의 SoptPart 이름으로 변환한다.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class AuthSoptPartMapper {
+
+    static String toSoptPartName(String partCode, String roleCode, String teamCode) {
+        if (roleCode == null) {
+            return toBasePartName(partCode);
+        }
+        return switch (roleCode) {
+            case "PRESIDENT" -> SoptPart.PRESIDENT.getPartName();
+            case "VICE_PRESIDENT" -> SoptPart.VICE_PRESIDENT.getPartName();
+            case "GENERAL_AFFAIRS" -> SoptPart.GENERAL_AFFAIR.getPartName();
+            case "ART_DIRECTOR" -> SoptPart.ART_DIRECTOR.getPartName();
+            case "TEAM_LEADER" -> toTeamLeaderPartName(teamCode);
+            case "PART_LEADER" -> toPartLeaderPartName(partCode);
+            default -> toBasePartName(partCode);
+        };
+    }
+
+    private static String toTeamLeaderPartName(String teamCode) {
+        if (teamCode == null) {
+            return SoptPart.NONE.getPartName();
+        }
+        return switch (teamCode) {
+            case "MAKERS" -> SoptPart.MAKERS_TEAM_LEADER.getPartName();
+            case "MEDIA" -> SoptPart.MEDIA_TEAM_LEADER.getPartName();
+            case "OPERATION" -> SoptPart.OPERATIONS_TEAM_LEADER.getPartName();
+            default -> SoptPart.NONE.getPartName();
+        };
+    }
+
+    private static String toPartLeaderPartName(String partCode) {
+        if (partCode == null) {
+            return SoptPart.NONE.getPartName();
+        }
+        return switch (partCode) {
+            case "PLAN" -> SoptPart.PLAN_PART_LEADER.getPartName();
+            case "DESIGN" -> SoptPart.DESIGN_PART_LEADER.getPartName();
+            case "ANDROID" -> SoptPart.ANDROID_PART_LEADER.getPartName();
+            case "IOS" -> SoptPart.IOS_PART_LEADER.getPartName();
+            case "WEB" -> SoptPart.WEB_PART_LEADER.getPartName();
+            case "SERVER" -> SoptPart.SERVER_PART_LEADER.getPartName();
+            default -> toBasePartName(partCode);
+        };
+    }
+
+    private static String toBasePartName(String partCode) {
+        try {
+            return SoptPart.valueOf(partCode).getPartName();
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return SoptPart.NONE.getPartName();
+        }
+    }
+}

--- a/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
-import org.sopt.app.domain.enums.SoptPart;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -21,6 +20,9 @@ public class AuthUserProfileReader {
     @Value("${makers.auth.schema}")
     private String authSchema;
 
+    /**
+     * auth DB에서 전체 유저 프로필 조회 (앱잼 시즌용 — OB 포함 전체 대상)
+     */
     public Map<Long, PlatformUserInfoResponse> getAllUserProfiles() {
         String sql = """
                 SELECT u.id AS user_id,
@@ -53,9 +55,13 @@ public class AuthUserProfileReader {
             ));
             activitiesMap.computeIfAbsent(userId, k -> new ArrayList<>())
                 .add(new PlatformUserInfoResponse.SoptActivities(
-                    0,
+                    0, // activityId — 배치 upsert에서 미사용
                     rs.getInt("generation"),
-                    toSoptPartName(rs.getString("part"), rs.getString("role"), rs.getString("team")),
+                    AuthSoptPartMapper.toSoptPartName(
+                        rs.getString("part"),
+                        rs.getString("role"),
+                        rs.getString("team")
+                    ),
                     rs.getString("team"),
                     rs.getBoolean("is_sopt")
                 ));
@@ -84,56 +90,6 @@ public class AuthUserProfileReader {
             lastGeneration,
             activities
         );
-    }
-
-    private String toSoptPartName(String partCode, String roleCode, String teamCode) {
-        if (roleCode == null) {
-            return toBasePartName(partCode);
-        }
-        return switch (roleCode) {
-            case "PRESIDENT" -> SoptPart.PRESIDENT.getPartName();
-            case "VICE_PRESIDENT" -> SoptPart.VICE_PRESIDENT.getPartName();
-            case "GENERAL_AFFAIRS" -> SoptPart.GENERAL_AFFAIR.getPartName();
-            case "ART_DIRECTOR" -> SoptPart.ART_DIRECTOR.getPartName();
-            case "TEAM_LEADER" -> toTeamLeaderPartName(teamCode);
-            case "PART_LEADER" -> toPartLeaderPartName(partCode);
-            default -> toBasePartName(partCode);
-        };
-    }
-
-    private String toTeamLeaderPartName(String teamCode) {
-        if (teamCode == null) {
-            return SoptPart.NONE.getPartName();
-        }
-        return switch (teamCode) {
-            case "MAKERS" -> SoptPart.MAKERS_TEAM_LEADER.getPartName();
-            case "MEDIA" -> SoptPart.MEDIA_TEAM_LEADER.getPartName();
-            case "OPERATION" -> SoptPart.OPERATIONS_TEAM_LEADER.getPartName();
-            default -> SoptPart.NONE.getPartName();
-        };
-    }
-
-    private String toPartLeaderPartName(String partCode) {
-        if (partCode == null) {
-            return SoptPart.NONE.getPartName();
-        }
-        return switch (partCode) {
-            case "PLAN" -> SoptPart.PLAN_PART_LEADER.getPartName();
-            case "DESIGN" -> SoptPart.DESIGN_PART_LEADER.getPartName();
-            case "ANDROID" -> SoptPart.ANDROID_PART_LEADER.getPartName();
-            case "IOS" -> SoptPart.IOS_PART_LEADER.getPartName();
-            case "WEB" -> SoptPart.WEB_PART_LEADER.getPartName();
-            case "SERVER" -> SoptPart.SERVER_PART_LEADER.getPartName();
-            default -> toBasePartName(partCode);
-        };
-    }
-
-    private String toBasePartName(String partCode) {
-        try {
-            return SoptPart.valueOf(partCode).getPartName();
-        } catch (IllegalArgumentException | NullPointerException e) {
-            return SoptPart.NONE.getPartName();
-        }
     }
 
     private record AuthUserProfile(

--- a/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
@@ -38,7 +38,6 @@ public class AuthUserProfileReader {
                        uah.team
                 FROM %s.users u
                 JOIN %s.user_activity_histories uah ON uah.user_id = u.id
-                ORDER BY u.id, uah.generation
                 """.formatted(authSchema, authSchema);
 
         Map<Long, AuthUserProfile> profileMap = new HashMap<>();

--- a/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
@@ -1,0 +1,147 @@
+package org.sopt.app.application.soptamp;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+import org.sopt.app.domain.enums.SoptPart;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserProfileReader {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Value("${makers.auth.schema}")
+    private String authSchema;
+
+    public Map<Long, PlatformUserInfoResponse> getAllUserProfiles() {
+        String sql = """
+                SELECT u.id AS user_id,
+                       u.name,
+                       u.profile_image,
+                       u.birthday,
+                       u.phone,
+                       u.email,
+                       uah.generation,
+                       uah.part,
+                       uah.role,
+                       uah.is_sopt,
+                       uah.team
+                FROM %s.users u
+                JOIN %s.user_activity_histories uah ON uah.user_id = u.id
+                ORDER BY u.id, uah.generation, uah.is_sopt DESC
+                """.formatted(authSchema, authSchema);
+
+        Map<Long, AuthUserProfile> profileMap = new HashMap<>();
+        Map<Long, List<PlatformUserInfoResponse.SoptActivities>> activitiesMap = new HashMap<>();
+
+        jdbcTemplate.query(sql, rs -> {
+            long userId = rs.getLong("user_id");
+            profileMap.putIfAbsent(userId, new AuthUserProfile(
+                rs.getString("name"),
+                rs.getString("profile_image"),
+                rs.getString("birthday"),
+                rs.getString("phone"),
+                rs.getString("email")
+            ));
+            activitiesMap.computeIfAbsent(userId, k -> new ArrayList<>())
+                .add(new PlatformUserInfoResponse.SoptActivities(
+                    0,
+                    rs.getInt("generation"),
+                    toSoptPartName(rs.getString("part"), rs.getString("role"), rs.getString("team")),
+                    rs.getString("team"),
+                    rs.getBoolean("is_sopt")
+                ));
+        });
+
+        return activitiesMap.entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> buildProfile(e.getKey(), profileMap.get(e.getKey()), e.getValue())
+            ));
+    }
+
+    private PlatformUserInfoResponse buildProfile(long userId, AuthUserProfile profile,
+            List<PlatformUserInfoResponse.SoptActivities> activities) {
+        int lastGeneration = activities.stream()
+            .mapToInt(PlatformUserInfoResponse.SoptActivities::generation)
+            .max()
+            .orElse(0);
+        return new PlatformUserInfoResponse(
+            (int) userId,
+            profile.name(),
+            profile.profileImage(),
+            profile.birthday(),
+            profile.phone(),
+            profile.email(),
+            lastGeneration,
+            activities
+        );
+    }
+
+    private String toSoptPartName(String partCode, String roleCode, String teamCode) {
+        if (roleCode == null) {
+            return toBasePartName(partCode);
+        }
+        return switch (roleCode) {
+            case "PRESIDENT" -> SoptPart.PRESIDENT.getPartName();
+            case "VICE_PRESIDENT" -> SoptPart.VICE_PRESIDENT.getPartName();
+            case "GENERAL_AFFAIRS" -> SoptPart.GENERAL_AFFAIR.getPartName();
+            case "ART_DIRECTOR" -> SoptPart.ART_DIRECTOR.getPartName();
+            case "TEAM_LEADER" -> toTeamLeaderPartName(teamCode);
+            case "PART_LEADER" -> toPartLeaderPartName(partCode);
+            default -> toBasePartName(partCode);
+        };
+    }
+
+    private String toTeamLeaderPartName(String teamCode) {
+        if (teamCode == null) {
+            return SoptPart.NONE.getPartName();
+        }
+        return switch (teamCode) {
+            case "MAKERS" -> SoptPart.MAKERS_TEAM_LEADER.getPartName();
+            case "MEDIA" -> SoptPart.MEDIA_TEAM_LEADER.getPartName();
+            case "OPERATION" -> SoptPart.OPERATIONS_TEAM_LEADER.getPartName();
+            default -> SoptPart.NONE.getPartName();
+        };
+    }
+
+    private String toPartLeaderPartName(String partCode) {
+        if (partCode == null) {
+            return SoptPart.NONE.getPartName();
+        }
+        return switch (partCode) {
+            case "PLAN" -> SoptPart.PLAN_PART_LEADER.getPartName();
+            case "DESIGN" -> SoptPart.DESIGN_PART_LEADER.getPartName();
+            case "ANDROID" -> SoptPart.ANDROID_PART_LEADER.getPartName();
+            case "IOS" -> SoptPart.IOS_PART_LEADER.getPartName();
+            case "WEB" -> SoptPart.WEB_PART_LEADER.getPartName();
+            case "SERVER" -> SoptPart.SERVER_PART_LEADER.getPartName();
+            default -> toBasePartName(partCode);
+        };
+    }
+
+    private String toBasePartName(String partCode) {
+        try {
+            return SoptPart.valueOf(partCode).getPartName();
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return SoptPart.NONE.getPartName();
+        }
+    }
+
+    private record AuthUserProfile(
+        String name,
+        String profileImage,
+        String birthday,
+        String phone,
+        String email
+    ) {
+    }
+}

--- a/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
@@ -1,10 +1,12 @@
 package org.sopt.app.application.soptamp;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,7 +25,7 @@ public class AuthUserProfileReader {
     /**
      * auth DB에서 전체 유저 프로필 조회 (앱잼 시즌용 — OB 포함 전체 대상)
      */
-    public Map<Long, PlatformUserInfoResponse> getAllUserProfiles() {
+    public List<PlatformUserInfoResponse> getAllUserProfiles() {
         String sql = """
                 SELECT u.id AS user_id,
                        u.name,
@@ -41,36 +43,43 @@ public class AuthUserProfileReader {
                 """.formatted(authSchema, authSchema);
 
         Map<Long, AuthUserProfile> profileMap = new HashMap<>();
-        Map<Long, List<PlatformUserInfoResponse.SoptActivities>> activitiesMap = new HashMap<>();
+        Map<Long, List<PlatformUserInfoResponse.SoptActivities>> activitiesMap = new LinkedHashMap<>();
 
         jdbcTemplate.query(sql, rs -> {
             long userId = rs.getLong("user_id");
-            profileMap.putIfAbsent(userId, new AuthUserProfile(
-                rs.getString("name"),
-                rs.getString("profile_image"),
-                rs.getString("birthday"),
-                rs.getString("phone"),
-                rs.getString("email")
-            ));
-            activitiesMap.computeIfAbsent(userId, k -> new ArrayList<>())
-                .add(new PlatformUserInfoResponse.SoptActivities(
-                    0,
-                    rs.getInt("generation"),
-                    AuthSoptPartMapper.toSoptPartName(
-                        rs.getString("part"),
-                        rs.getString("role"),
-                        rs.getString("team")
-                    ),
-                    rs.getString("team"),
-                    rs.getBoolean("is_sopt")
-                ));
+            if (!profileMap.containsKey(userId)) {
+                profileMap.put(userId, extractProfile(rs));
+            }
+            activitiesMap.computeIfAbsent(userId, k -> new ArrayList<>()).add(extractActivity(rs));
         });
 
         return activitiesMap.entrySet().stream()
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                e -> buildProfile(e.getKey(), profileMap.get(e.getKey()), e.getValue())
-            ));
+            .map(e -> buildProfile(e.getKey(), profileMap.get(e.getKey()), e.getValue()))
+            .toList();
+    }
+
+    private AuthUserProfile extractProfile(ResultSet rs) throws SQLException {
+        return new AuthUserProfile(
+            rs.getString("name"),
+            rs.getString("profile_image"),
+            rs.getString("birthday"),
+            rs.getString("phone"),
+            rs.getString("email")
+        );
+    }
+
+    private PlatformUserInfoResponse.SoptActivities extractActivity(ResultSet rs) throws SQLException {
+        return new PlatformUserInfoResponse.SoptActivities(
+            0,
+            rs.getInt("generation"),
+            AuthSoptPartMapper.toSoptPartName(
+                rs.getString("part"),
+                rs.getString("role"),
+                rs.getString("team")
+            ),
+            rs.getString("team"),
+            rs.getBoolean("is_sopt")
+        );
     }
 
     private PlatformUserInfoResponse buildProfile(long userId, AuthUserProfile profile,

--- a/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
@@ -38,7 +38,7 @@ public class AuthUserProfileReader {
                        uah.team
                 FROM %s.users u
                 JOIN %s.user_activity_histories uah ON uah.user_id = u.id
-                ORDER BY u.id, uah.generation, uah.is_sopt DESC
+                ORDER BY u.id, uah.generation
                 """.formatted(authSchema, authSchema);
 
         Map<Long, AuthUserProfile> profileMap = new HashMap<>();
@@ -76,12 +76,18 @@ public class AuthUserProfileReader {
 
     private PlatformUserInfoResponse buildProfile(long userId, AuthUserProfile profile,
             List<PlatformUserInfoResponse.SoptActivities> activities) {
+        // isSopt=true 활동 기준 최대 기수 (플랫폼 API 동일 기준)
+        // isSopt=true 활동이 없는 Makers 전용 OB는 전체 활동 최대 기수로 fallback
         int lastGeneration = activities.stream()
+            .filter(a -> Boolean.TRUE.equals(a.isSopt()))
             .mapToInt(PlatformUserInfoResponse.SoptActivities::generation)
             .max()
-            .orElse(0);
+            .orElseGet(() -> activities.stream()
+                .mapToInt(PlatformUserInfoResponse.SoptActivities::generation)
+                .max()
+                .orElse(0));
         return new PlatformUserInfoResponse(
-            (int) userId,
+            Math.toIntExact(userId), // auth DB id(bigserial)는 실제로 int 범위를 넘지 않음. 오버플로우 시 즉시 예외
             profile.name(),
             profile.profileImage(),
             profile.birthday(),

--- a/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
@@ -54,7 +54,7 @@ public class AuthUserProfileReader {
             ));
             activitiesMap.computeIfAbsent(userId, k -> new ArrayList<>())
                 .add(new PlatformUserInfoResponse.SoptActivities(
-                    0, // activityId — 배치 upsert에서 미사용
+                    0,
                     rs.getInt("generation"),
                     AuthSoptPartMapper.toSoptPartName(
                         rs.getString("part"),
@@ -75,8 +75,6 @@ public class AuthUserProfileReader {
 
     private PlatformUserInfoResponse buildProfile(long userId, AuthUserProfile profile,
             List<PlatformUserInfoResponse.SoptActivities> activities) {
-        // isSopt=true 활동 기준 최대 기수 (플랫폼 API 동일 기준)
-        // isSopt=true 활동이 없는 Makers 전용 OB는 전체 활동 최대 기수로 fallback
         int lastGeneration = activities.stream()
             .filter(a -> Boolean.TRUE.equals(a.isSopt()))
             .mapToInt(PlatformUserInfoResponse.SoptActivities::generation)
@@ -86,7 +84,7 @@ public class AuthUserProfileReader {
                 .max()
                 .orElse(0));
         return new PlatformUserInfoResponse(
-            Math.toIntExact(userId), // auth DB id(bigserial)는 실제로 int 범위를 넘지 않음. 오버플로우 시 즉시 예외
+            Math.toIntExact(userId),
             profile.name(),
             profile.profileImage(),
             profile.birthday(),

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
@@ -76,7 +76,7 @@ public class SoptampBatchService {
             try {
                 Map<Long, PlatformUserInfoResponse> profileMap = platformService.getPlatformUserInfosAsMap(chunk);
                 soptampUserService.upsertAllSoptampUsers(profileMap);
-                successCount += chunk.size();
+                successCount += profileMap.size();
             } catch (Exception e) {
                 log.error("솝탬프 upsert 청크 처리 실패. chunk=[{}/{}], error={}", end, total, e.getMessage(), e);
             }

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
@@ -1,6 +1,5 @@
 package org.sopt.app.application.soptamp;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,19 +40,17 @@ public class SoptampBatchService {
     }
 
     private void upsertFromAuthDb() {
-        Map<Long, PlatformUserInfoResponse> allProfiles = authUserProfileReader.getAllUserProfiles();
-        List<Long> userIds = new ArrayList<>(allProfiles.keySet());
-        int total = userIds.size();
+        List<PlatformUserInfoResponse> allProfiles = authUserProfileReader.getAllUserProfiles();
+        int total = allProfiles.size();
+        int successCount = 0;
         log.info("솝탬프 유저 upsert 시작 (앱잼). 총 {}명, 청크 크기: {}", total, BATCH_SIZE);
 
-        int successCount = 0;
         for (int i = 0; i < total; i += BATCH_SIZE) {
             int end = Math.min(i + BATCH_SIZE, total);
-            List<Long> chunkIds = userIds.subList(i, end);
-            Map<Long, PlatformUserInfoResponse> chunkMap = chunkIds.stream()
-                .collect(Collectors.toMap(id -> id, allProfiles::get));
             log.info("청크 처리 중: [{}/{}]", end, total);
             try {
+                Map<Long, PlatformUserInfoResponse> chunkMap = allProfiles.subList(i, end).stream()
+                    .collect(Collectors.toMap(p -> (long) p.userId(), p -> p));
                 soptampUserService.upsertAllSoptampUsers(chunkMap);
                 successCount += chunkMap.size();
             } catch (Exception e) {
@@ -66,15 +63,15 @@ public class SoptampBatchService {
     private void upsertFromPlatformApi() {
         List<Long> targetUserIds = soptampUserService.getUpsertTargetUserIds();
         int total = targetUserIds.size();
+        int successCount = 0;
         log.info("솝탬프 유저 upsert 시작 (일반). 총 {}명, 청크 크기: {}", total, BATCH_SIZE);
 
-        int successCount = 0;
         for (int i = 0; i < total; i += BATCH_SIZE) {
             int end = Math.min(i + BATCH_SIZE, total);
-            List<Long> chunk = targetUserIds.subList(i, end);
             log.info("청크 처리 중: [{}/{}]", end, total);
             try {
-                Map<Long, PlatformUserInfoResponse> profileMap = platformService.getPlatformUserInfosAsMap(chunk);
+                Map<Long, PlatformUserInfoResponse> profileMap = platformService.getPlatformUserInfosAsMap(
+                    targetUserIds.subList(i, end));
                 soptampUserService.upsertAllSoptampUsers(profileMap);
                 successCount += profileMap.size();
             } catch (Exception e) {

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
@@ -25,6 +25,13 @@ public class SoptampBatchService {
     private final PlatformService platformService;
     private final AuthUserProfileReader authUserProfileReader;
 
+    /**
+     * 전체 솝탬프 유저 upsert 배치 실행
+     * - 앱잼 모드: auth DB에서 전체 유저 프로필을 직접 조회 (플랫폼 API 미사용)
+     * - 일반 모드: 기존 soptamp_user 대상으로 플랫폼 API 호출
+     * - 청크별 독립 트랜잭션 + 개별 예외 처리 (한 청크 실패가 나머지 청크에 영향 없음)
+     * - upsert 멱등이므로 실패 청크는 다음 스케줄 실행 시 재처리됨
+     */
     public void upsertAllSoptampUsers() {
         if (appjamMode) {
             upsertFromAuthDb();

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampBatchService.java
@@ -1,0 +1,79 @@
+package org.sopt.app.application.soptamp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.application.platform.PlatformService;
+import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SoptampBatchService {
+
+    private static final int BATCH_SIZE = 100;
+
+    @Value("${makers.app.soptamp.appjam-mode:false}")
+    private boolean appjamMode;
+
+    private final SoptampUserService soptampUserService;
+    private final PlatformService platformService;
+    private final AuthUserProfileReader authUserProfileReader;
+
+    public void upsertAllSoptampUsers() {
+        if (appjamMode) {
+            upsertFromAuthDb();
+        } else {
+            upsertFromPlatformApi();
+        }
+    }
+
+    private void upsertFromAuthDb() {
+        Map<Long, PlatformUserInfoResponse> allProfiles = authUserProfileReader.getAllUserProfiles();
+        List<Long> userIds = new ArrayList<>(allProfiles.keySet());
+        int total = userIds.size();
+        log.info("솝탬프 유저 upsert 시작 (앱잼). 총 {}명, 청크 크기: {}", total, BATCH_SIZE);
+
+        int successCount = 0;
+        for (int i = 0; i < total; i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, total);
+            List<Long> chunkIds = userIds.subList(i, end);
+            Map<Long, PlatformUserInfoResponse> chunkMap = chunkIds.stream()
+                .collect(Collectors.toMap(id -> id, allProfiles::get));
+            log.info("청크 처리 중: [{}/{}]", end, total);
+            try {
+                soptampUserService.upsertAllSoptampUsers(chunkMap);
+                successCount += chunkMap.size();
+            } catch (Exception e) {
+                log.error("솝탬프 upsert 청크 처리 실패. chunk=[{}/{}], error={}", end, total, e.getMessage(), e);
+            }
+        }
+        log.info("솝탬프 유저 upsert 완료. 성공: {}명 / 전체: {}명", successCount, total);
+    }
+
+    private void upsertFromPlatformApi() {
+        List<Long> targetUserIds = soptampUserService.getUpsertTargetUserIds();
+        int total = targetUserIds.size();
+        log.info("솝탬프 유저 upsert 시작 (일반). 총 {}명, 청크 크기: {}", total, BATCH_SIZE);
+
+        int successCount = 0;
+        for (int i = 0; i < total; i += BATCH_SIZE) {
+            int end = Math.min(i + BATCH_SIZE, total);
+            List<Long> chunk = targetUserIds.subList(i, end);
+            log.info("청크 처리 중: [{}/{}]", end, total);
+            try {
+                Map<Long, PlatformUserInfoResponse> profileMap = platformService.getPlatformUserInfosAsMap(chunk);
+                soptampUserService.upsertAllSoptampUsers(profileMap);
+                successCount += chunk.size();
+            } catch (Exception e) {
+                log.error("솝탬프 upsert 청크 처리 실패. chunk=[{}/{}], error={}", end, total, e.getMessage(), e);
+            }
+        }
+        log.info("솝탬프 유저 upsert 완료. 성공: {}명 / 전체: {}명", successCount, total);
+    }
+}

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUpsertScheduler.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUpsertScheduler.java
@@ -1,0 +1,36 @@
+package org.sopt.app.application.soptamp;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.application.appservice.OperationConfigService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("!lambda")
+@RequiredArgsConstructor
+public class SoptampUpsertScheduler implements SchedulingConfigurer {
+
+    private final SoptampBatchService soptampBatchService;
+    private final OperationConfigService operationConfigService;
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar registrar) {
+        registrar.addTriggerTask(
+            this::runUpsertBatch,
+            context -> {
+                String cron = operationConfigService.getSoptampUpsertCron();
+                return new CronTrigger(cron).nextExecution(context);
+            }
+        );
+    }
+
+    void runUpsertBatch() {
+        log.info("솝탬프 upsert 배치 자동 실행 시작");
+        soptampBatchService.upsertAllSoptampUsers();
+    }
+}

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUpsertScheduler.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUpsertScheduler.java
@@ -27,16 +27,11 @@ public class SoptampUpsertScheduler implements SchedulingConfigurer {
     @Override
     public void configureTasks(ScheduledTaskRegistrar registrar) {
         registrar.addTriggerTask(
-            this::runUpsertBatch,
-            context -> {
-                String cron = operationConfigService.getSoptampUpsertCron();
-                return new CronTrigger(cron).nextExecution(context);
-            }
+            () -> {
+                log.info("솝탬프 upsert 배치 자동 실행 시작");
+                soptampBatchService.upsertAllSoptampUsers();
+            },
+            context -> new CronTrigger(operationConfigService.getSoptampUpsertCron()).nextExecution(context)
         );
-    }
-
-    void runUpsertBatch() {
-        log.info("솝탬프 upsert 배치 자동 실행 시작");
-        soptampBatchService.upsertAllSoptampUsers();
     }
 }

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUpsertScheduler.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUpsertScheduler.java
@@ -18,6 +18,12 @@ public class SoptampUpsertScheduler implements SchedulingConfigurer {
     private final SoptampBatchService soptampBatchService;
     private final OperationConfigService operationConfigService;
 
+    /**
+     * DB에 저장된 cron 표현식을 매 실행 직전에 읽어 동적으로 스케줄을 적용한다.
+     * PATCH /api/v2/admin/soptamp/upsert/schedule 으로 cron 변경 시 다음 실행부터 반영.
+     *
+     * DB 미설정 시 기본값: 매일 새벽 3시 (0 0 3 * * *)
+     */
     @Override
     public void configureTasks(ScheduledTaskRegistrar registrar) {
         registrar.addTriggerTask(

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -74,30 +74,26 @@ public class SoptampUserService {
     public void upsertAllSoptampUsers(Map<Long, PlatformUserInfoResponse> profileMap) {
         if (profileMap.isEmpty()) return;
 
-        // chunk 단위로 SoptampUser 일괄 조회 → findByUserId N+1 방지
         Map<Long, SoptampUser> existingUserMap = soptampUserRepository
             .findAllByUserIdIn(profileMap.keySet()).stream()
             .collect(Collectors.toMap(SoptampUser::getUserId, Function.identity()));
 
-        // 앱잼 모드: AppjamUser도 일괄 조회
         Map<Long, AppjamUser> appjamUserMap = appjamMode
             ? appjamUserRepository.findAllByUserIdIn(profileMap.keySet()).stream()
                 .collect(Collectors.toMap(AppjamUser::getUserId, Function.identity(), (a, b) -> a))
             : Map.of();
 
-        // 청크 내 닉네임 중복 방지용 예약 셋 (같은 청크 안에서 할당된 닉네임 추적)
         Set<String> reservedNicknames = new HashSet<>();
 
         profileMap.forEach((userId, profile) ->
             upsertSoptampUserCore(profile, userId, appjamUserMap, existingUserMap, reservedNicknames));
     }
 
-    // 단건 진입점 — 테스트 및 외부 호출용
     @Transactional
     public void upsertSoptampUser(PlatformUserInfoResponse profile, Long userId) {
         if (profile == null) return;
-        if (appjamMode && profile.getLatestActivity() == null) return;   // 앱잼: 활동 이력 없으면 skip
-        if (!appjamMode && profile.getLatestSoptActivity() == null) return; // 일반: SOPT 활동 없으면 skip
+        if (appjamMode && profile.getLatestActivity() == null) return;
+        if (!appjamMode && profile.getLatestSoptActivity() == null) return;
 
         Map<Long, SoptampUser> existingUserMap = soptampUserRepository.findByUserId(userId)
             .map(u -> Map.of(userId, u))
@@ -120,7 +116,7 @@ public class SoptampUserService {
 
         if (appjamMode) {
             var latest = profile.getLatestActivity();
-            if (latest == null) return; // 활동 이력 없는 유저 skip
+            if (latest == null) return;
             upsertSoptampUserForAppjam(profile, userId, latest,
                 appjamUserMap, existingUserMap, reservedNicknames);
         } else {
@@ -139,38 +135,37 @@ public class SoptampUserService {
             Set<String> reservedNicknames) {
         SoptampUser registeredUser = existingUserMap.get(userId);
         if (registeredUser == null) {
-            this.createSoptampUserNormal(profile, userId, latest, reservedNicknames);
+            createSoptampUserNormal(profile, userId, latest, reservedNicknames);
             return;
         }
-        if (this.isGenerationChanged(registeredUser, (long) profile.lastGeneration())) {
+        if (isGenerationChanged(registeredUser, (long) profile.lastGeneration())) {
             updateSoptampUserNormal(registeredUser, profile, latest, reservedNicknames);
         }
     }
 
     private void updateSoptampUserNormal(SoptampUser registeredUser, PlatformUserInfoResponse profile,
             PlatformUserInfoResponse.SoptActivities latest, Set<String> reservedNicknames) {
-        String part = latest.part() == null ? "미상" : latest.part();
+        String part = partOrDefault(latest);
         String newNickname = generatePartBasedUniqueNickname(profile.name(), part, registeredUser.getUserId(), reservedNicknames);
 
         registeredUser.initTotalPoints();
         registeredUser.updateChangedGenerationInfo(
                 (long) profile.lastGeneration(),
                 findSoptPartByPartName(part),
-            newNickname
+                newNickname
         );
 
-        this.raiseAllCacheSyncEvent(registeredUser);
+        raiseAllCacheSyncEvent(registeredUser);
     }
 
     private void createSoptampUserNormal(PlatformUserInfoResponse profile, Long userId,
-        PlatformUserInfoResponse.SoptActivities latestSopt, Set<String> reservedNicknames
-    ) {
-        String part = latestSopt.part() == null ? "미상" : latestSopt.part();
+            PlatformUserInfoResponse.SoptActivities latest, Set<String> reservedNicknames) {
+        String part = partOrDefault(latest);
         String uniqueNickname = generatePartBasedUniqueNickname(profile.name(), part, null, reservedNicknames);
         SoptampUser newSoptampUser = createNewSoptampUser(userId, uniqueNickname, (long) profile.lastGeneration(),
                 findSoptPartByPartName(part));
         soptampUserRepository.save(newSoptampUser);
-        this.raiseAllCacheSyncEvent(newSoptampUser);
+        raiseAllCacheSyncEvent(newSoptampUser);
     }
 
     private boolean isGenerationChanged(SoptampUser registeredUser, Long profileGeneration) {
@@ -201,38 +196,33 @@ public class SoptampUserService {
         String baseNickname = buildAppjamBaseNickname(profile, userId, appjamUserMap);
         String uniqueNickname = generateUniqueNicknameInternal(baseNickname, userId, reservedNicknames);
 
-        String part = (latest == null || latest.part() == null) ? "미상" : latest.part();
+        String part = partOrDefault(latest);
         registeredUser.updateChangedGenerationInfo(
                 (long) profile.lastGeneration(),
                 findSoptPartByPartName(part),
                 uniqueNickname
-            );
+        );
 
         // 앱잼 변환 시점에 한 번 포인트 초기화
         registeredUser.initTotalPoints();
-        this.raiseAllCacheSyncEvent(registeredUser);
+        raiseAllCacheSyncEvent(registeredUser);
     }
 
     private void createSoptampUserAppjam(PlatformUserInfoResponse profile,
             Long userId,
             PlatformUserInfoResponse.SoptActivities latest,
             Map<Long, AppjamUser> appjamUserMap,
-            Set<String> reservedNicknames
-    ) {
+            Set<String> reservedNicknames) {
         String baseNickname = buildAppjamBaseNickname(profile, userId, appjamUserMap);
         String uniqueNickname = generateUniqueNicknameInternal(baseNickname, null, reservedNicknames);
-
-        String part = (latest == null || latest.part() == null) ? "미상" : latest.part();
+        String part = partOrDefault(latest);
 
         SoptampUser newSoptampUser = createNewSoptampUser(
-                userId,
-                uniqueNickname,
-                (long) profile.lastGeneration(),
-                findSoptPartByPartName(part));
-        newSoptampUser.initTotalPoints(); // 새 시즌이니 0점부터
+                userId, uniqueNickname, (long) profile.lastGeneration(), findSoptPartByPartName(part));
+        newSoptampUser.initTotalPoints();
 
         soptampUserRepository.save(newSoptampUser);
-        this.raiseAllCacheSyncEvent(newSoptampUser);
+        raiseAllCacheSyncEvent(newSoptampUser);
     }
 
     /**
@@ -247,7 +237,6 @@ public class SoptampUserService {
             return true;
         }
 
-        // "파트명 + 이름"으로 시작하면 구시즌(파트 기반) 닉네임 → 앱잼 변환 필요 (SOPT 파트만)
         for (SoptPart part : SoptPart.values()) {
             if (!part.isSoptPart()) continue;
             if (nickname.startsWith(part.getShortedPartName() + profileName)) {
@@ -255,7 +244,6 @@ public class SoptampUserService {
             }
         }
 
-        // 그 외 (비트김솝트, 37기김솝트 등) → 이미 앱잼 스타일
         return false;
     }
 
@@ -279,6 +267,10 @@ public class SoptampUserService {
     // ==================== 닉네임 유니크 로직 공통부 ====================
 
     private static final String SUFFIX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    private static String partOrDefault(PlatformUserInfoResponse.SoptActivities activity) {
+        return activity == null || activity.part() == null ? "미상" : activity.part();
+    }
 
     /**
      * 파트 기반 닉네임 (NORMAL 시즌용)

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -95,9 +95,9 @@ public class SoptampUserService {
     // 단건 진입점 — 테스트 및 외부 호출용
     @Transactional
     public void upsertSoptampUser(PlatformUserInfoResponse profile, Long userId) {
-        // DB 조회 전 early return (배치와 동일한 guard 조건)
         if (profile == null) return;
-        if (!appjamMode && profile.getLatestSoptActivity() == null) return;
+        if (appjamMode && profile.getLatestActivity() == null) return;   // 앱잼: 활동 이력 없으면 skip
+        if (!appjamMode && profile.getLatestSoptActivity() == null) return; // 일반: SOPT 활동 없으면 skip
 
         Map<Long, SoptampUser> existingUserMap = soptampUserRepository.findByUserId(userId)
             .map(u -> Map.of(userId, u))
@@ -119,7 +119,9 @@ public class SoptampUserService {
         if (profile == null) return;
 
         if (appjamMode) {
-            upsertSoptampUserForAppjam(profile, userId, profile.getLatestActivity(),
+            var latest = profile.getLatestActivity();
+            if (latest == null) return; // 활동 이력 없는 유저 skip
+            upsertSoptampUserForAppjam(profile, userId, latest,
                 appjamUserMap, existingUserMap, reservedNicknames);
         } else {
             var latestSopt = profile.getLatestSoptActivity();
@@ -191,7 +193,7 @@ public class SoptampUserService {
         }
 
         // 이미 앱잼 규칙이 적용된 닉네임이면 그대로 둠 (비트OOO, 37기OOO 등)
-        if (!needsAppjamNicknameMigration(registeredUser)) {
+        if (!needsAppjamNicknameMigration(registeredUser, profile.name())) {
             return;
         }
 
@@ -233,25 +235,27 @@ public class SoptampUserService {
         this.raiseAllCacheSyncEvent(newSoptampUser);
     }
 
-    private boolean needsAppjamNicknameMigration(SoptampUser user) {
+    /**
+     * "파트명 + 이름" 형식의 구시즌 닉네임이면 앱잼 닉네임으로 변환 필요.
+     * profileName을 함께 받아 "파트명"만으로 prefix 체크하는 오탐을 방지.
+     * (예: 앱잼 팀명 "서버" + 이름 "김솝트" → "서버김솝트"는 구시즌 형식과 구별 불가 → 변환)
+     * (예: 앱잼 팀명 "비트" + 이름 "김솝트" → "비트김솝트"는 어떤 파트 prefix + 이름과도 불일치 → 유지)
+     */
+    private boolean needsAppjamNicknameMigration(SoptampUser user, String profileName) {
         String nickname = user.getNickname();
         if (nickname == null || nickname.isBlank()) {
-            // 닉네임이 비어 있으면 앱잼 규칙으로 한 번 세팅해 주는 게 자연스러움
             return true;
         }
 
-        // SoptPart 기준으로 "서버", "기획" 같은 축약/프리픽스를 모두 검사 (SOPT 파트만)
+        // "파트명 + 이름"으로 시작하면 구시즌(파트 기반) 닉네임 → 앱잼 변환 필요 (SOPT 파트만)
         for (SoptPart part : SoptPart.values()) {
-            if (!part.isSoptPart())
-                continue;
-            String prefix = part.getShortedPartName();
-            if (nickname.startsWith(prefix)) {
-                // 서버김솝트, 디자인김솝트 등 → 기존 시즌(파트 기반) 닉네임이므로 앱잼 변환 필요
+            if (!part.isSoptPart()) continue;
+            if (nickname.startsWith(part.getShortedPartName() + profileName)) {
                 return true;
             }
         }
 
-        // 그 외 (비트김솝트, 37기김솝트 등) → 이미 앱잼 스타일로 적용된 걸로 간주
+        // 그 외 (비트김솝트, 37기김솝트 등) → 이미 앱잼 스타일
         return false;
     }
 

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -3,9 +3,13 @@ package org.sopt.app.application.soptamp;
 import static org.sopt.app.domain.entity.soptamp.SoptampUser.createNewSoptampUser;
 import static org.sopt.app.domain.enums.SoptPart.findSoptPartByPartName;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
 import org.sopt.app.application.rank.RankCacheService;
@@ -41,8 +45,6 @@ public class SoptampUserService {
     @Value("${sopt.current.generation}")
     private Long currentGeneration;
 
-    /* ==================== 조회/프로필 ==================== */
-
     @Transactional(readOnly = true)
     public SoptampUserInfo getSoptampUserInfo(Long userId) {
         SoptampUser user = soptampUserRepository.findByUserId(userId)
@@ -59,57 +61,75 @@ public class SoptampUserService {
         return SoptampUserInfo.of(soptampUser);
     }
 
-    /* ==================== upsert 진입점 ==================== */
-
     @Transactional(readOnly = true)
     public List<Long> getUpsertTargetUserIds() {
-        return appjamMode
-            ? appjamUserRepository.findAll().stream().map(AppjamUser::getUserId).toList()
-            : soptampUserRepository.findAll().stream().map(SoptampUser::getUserId).toList();
+        return soptampUserRepository.findAllUserIds();
     }
 
     @Transactional
     public void upsertAllSoptampUsers(Map<Long, PlatformUserInfoResponse> profileMap) {
-        profileMap.forEach((userId, profile) -> upsertSoptampUser(profile, userId));
+        if (profileMap.isEmpty()) return;
+
+        Map<Long, SoptampUser> existingUserMap = soptampUserRepository
+            .findAllByUserIdIn(profileMap.keySet()).stream()
+            .collect(Collectors.toMap(SoptampUser::getUserId, Function.identity()));
+
+        Map<Long, AppjamUser> appjamUserMap = appjamMode
+            ? appjamUserRepository.findAllByUserIdIn(profileMap.keySet()).stream()
+                .collect(Collectors.toMap(AppjamUser::getUserId, Function.identity(), (a, b) -> a))
+            : Map.of();
+
+        Set<String> reservedNicknames = new HashSet<>();
+
+        profileMap.forEach((userId, profile) ->
+            upsertSoptampUserCore(profile, userId, appjamUserMap, existingUserMap, reservedNicknames));
     }
 
-    // 앱잼 시즌 여부에 따라 upsert 로직 분기
     @Transactional
     public void upsertSoptampUser(PlatformUserInfoResponse profile, Long userId) {
-        if (profile == null)
-            return;
+        if (profile == null) return;
+        if (!appjamMode && profile.getLatestSoptActivity() == null) return;
+
+        Map<Long, SoptampUser> existingUserMap = soptampUserRepository.findByUserId(userId)
+            .map(u -> Map.of(userId, u))
+            .orElse(Map.of());
+        upsertSoptampUserCore(profile, userId, null, existingUserMap, new HashSet<>());
+    }
+
+    private void upsertSoptampUserCore(PlatformUserInfoResponse profile, Long userId,
+            Map<Long, AppjamUser> appjamUserMap,
+            Map<Long, SoptampUser> existingUserMap,
+            Set<String> reservedNicknames) {
+        if (profile == null) return;
 
         if (appjamMode) {
-            upsertSoptampUserForAppjam(profile, userId, profile.getLatestActivity());
+            upsertSoptampUserForAppjam(profile, userId, profile.getLatestActivity(),
+                appjamUserMap, existingUserMap, reservedNicknames);
         } else {
             var latestSopt = profile.getLatestSoptActivity();
-            if (latestSopt == null) {
-                return;
-            }
-            upsertSoptampUserNormal(profile, userId, latestSopt);
+            if (latestSopt == null) return;
+            upsertSoptampUserNormal(profile, userId, latestSopt, existingUserMap, reservedNicknames);
         }
     }
 
-    /* ==================== NORMAL 시즌용 upsert ==================== */
-
-    // 기본 시즌용 upsert (파트 + 이름 기반 닉네임)
     private void upsertSoptampUserNormal(PlatformUserInfoResponse profile, Long userId,
-            PlatformUserInfoResponse.SoptActivities latest) {
-        Optional<SoptampUser> user = soptampUserRepository.findByUserId(userId);
-        if (user.isEmpty()) {
-            this.createSoptampUserNormal(profile, userId, latest);
+            PlatformUserInfoResponse.SoptActivities latest,
+            Map<Long, SoptampUser> existingUserMap,
+            Set<String> reservedNicknames) {
+        SoptampUser registeredUser = existingUserMap.get(userId);
+        if (registeredUser == null) {
+            this.createSoptampUserNormal(profile, userId, latest, reservedNicknames);
             return;
         }
-        SoptampUser registeredUser = user.get();
         if (this.isGenerationChanged(registeredUser, (long) profile.lastGeneration())) {
-            updateSoptampUserNormal(registeredUser, profile, latest);
+            updateSoptampUserNormal(registeredUser, profile, latest, reservedNicknames);
         }
     }
 
     private void updateSoptampUserNormal(SoptampUser registeredUser, PlatformUserInfoResponse profile,
-            PlatformUserInfoResponse.SoptActivities latest) {
+            PlatformUserInfoResponse.SoptActivities latest, Set<String> reservedNicknames) {
         String part = latest.part() == null ? "미상" : latest.part();
-        String newNickname = generatePartBasedUniqueNickname(profile.name(), part, registeredUser.getUserId());
+        String newNickname = generatePartBasedUniqueNickname(profile.name(), part, registeredUser.getUserId(), reservedNicknames);
 
         registeredUser.initTotalPoints();
         registeredUser.updateChangedGenerationInfo(
@@ -122,10 +142,10 @@ public class SoptampUserService {
     }
 
     private void createSoptampUserNormal(PlatformUserInfoResponse profile, Long userId,
-        PlatformUserInfoResponse.SoptActivities latestSopt
+        PlatformUserInfoResponse.SoptActivities latestSopt, Set<String> reservedNicknames
     ) {
         String part = latestSopt.part() == null ? "미상" : latestSopt.part();
-        String uniqueNickname = generatePartBasedUniqueNickname(profile.name(), part, null);
+        String uniqueNickname = generatePartBasedUniqueNickname(profile.name(), part, null, reservedNicknames);
         SoptampUser newSoptampUser = createNewSoptampUser(userId, uniqueNickname, (long) profile.lastGeneration(),
                 findSoptPartByPartName(part));
         soptampUserRepository.save(newSoptampUser);
@@ -136,54 +156,45 @@ public class SoptampUserService {
         return !registeredUser.getGeneration().equals(profileGeneration);
     }
 
-    // ==================== 앱잼 시즌용 upsert ====================
-
     private void upsertSoptampUserForAppjam(PlatformUserInfoResponse profile,
             Long userId,
-            PlatformUserInfoResponse.SoptActivities latest) {
-        Optional<SoptampUser> userOpt = soptampUserRepository.findByUserId(userId);
+            PlatformUserInfoResponse.SoptActivities latest,
+            Map<Long, AppjamUser> appjamUserMap,
+            Map<Long, SoptampUser> existingUserMap,
+            Set<String> reservedNicknames) {
+        SoptampUser registeredUser = existingUserMap.get(userId);
 
-        if (userOpt.isEmpty()) {
-            createSoptampUserAppjam(profile, userId, latest);
+        if (registeredUser == null) {
+            createSoptampUserAppjam(profile, userId, latest, appjamUserMap, reservedNicknames);
             return;
         }
 
-        SoptampUser registeredUser = userOpt.get();
-
-        // 이미 앱잼 규칙이 적용된 닉네임이면 그대로 둠 (비트OOO, 37기OOO 등)
         if (!needsAppjamNicknameMigration(registeredUser)) {
             return;
         }
 
-        // 여기까지 오면: 기존 닉네임이 "서버OOO" 같은 파트 기반 → 앱잼 닉네임으로 변환
-        String baseNickname = buildAppjamBaseNickname(profile, userId);
-
-        String uniqueNickname = generateUniqueNicknameInternal(baseNickname, userId);
+        String baseNickname = buildAppjamBaseNickname(profile, userId, appjamUserMap);
+        String uniqueNickname = generateUniqueNicknameInternal(baseNickname, userId, reservedNicknames);
 
         String part = (latest == null || latest.part() == null) ? "미상" : latest.part();
-        // 앱잼 시즌: 파트, Makers 무관 buildAppjamBaseNickname이 자연스럽게 처리
         registeredUser.updateChangedGenerationInfo(
                 (long) profile.lastGeneration(),
                 findSoptPartByPartName(part),
                 uniqueNickname
             );
 
-        // 앱잼 변환 시점에 한 번 포인트 초기화
         registeredUser.initTotalPoints();
         this.raiseAllCacheSyncEvent(registeredUser);
     }
 
     private void createSoptampUserAppjam(PlatformUserInfoResponse profile,
             Long userId,
-            PlatformUserInfoResponse.SoptActivities latest
+            PlatformUserInfoResponse.SoptActivities latest,
+            Map<Long, AppjamUser> appjamUserMap,
+            Set<String> reservedNicknames
     ) {
-        String baseNickname = buildAppjamBaseNickname(profile, userId);
-
-        // 새 유저: 전체에서 중복 검사
-        String uniqueNickname = generateUniqueNicknameInternal(
-                baseNickname,
-                null
-            );
+        String baseNickname = buildAppjamBaseNickname(profile, userId, appjamUserMap);
+        String uniqueNickname = generateUniqueNicknameInternal(baseNickname, null, reservedNicknames);
 
         String part = (latest == null || latest.part() == null) ? "미상" : latest.part();
 
@@ -192,7 +203,7 @@ public class SoptampUserService {
                 uniqueNickname,
                 (long) profile.lastGeneration(),
                 findSoptPartByPartName(part));
-        newSoptampUser.initTotalPoints(); // 새 시즌이니 0점부터
+        newSoptampUser.initTotalPoints();
 
         soptampUserRepository.save(newSoptampUser);
         this.raiseAllCacheSyncEvent(newSoptampUser);
@@ -201,62 +212,51 @@ public class SoptampUserService {
     private boolean needsAppjamNicknameMigration(SoptampUser user) {
         String nickname = user.getNickname();
         if (nickname == null || nickname.isBlank()) {
-            // 닉네임이 비어 있으면 앱잼 규칙으로 한 번 세팅해 주는 게 자연스러움
             return true;
         }
 
-        // SoptPart 기준으로 "서버", "기획" 같은 축약/프리픽스를 모두 검사 (SOPT 파트만)
         for (SoptPart part : SoptPart.values()) {
             if (!part.isSoptPart())
                 continue;
             String prefix = part.getShortedPartName();
             if (nickname.startsWith(prefix)) {
-                // 서버김솝트, 디자인김솝트 등 → 기존 시즌(파트 기반) 닉네임이므로 앱잼 변환 필요
                 return true;
             }
         }
 
-        // 그 외 (비트김솝트, 37기김솝트 등) → 이미 앱잼 스타일로 적용된 걸로 간주
         return false;
     }
 
-    /**
-     * 앱잼용 base nickname 생성
-     * 1. AppjamUser에 있으면: teamName + 이름 (ex. 비트김솝트)
-     * 2. 없으면: lastGeneration + "기" + 이름 (ex. 37기김솝트)
-     */
-    private String buildAppjamBaseNickname(PlatformUserInfoResponse profile, Long userId) {
-        return appjamUserRepository.findByUserId(userId)
-                .map(appjamUser -> appjamUser.getTeamName() + profile.name())
-                .orElseGet(() -> profile.lastGeneration() + "기" + profile.name());
+    private String buildAppjamBaseNickname(PlatformUserInfoResponse profile, Long userId,
+            Map<Long, AppjamUser> appjamUserMap) {
+        Optional<AppjamUser> appjamUser = (appjamUserMap != null)
+            ? Optional.ofNullable(appjamUserMap.get(userId))
+            : appjamUserRepository.findByUserId(userId);
+        return appjamUser
+            .map(u -> u.getTeamName() + profile.name())
+            .orElseGet(() -> profile.lastGeneration() + "기" + profile.name());
     }
 
-    // ==================== 닉네임 유니크 로직 공통부 ====================
+    private static final String SUFFIX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-    /**
-     * 파트 기반 닉네임 (NORMAL 시즌용)
-     * ex. "서버" + "김솝트" → "서버김솝트"
-     */
-    private String generatePartBasedUniqueNickname(String name, String part, Long currentUserIdOrNull) {
+    private String generatePartBasedUniqueNickname(String name, String part, Long currentUserIdOrNull,
+            Set<String> reservedNicknames) {
         String prefixPartName = SoptPart.findSoptPartByPartName(part).getShortedPartName();
         String baseNickname = prefixPartName + name;
-        return generateUniqueNicknameInternal(baseNickname, currentUserIdOrNull);
+        return generateUniqueNicknameInternal(baseNickname, currentUserIdOrNull, reservedNicknames);
     }
 
-    /**
-     * baseNickname을 기준으로, 전역 유니크 닉네임 생성
-     * - currentUserIdOrNull == null : 새 유저 생성 (그냥 existsByNickname)
-     * - currentUserIdOrNull != null : 내 row는 제외하고 중복 체크
-     */
-    private String generateUniqueNicknameInternal(String baseNickname, Long currentUserIdOrNull) {
-        if (!existsNickname(baseNickname, currentUserIdOrNull)) {
+    private String generateUniqueNicknameInternal(String baseNickname, Long currentUserIdOrNull,
+            Set<String> reservedNicknames) {
+        if (!existsNickname(baseNickname, currentUserIdOrNull) && !reservedNicknames.contains(baseNickname)) {
+            reservedNicknames.add(baseNickname);
             return baseNickname;
         }
 
-        char suffix = 'A';
-        for (int i = 0; i < 52; i++, suffix++) {
-            String candidate = baseNickname + suffix;
-            if (!existsNickname(candidate, currentUserIdOrNull)) {
+        for (int i = 0; i < SUFFIX_CHARS.length(); i++) {
+            String candidate = baseNickname + SUFFIX_CHARS.charAt(i);
+            if (!existsNickname(candidate, currentUserIdOrNull) && !reservedNicknames.contains(candidate)) {
+                reservedNicknames.add(candidate);
                 return candidate;
             }
         }
@@ -269,8 +269,6 @@ public class SoptampUserService {
         }
         return soptampUserRepository.existsByNicknameAndUserIdNot(nickname, currentUserIdOrNull);
     }
-
-    // ==================== 포인트/회원 탈퇴 로직 ====================
 
     @Transactional
     public void addPointByLevel(Long userId, Integer level) {

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -194,15 +194,18 @@ public class SoptampUserService {
         String baseNickname = buildAppjamBaseNickname(profile, userId, appjamUserMap);
         String uniqueNickname = generateUniqueNicknameInternal(baseNickname, userId, reservedNicknames);
 
+        // 닉네임이 실제로 바뀌지 않으면 포인트 초기화 없이 종료 (멱등성 보장)
+        if (uniqueNickname.equals(registeredUser.getNickname())) {
+            return;
+        }
+
         String part = partOrDefault(latest);
+        registeredUser.initTotalPoints();
         registeredUser.updateChangedGenerationInfo(
                 (long) profile.lastGeneration(),
                 findSoptPartByPartName(part),
                 uniqueNickname
         );
-
-        // 앱잼 변환 시점에 한 번 포인트 초기화
-        registeredUser.initTotalPoints();
         raiseAllCacheSyncEvent(registeredUser);
     }
 
@@ -254,12 +257,15 @@ public class SoptampUserService {
      */
     private String buildAppjamBaseNickname(PlatformUserInfoResponse profile, Long userId,
             Map<Long, AppjamUser> appjamUserMap) {
-        Optional<AppjamUser> appjamUser = (appjamUserMap != null)
-            ? Optional.ofNullable(appjamUserMap.get(userId))
-            : appjamUserRepository.findByUserId(userId);
-        return appjamUser
+        return findAppjamUser(userId, appjamUserMap)
             .map(u -> u.getTeamName() + profile.name())
             .orElseGet(() -> profile.lastGeneration() + "기" + profile.name());
+    }
+
+    private Optional<AppjamUser> findAppjamUser(Long userId, Map<Long, AppjamUser> appjamUserMap) {
+        return (appjamUserMap != null)
+            ? Optional.ofNullable(appjamUserMap.get(userId))
+            : appjamUserRepository.findByUserId(userId);
     }
 
     // ==================== 닉네임 유니크 로직 공통부 ====================

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -220,8 +220,6 @@ public class SoptampUserService {
 
         SoptampUser newSoptampUser = createNewSoptampUser(
                 userId, uniqueNickname, (long) profile.lastGeneration(), findSoptPartByPartName(part));
-        newSoptampUser.initTotalPoints();
-
         soptampUserRepository.save(newSoptampUser);
         raiseAllCacheSyncEvent(newSoptampUser);
     }
@@ -282,8 +280,7 @@ public class SoptampUserService {
      */
     private String generatePartBasedUniqueNickname(String name, String part, Long currentUserIdOrNull,
             Set<String> reservedNicknames) {
-        String prefixPartName = SoptPart.findSoptPartByPartName(part).getShortedPartName();
-        String baseNickname = prefixPartName + name;
+        String baseNickname = SoptPart.findSoptPartByPartName(part).getShortedPartName() + name;
         return generateUniqueNicknameInternal(baseNickname, currentUserIdOrNull, reservedNicknames);
     }
 

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -112,8 +112,6 @@ public class SoptampUserService {
             Map<Long, AppjamUser> appjamUserMap,
             Map<Long, SoptampUser> existingUserMap,
             Set<String> reservedNicknames) {
-        if (profile == null) return;
-
         if (appjamMode) {
             var latest = profile.getLatestActivity();
             if (latest == null) return;

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -45,6 +45,8 @@ public class SoptampUserService {
     @Value("${sopt.current.generation}")
     private Long currentGeneration;
 
+    /* ==================== 조회/프로필 ==================== */
+
     @Transactional(readOnly = true)
     public SoptampUserInfo getSoptampUserInfo(Long userId) {
         SoptampUser user = soptampUserRepository.findByUserId(userId)
@@ -61,6 +63,8 @@ public class SoptampUserService {
         return SoptampUserInfo.of(soptampUser);
     }
 
+    /* ==================== upsert 진입점 ==================== */
+
     @Transactional(readOnly = true)
     public List<Long> getUpsertTargetUserIds() {
         return soptampUserRepository.findAllUserIds();
@@ -70,23 +74,28 @@ public class SoptampUserService {
     public void upsertAllSoptampUsers(Map<Long, PlatformUserInfoResponse> profileMap) {
         if (profileMap.isEmpty()) return;
 
+        // chunk 단위로 SoptampUser 일괄 조회 → findByUserId N+1 방지
         Map<Long, SoptampUser> existingUserMap = soptampUserRepository
             .findAllByUserIdIn(profileMap.keySet()).stream()
             .collect(Collectors.toMap(SoptampUser::getUserId, Function.identity()));
 
+        // 앱잼 모드: AppjamUser도 일괄 조회
         Map<Long, AppjamUser> appjamUserMap = appjamMode
             ? appjamUserRepository.findAllByUserIdIn(profileMap.keySet()).stream()
                 .collect(Collectors.toMap(AppjamUser::getUserId, Function.identity(), (a, b) -> a))
             : Map.of();
 
+        // 청크 내 닉네임 중복 방지용 예약 셋 (같은 청크 안에서 할당된 닉네임 추적)
         Set<String> reservedNicknames = new HashSet<>();
 
         profileMap.forEach((userId, profile) ->
             upsertSoptampUserCore(profile, userId, appjamUserMap, existingUserMap, reservedNicknames));
     }
 
+    // 단건 진입점 — 테스트 및 외부 호출용
     @Transactional
     public void upsertSoptampUser(PlatformUserInfoResponse profile, Long userId) {
+        // DB 조회 전 early return (배치와 동일한 guard 조건)
         if (profile == null) return;
         if (!appjamMode && profile.getLatestSoptActivity() == null) return;
 
@@ -96,6 +105,13 @@ public class SoptampUserService {
         upsertSoptampUserCore(profile, userId, null, existingUserMap, new HashSet<>());
     }
 
+    /**
+     * upsert 핵심 로직.
+     *
+     * @param appjamUserMap   배치: 미리 조회한 AppjamUser 맵 / 단건: null (내부 DB 조회)
+     * @param existingUserMap 배치: 미리 조회한 SoptampUser 맵 / 단건: 1건 맵 또는 빈 맵
+     * @param reservedNicknames 청크 내 이미 할당된 닉네임 셋 (중복 방지)
+     */
     private void upsertSoptampUserCore(PlatformUserInfoResponse profile, Long userId,
             Map<Long, AppjamUser> appjamUserMap,
             Map<Long, SoptampUser> existingUserMap,
@@ -112,6 +128,9 @@ public class SoptampUserService {
         }
     }
 
+    /* ==================== NORMAL 시즌용 upsert ==================== */
+
+    // 기본 시즌용 upsert (파트 + 이름 기반 닉네임)
     private void upsertSoptampUserNormal(PlatformUserInfoResponse profile, Long userId,
             PlatformUserInfoResponse.SoptActivities latest,
             Map<Long, SoptampUser> existingUserMap,
@@ -156,6 +175,8 @@ public class SoptampUserService {
         return !registeredUser.getGeneration().equals(profileGeneration);
     }
 
+    // ==================== 앱잼 시즌용 upsert ====================
+
     private void upsertSoptampUserForAppjam(PlatformUserInfoResponse profile,
             Long userId,
             PlatformUserInfoResponse.SoptActivities latest,
@@ -169,10 +190,12 @@ public class SoptampUserService {
             return;
         }
 
+        // 이미 앱잼 규칙이 적용된 닉네임이면 그대로 둠 (비트OOO, 37기OOO 등)
         if (!needsAppjamNicknameMigration(registeredUser)) {
             return;
         }
 
+        // 여기까지 오면: 기존 닉네임이 "서버OOO" 같은 파트 기반 → 앱잼 닉네임으로 변환
         String baseNickname = buildAppjamBaseNickname(profile, userId, appjamUserMap);
         String uniqueNickname = generateUniqueNicknameInternal(baseNickname, userId, reservedNicknames);
 
@@ -183,6 +206,7 @@ public class SoptampUserService {
                 uniqueNickname
             );
 
+        // 앱잼 변환 시점에 한 번 포인트 초기화
         registeredUser.initTotalPoints();
         this.raiseAllCacheSyncEvent(registeredUser);
     }
@@ -203,7 +227,7 @@ public class SoptampUserService {
                 uniqueNickname,
                 (long) profile.lastGeneration(),
                 findSoptPartByPartName(part));
-        newSoptampUser.initTotalPoints();
+        newSoptampUser.initTotalPoints(); // 새 시즌이니 0점부터
 
         soptampUserRepository.save(newSoptampUser);
         this.raiseAllCacheSyncEvent(newSoptampUser);
@@ -212,21 +236,32 @@ public class SoptampUserService {
     private boolean needsAppjamNicknameMigration(SoptampUser user) {
         String nickname = user.getNickname();
         if (nickname == null || nickname.isBlank()) {
+            // 닉네임이 비어 있으면 앱잼 규칙으로 한 번 세팅해 주는 게 자연스러움
             return true;
         }
 
+        // SoptPart 기준으로 "서버", "기획" 같은 축약/프리픽스를 모두 검사 (SOPT 파트만)
         for (SoptPart part : SoptPart.values()) {
             if (!part.isSoptPart())
                 continue;
             String prefix = part.getShortedPartName();
             if (nickname.startsWith(prefix)) {
+                // 서버김솝트, 디자인김솝트 등 → 기존 시즌(파트 기반) 닉네임이므로 앱잼 변환 필요
                 return true;
             }
         }
 
+        // 그 외 (비트김솝트, 37기김솝트 등) → 이미 앱잼 스타일로 적용된 걸로 간주
         return false;
     }
 
+    /**
+     * 앱잼용 base nickname 생성
+     * 1. AppjamUser에 있으면: teamName + 이름 (ex. 비트김솝트)
+     * 2. 없으면: lastGeneration + "기" + 이름 (ex. 37기김솝트)
+     *
+     * @param appjamUserMap 배치 호출 시 미리 로드된 맵 (null이면 DB 단건 조회)
+     */
     private String buildAppjamBaseNickname(PlatformUserInfoResponse profile, Long userId,
             Map<Long, AppjamUser> appjamUserMap) {
         Optional<AppjamUser> appjamUser = (appjamUserMap != null)
@@ -237,8 +272,14 @@ public class SoptampUserService {
             .orElseGet(() -> profile.lastGeneration() + "기" + profile.name());
     }
 
+    // ==================== 닉네임 유니크 로직 공통부 ====================
+
     private static final String SUFFIX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
+    /**
+     * 파트 기반 닉네임 (NORMAL 시즌용)
+     * ex. "서버" + "김솝트" → "서버김솝트"
+     */
     private String generatePartBasedUniqueNickname(String name, String part, Long currentUserIdOrNull,
             Set<String> reservedNicknames) {
         String prefixPartName = SoptPart.findSoptPartByPartName(part).getShortedPartName();
@@ -246,6 +287,12 @@ public class SoptampUserService {
         return generateUniqueNicknameInternal(baseNickname, currentUserIdOrNull, reservedNicknames);
     }
 
+    /**
+     * baseNickname을 기준으로 전역 유니크 닉네임 생성.
+     * - currentUserIdOrNull == null : 새 유저 생성 (existsByNickname)
+     * - currentUserIdOrNull != null : 내 row 제외하고 중복 체크
+     * - reservedNicknames : 같은 청크 내에서 이미 할당된 닉네임 (DB 조회 없이 충돌 방지)
+     */
     private String generateUniqueNicknameInternal(String baseNickname, Long currentUserIdOrNull,
             Set<String> reservedNicknames) {
         if (!existsNickname(baseNickname, currentUserIdOrNull) && !reservedNicknames.contains(baseNickname)) {
@@ -269,6 +316,8 @@ public class SoptampUserService {
         }
         return soptampUserRepository.existsByNicknameAndUserIdNot(nickname, currentUserIdOrNull);
     }
+
+    // ==================== 포인트/회원 탈퇴 로직 ====================
 
     @Transactional
     public void addPointByLevel(Long userId, Integer level) {

--- a/src/main/java/org/sopt/app/common/config/OperationConfig.java
+++ b/src/main/java/org/sopt/app/common/config/OperationConfig.java
@@ -38,4 +38,18 @@ public class OperationConfig extends BaseEntity {
 
     @Column(nullable = false)
     private String description;
+
+    public static OperationConfig of(OperationConfigCategory category, String key, String value, String description) {
+        OperationConfig config = new OperationConfig();
+        config.key = key;
+        config.value = value;
+        config.operationConfigType = OperationConfigType.TEXT;
+        config.operationConfigCategory = category;
+        config.description = description;
+        return config;
+    }
+
+    public void updateValue(String newValue) {
+        this.value = newValue;
+    }
 }

--- a/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
+++ b/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
@@ -3,5 +3,6 @@ package org.sopt.app.common.config;
 public enum OperationConfigCategory {
     FLOATING_BUTTON,
     REVIEW_FORM,
-    PLAYGROUND_POST
+    PLAYGROUND_POST,
+    SOPTAMP_BATCH
 }

--- a/src/main/java/org/sopt/app/facade/AdminSoptampFacade.java
+++ b/src/main/java/org/sopt/app/facade/AdminSoptampFacade.java
@@ -1,10 +1,8 @@
 package org.sopt.app.facade;
 
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.sopt.app.application.platform.PlatformService;
-import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.app.application.appservice.OperationConfigService;
 import org.sopt.app.application.soptamp.SoptampUserService;
 import org.sopt.app.application.stamp.ClapService;
 import org.sopt.app.application.stamp.StampService;
@@ -12,6 +10,7 @@ import org.sopt.app.interfaces.postgres.ClapMilestoneGuard;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminSoptampFacade {
@@ -20,7 +19,7 @@ public class AdminSoptampFacade {
     private final SoptampUserService soptampUserService;
     private final ClapService clapService;
     private final ClapMilestoneGuard clapMilestoneGuard;
-    private final PlatformService platformService;
+    private final OperationConfigService operationConfigService;
 
     @Transactional
     public void clearSoptampData(boolean stamp, boolean soptampUser) {
@@ -44,9 +43,9 @@ public class AdminSoptampFacade {
         soptampUserService.initSoptampRankCache();
     }
 
-    public void upsertAllSoptampUsers() {
-        List<Long> targetUserIds = soptampUserService.getUpsertTargetUserIds();
-        Map<Long, PlatformUserInfoResponse> profileMap = platformService.getPlatformUserInfosAsMap(targetUserIds);
-        soptampUserService.upsertAllSoptampUsers(profileMap);
+    @Transactional
+    public void updateUpsertBatchSchedule(String cron) {
+        operationConfigService.updateSoptampBatchConfig(cron);
+        log.info("솝탬프 upsert 배치 스케줄 변경. cron={}", cron);
     }
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/OperationConfigRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/OperationConfigRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface OperationConfigRepository extends JpaRepository<OperationConfig, Long> {
     Optional<List<OperationConfig>> findByOperationConfigCategory(OperationConfigCategory operationConfigCategory);
+    Optional<OperationConfig> findByOperationConfigCategoryAndKey(OperationConfigCategory category, String key);
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/SoptampUserRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/SoptampUserRepository.java
@@ -5,8 +5,12 @@ import java.util.List;
 import java.util.Optional;
 import org.sopt.app.domain.entity.soptamp.SoptampUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SoptampUserRepository extends JpaRepository<SoptampUser, Long> {
+
+    @Query("SELECT u.userId FROM SoptampUser u")
+    List<Long> findAllUserIds();
 
     Optional<SoptampUser> findByUserId(Long userId);
 

--- a/src/main/java/org/sopt/app/presentation/admin/AdminSoptampController.java
+++ b/src/main/java/org/sopt/app/presentation/admin/AdminSoptampController.java
@@ -11,8 +11,9 @@ import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.facade.AdminSoptampFacade;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -75,24 +76,34 @@ public class AdminSoptampController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "솝탬프 유저 일괄 upsert")
+    @Operation(summary = "솝탬프 upsert 배치 스케줄 설정")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "success"),
         @ApiResponse(responseCode = "401", description = "token error", content = @Content),
         @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    @PostMapping("/upsert")
-    public ResponseEntity<Void> upsertAllSoptampUsers(
-        @RequestParam(name = "password") String password
+    @PatchMapping("/upsert/schedule")
+    public ResponseEntity<Void> updateUpsertBatchSchedule(
+        @RequestParam(name = "password") String password,
+        @RequestParam(name = "cron") String cron
     ) {
         validateAdmin(password);
-        adminSoptampFacade.upsertAllSoptampUsers();
+        validateCron(cron);
+        adminSoptampFacade.updateUpsertBatchSchedule(cron);
         return ResponseEntity.ok().build();
     }
 
     private void validateAdmin(String password) {
         if (!password.equals(adminPassword)) {
             throw new BadRequestException(ErrorCode.INVALID_APP_ADMIN_PASSWORD);
+        }
+    }
+
+    private void validateCron(String cron) {
+        try {
+            new CronTrigger(cron);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(ErrorCode.INVALID_PARAMETER);
         }
     }
 }

--- a/src/main/java/org/sopt/app/presentation/admin/schedule/AdminScheduleController.java
+++ b/src/main/java/org/sopt/app/presentation/admin/schedule/AdminScheduleController.java
@@ -37,7 +37,7 @@ public class AdminScheduleController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "솝탬프 유저 upsert 배치 실행")
+    @Operation(summary = "솝탬프/앱잼탬프 유저 upsert 배치 실행")
     @PostMapping("/soptamp/upsert")
     public ResponseEntity<Void> upsertSoptampUsers(
         @RequestHeader("x-admin-password") String password

--- a/src/main/java/org/sopt/app/presentation/admin/schedule/AdminScheduleController.java
+++ b/src/main/java/org/sopt/app/presentation/admin/schedule/AdminScheduleController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.rank.RankScheduler;
+import org.sopt.app.application.soptamp.SoptampBatchService;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.response.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Profile("lambda")
 public class AdminScheduleController {
     private final RankScheduler rankScheduler;
+    private final SoptampBatchService soptampBatchService;
 
     @Value("${makers.app.admin.password}")
     private String adminPassword;
@@ -32,6 +34,16 @@ public class AdminScheduleController {
     ){
         validateAdmin(password);
         rankScheduler.executeSoptampRank();
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "솝탬프 유저 upsert 배치 실행")
+    @PostMapping("/soptamp/upsert")
+    public ResponseEntity<Void> upsertSoptampUsers(
+        @RequestHeader("x-admin-password") String password
+    ){
+        validateAdmin(password);
+        soptampBatchService.upsertAllSoptampUsers();
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
## Related issue

- closes #754

## Work Description

솝탬프 유저 upsert를 수동 어드민 API 실행 방식에서 자동 스케줄 배치 방식으로 전환했습니다.

- 기존 `POST /api/v2/admin/soptamp/upsert` 수동 실행 API 제거
- `PATCH /api/v2/admin/soptamp/upsert/schedule` 추가
  - cron 표현식 검증 후 DB의 `operation_configs`에 저장
  - DB 설정이 없으면 기본값 `0 0 3 * * *` 사용
- `SoptampUpsertScheduler` 추가
  - lambda 프로필이 아닐 때만 동작
  - DB에 저장된 cron 기준으로 솝탬프 upsert 배치 실행
- Lambda 프로필용 배치 실행 API 추가
  - `POST /api/v2/admin/schedule/soptamp/upsert`
  - 외부 cron 또는 GitHub Actions schedule에서 dev Lambda 배치를 실행할 때 사용
- `SoptampBatchService` 추가
  - 100명 단위 청크로 분할 처리
  - 청크별 예외 처리로 일부 실패가 전체 배치를 막지 않도록 구성
- 일반 솝탬프 모드
  - 기존 `soptamp_user` 대상 유저 기준으로 플랫폼 API 프로필을 조회해 갱신
- 앱잼 모드
  - 플랫폼 API를 사용하지 않고 auth DB의 `users`, `user_activity_histories`를 직접 조회
  - 한 번도 로그인하지 않은 OB 포함 전체 유저를 대상으로 `SoptampUser` 생성/갱신
  - auth DB의 part/role/team 코드를 기존 `SoptPart` 기준 값으로 변환
- 배치 upsert 성능 개선
  - 청크 단위로 `SoptampUser`, `AppjamUser`를 일괄 조회해 반복 DB 조회를 줄임
  - 같은 청크 안에서 생성되는 닉네임 중복을 방지

## To Reviewers

스케줄 변경 예시:

```http
PATCH /api/v2/admin/soptamp/upsert/schedule?password={password}&cron=0 0 3 * * *
```

cron 변경은 DB에 저장되며, 스케줄러가 다음 실행 시각을 계산할 때 최신 값을 읽어 반영합니다. API 호출 자체가 배치를 즉시 실행하지는 않습니다.

Lambda 환경에서 외부 스케줄러가 배치를 직접 실행할 때:

```http
POST /api/v2/admin/schedule/soptamp/upsert
x-admin-password: {password}
```

## Verification

```bash
./gradlew test
git diff --check
```
