### PR TITLE
[Fix] #754: 닉네임 suffix 확장

### DIFF
--- a/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
+++ b/src/main/java/org/sopt/app/application/soptamp/SoptampUserService.java
@@ -298,6 +298,15 @@ public class SoptampUserService {
                 return candidate;
             }
         }
+
+        for (int n = 1; n <= 9999; n++) {
+            String candidate = baseNickname + n;
+            if (!existsNickname(candidate, currentUserIdOrNull) && !reservedNicknames.contains(candidate)) {
+                reservedNicknames.add(candidate);
+                return candidate;
+            }
+        }
+
         throw new BadRequestException(ErrorCode.NICKNAME_IS_FULL);
     }
 

--- a/src/test/java/org/sopt/app/application/SoptampUserServiceTest.java
+++ b/src/test/java/org/sopt/app/application/SoptampUserServiceTest.java
@@ -739,6 +739,41 @@ class SoptampUserServiceTest {
     }
 
     @Test
+    @DisplayName("SUCCESS_동일한 파트, 이름의 닉네임 알파벳 후보가 모두 존재하면 숫자 suffix로 생성함")
+    void SUCCESS_upsertSoptampUser_whenAlphabetSuffixExhausted() {
+        //given
+        final Long userId = 1L;
+        final Long generation = 37L;
+        final int platformUserId = userId.intValue();
+
+        final SoptActivities activities = SoptampUserFixture.getSoptActivities(generation.intValue(), PLATFORM_PART_NAME_SERVER);
+
+        final PlatformUserInfoResponse platformUserInfoResponse = SoptampUserFixture.getPlatformUserInfoResponse(platformUserId, List.of(activities));
+
+        final String baseNickname = PLATFORM_PART_NAME_SERVER + platformUserInfoResponse.name();
+
+        when(soptampUserRepository.findByUserId(anyLong())).thenReturn(Optional.empty());
+        when(soptampUserRepository.existsByNickname(baseNickname)).thenReturn(true);
+        for (char suffix : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray()) {
+            when(soptampUserRepository.existsByNickname(baseNickname + suffix)).thenReturn(true);
+        }
+        when(soptampUserRepository.existsByNickname(baseNickname + "1")).thenReturn(false);
+
+        // when
+        soptampUserService.upsertSoptampUser(platformUserInfoResponse, userId);
+
+        // then
+        ArgumentCaptor<SoptampUser> soptampUserArgumentCaptor = ArgumentCaptor.forClass(SoptampUser.class);
+        verify(soptampUserRepository).save(soptampUserArgumentCaptor.capture());
+        SoptampUser capturedSoptampUser = soptampUserArgumentCaptor.getValue();
+
+        assertThat(capturedSoptampUser)
+            .extracting(SoptampUser::getUserId, SoptampUser::getNickname, SoptampUser::getGeneration)
+            .contains(userId, baseNickname + "1", generation);
+        verify(eventPublisher).raise(any(SoptampUserAllCacheSyncEvent.class));
+    }
+
+    @Test
     @DisplayName("SUCCESS_soptampUser 가 이미 존재하는 경우 totalPoint를 초기화하고 기수와 파트를 최신으로 업데이트하고 이벤트를 발행함")
     void SUCCESS_upsertSoptampUser_whenAlreadyExist() {
         //given


### PR DESCRIPTION
## Related issue 🛠

- Related to #754

## Work Description ✏️

- 닉네임 알파벳 suffix 후보가 모두 소진되면 숫자 suffix로 추가 후보를 생성하도록 확장했습니다.
- 기존 후보 순서인 `base`, `baseA`~`baseZ`, `basea`~`basez`는 유지하고 이후 `base1`, `base2` 순서로 탐색합니다.
- 전체 유저 앱잼 upsert 배치에서 동명이인 fallback 닉네임이 53개를 초과해도 청크가 실패하지 않도록 보완했습니다.

## Related ScreenShot 📷

- 없음

## To Reviewers 📢
