### PR TITLE
[Feat] #763: 콕찌르기 중복 친구 생성 방지

### DIFF
--- a/src/main/java/org/sopt/app/application/friend/FriendService.java
+++ b/src/main/java/org/sopt/app/application/friend/FriendService.java
@@ -97,6 +97,9 @@ public class FriendService {
 
     @Transactional
     public void registerFriendshipOf(Long userId, Long friendId) {
+        if (friendRepository.existsByUserIdAndFriendUserId(userId, friendId)) {
+            return;
+        }
         Friend createdRelationUserToFriend = Friend.builder()
                 .userId(userId)
                 .friendUserId(friendId)

--- a/src/main/java/org/sopt/app/interfaces/postgres/FriendRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/FriendRepository.java
@@ -13,6 +13,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     Optional<Friend> findByUserIdAndFriendUserId(Long userId, Long friendId);
 
+    boolean existsByUserIdAndFriendUserId(Long userId, Long friendUserId);
+
     @Query("SELECT f.friendUserId FROM Friend f WHERE f.userId = :userId")
     Set<Long> findAllOfFriendIdsByUserId(@Param("userId") Long userId);
 

--- a/src/test/java/org/sopt/app/application/FriendServiceTest.java
+++ b/src/test/java/org/sopt/app/application/FriendServiceTest.java
@@ -1,37 +1,59 @@
-// package org.sopt.app.application;
-//
-// import static org.mockito.ArgumentMatchers.anyLong;
-// import static org.mockito.Mockito.when;
-//
-// import java.util.List;
-// import org.junit.jupiter.api.Assertions;
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.extension.ExtendWith;
-// import org.mockito.InjectMocks;
-// import org.mockito.Mock;
-// import org.mockito.junit.jupiter.MockitoExtension;
-// import org.sopt.app.application.friend.FriendService;
-// import org.sopt.app.interfaces.postgres.FriendRepository;
-//
-// @ExtendWith(MockitoExtension.class)
-// class FriendServiceTest {
-//
-//     @Mock
-//     private FriendRepository friendRepository;
-//
-//     @InjectMocks
-//     private FriendService friendService;
-//
-//     @Test
-//     @DisplayName("SUCCESS_친구가 없다면 새로운 유저로 판단하여 true 반환")
-//     void getIsNewUserSuccess() {
-//         //given
-//         final Long anyUserId = anyLong();
-//         //when
-//         when(friendRepository.findAllByFriendUserId(anyUserId)).thenReturn(List.of());
-//         when(friendRepository.findAllByUserIdAndFriendUserIdIn(anyUserId, List.of())).thenReturn(List.of());
-//         //then
-//         Assertions.assertTrue(friendService.getIsNewUser(anyUserId));
-//     }
-// }
+package org.sopt.app.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.friend.FriendService;
+import org.sopt.app.common.utils.AnonymousNameGenerator;
+import org.sopt.app.interfaces.postgres.FriendRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FriendServiceTest {
+
+    @Mock
+    private FriendRepository friendRepository;
+
+    @Mock
+    private AnonymousNameGenerator anonymousNameGenerator;
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Test
+    @DisplayName("SUCCESS_친구가 없다면 새로운 유저로 판단하여 true 반환")
+    void getIsNewUserSuccess() {
+        //given
+        final Long anyUserId = 1L;
+        //when
+        when(friendRepository.findAllByFriendUserId(anyUserId)).thenReturn(List.of());
+        when(friendRepository.findAllByUserIdAndFriendUserIdIn(anyUserId, List.of())).thenReturn(List.of());
+        //then
+        Assertions.assertTrue(friendService.getIsNewUser(anyUserId));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_이미 존재하는 친구 관계라면 저장하지 않음")
+    void registerFriendshipOf_이미_존재하는_경우_저장하지_않음() {
+        //given
+        Long userId = 1L;
+        Long friendId = 2L;
+        when(friendRepository.existsByUserIdAndFriendUserId(userId, friendId)).thenReturn(true);
+
+        //when
+        friendService.registerFriendshipOf(userId, friendId);
+
+        //then
+        verify(friendRepository, times(0)).save(any());
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #763 

## Work Description ✏️
-  콕찌르기 중복 친구 생성 방지를 위한 검증 로직 추가
- 유니크 인덱스 설정
``` sql
create unique index uk_friend_user_friend
    on app_prod.friend (user_id, friend_user_id);
```
<!-- 작업 내용을 간단히 소개주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

- 일단 작업 하는 김에 검증 로직을 추가 하긴 했는데.... 사실 중복 생성된 케이스가 검증 로직으로는 방어가 안되는 케이스긴 해요. 생성 요청을 완전 동시에 보내온 케이스여서.. 우선 안전하게 넣어두긴 했습니다! 
  - 검증 로직이 오히려 불필요한 오버헤드를 유발하는 것 같으신가요?
<img width="2419" height="253" alt="image" src="https://github.com/user-attachments/assets/f741cb87-c4b4-45ce-8ce2-099c6f0e3f57" />
