### PR TITLE
[Fix] #754: 앱잼 upsert 파트 매핑 수정

### DIFF
--- a/src/main/java/org/sopt/app/application/soptamp/AuthSoptPartMapper.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthSoptPartMapper.java
@@ -1,5 +1,7 @@
 package org.sopt.app.application.soptamp;
 
+import java.util.EnumSet;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.sopt.app.domain.enums.SoptPart;
@@ -10,6 +12,14 @@ import org.sopt.app.domain.enums.SoptPart;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class AuthSoptPartMapper {
 
+    /**
+     * soptamp_user.part CHECK 제약에 포함되지 않는 auth 활동 파트는 NONE으로 처리한다.
+     */
+    private static final Set<SoptPart> UNSUPPORTED_SOPTAMP_PARTS = EnumSet.of(
+        SoptPart.BACKEND, SoptPart.FRONTEND, SoptPart.PM,
+        SoptPart.MARKETER, SoptPart.RESEARCHER, SoptPart.ORGANIZER, SoptPart.CX
+    );
+
     static String toSoptPartName(String partCode, String roleCode, String teamCode) {
         if (roleCode == null) {
             return toBasePartName(partCode);
@@ -18,7 +28,7 @@ final class AuthSoptPartMapper {
             case "PRESIDENT" -> SoptPart.PRESIDENT.getPartName();
             case "VICE_PRESIDENT" -> SoptPart.VICE_PRESIDENT.getPartName();
             case "GENERAL_AFFAIRS" -> SoptPart.GENERAL_AFFAIR.getPartName();
-            case "ART_DIRECTOR" -> SoptPart.ART_DIRECTOR.getPartName();
+            case "ART_DIRECTOR" -> SoptPart.NONE.getPartName();
             case "TEAM_LEADER" -> toTeamLeaderPartName(teamCode);
             case "PART_LEADER" -> toPartLeaderPartName(partCode);
             default -> toBasePartName(partCode);
@@ -54,7 +64,11 @@ final class AuthSoptPartMapper {
 
     private static String toBasePartName(String partCode) {
         try {
-            return SoptPart.valueOf(partCode).getPartName();
+            SoptPart part = SoptPart.valueOf(partCode);
+            if (UNSUPPORTED_SOPTAMP_PARTS.contains(part)) {
+                return SoptPart.NONE.getPartName();
+            }
+            return part.getPartName();
         } catch (IllegalArgumentException | NullPointerException e) {
             return SoptPart.NONE.getPartName();
         }

--- a/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
+++ b/src/main/java/org/sopt/app/application/soptamp/AuthUserProfileReader.java
@@ -40,6 +40,7 @@ public class AuthUserProfileReader {
                        uah.team
                 FROM %s.users u
                 JOIN %s.user_activity_histories uah ON uah.user_id = u.id
+                ORDER BY u.id, uah.generation, uah.is_sopt DESC
                 """.formatted(authSchema, authSchema);
 
         Map<Long, AuthUserProfile> profileMap = new HashMap<>();

--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -186,7 +186,7 @@ public class SoptampUserService {
         }
 
         // 이미 앱잼 규칙이 적용된 닉네임이면 그대로 둠 (비트OOO, 37기OOO 등)
-        if (!needsAppjamNicknameMigration(registeredUser, profile.name())) {
+        if (!needsAppjamNicknameMigration(registeredUser)) {
             return;
         }
 
@@ -224,13 +224,7 @@ public class SoptampUserService {
         raiseAllCacheSyncEvent(newSoptampUser);
     }
 
-    /**
-     * "파트명 + 이름" 형식의 구시즌 닉네임이면 앱잼 닉네임으로 변환 필요.
-     * profileName을 함께 받아 "파트명"만으로 prefix 체크하는 오탐을 방지.
-     * (예: 앱잼 팀명 "서버" + 이름 "김솝트" → "서버김솝트"는 구시즌 형식과 구별 불가 → 변환)
-     * (예: 앱잼 팀명 "비트" + 이름 "김솝트" → "비트김솝트"는 어떤 파트 prefix + 이름과도 불일치 → 유지)
-     */
-    private boolean needsAppjamNicknameMigration(SoptampUser user, String profileName) {
+    private boolean needsAppjamNicknameMigration(SoptampUser user) {
         String nickname = user.getNickname();
         if (nickname == null || nickname.isBlank()) {
             return true;
@@ -238,7 +232,7 @@ public class SoptampUserService {
 
         for (SoptPart part : SoptPart.values()) {
             if (!part.isSoptPart()) continue;
-            if (nickname.startsWith(part.getShortedPartName() + profileName)) {
+            if (nickname.startsWith(part.getShortedPartName())) {
                 return true;
             }
         }


### PR DESCRIPTION
## Related issue 🛠

- Related to #754

## Work Description ✏️

- 앱잼 upsert 배치에서 auth DB의 Makers Chapter 파트와 `ART_DIRECTOR`가 `soptamp_user.part` CHECK 제약을 위반하지 않도록 `NONE`으로 매핑했습니다.
- auth 활동 이력을 조회할 때 같은 기수의 SOPT 활동을 우선하도록 정렬을 추가했습니다.
- 앱잼 닉네임 마이그레이션 판단 기준을 분리 전 방식과 동일하게 SOPT 파트 prefix 기준으로 되돌렸습니다.
- 닉네임 알파벳 suffix 후보가 모두 소진되면 숫자 suffix로 추가 후보를 생성하도록 확장했습니다.

## Related ScreenShot 📷

- 없음

## To Reviewers 📢

- 배치 대상은 기존처럼 auth DB 전체 유저 기준을 유지합니다.
- 닉네임 변경 기준은 분리 전 앱 호출 시점의 동작과 동일하게 맞췄습니다.
- 확인: `./gradlew test --tests org.sopt.app.application.SoptampUserServiceTest`
