### PR TITLE
[Feat] #765: 솝레터 관련 엔티티 작성

### DIFF
--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -1,0 +1,42 @@
+package org.sopt.app.domain.entity.soptletter;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+import org.sopt.app.domain.entity.BaseEntity;
+import org.sopt.app.domain.enums.SoptLetterShapeType;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SoptLetter extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long authorProfileId;
+
+    private Long topicId;
+
+    private Double degree;
+
+    private String message;
+
+    @Length(max = 7)
+    private String hexCode;
+
+    @Enumerated(EnumType.STRING)
+    private SoptLetterShapeType shapeType;
+}

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -1,5 +1,6 @@
 package org.sopt.app.domain.entity.soptletter;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -30,8 +31,10 @@ public class SoptLetter extends BaseEntity {
 
     private Long topicId;
 
+    @Column(nullable = false)
     private Double degree;
 
+    @Column(length = 350, nullable = false)
     private String message;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -11,8 +11,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.Length;
 import org.sopt.app.domain.entity.BaseEntity;
+import org.sopt.app.domain.enums.SoptLetterColor;
 import org.sopt.app.domain.enums.SoptLetterShapeType;
 
 @Entity
@@ -34,8 +34,8 @@ public class SoptLetter extends BaseEntity {
 
     private String message;
 
-    @Length(max = 7)
-    private String hexCode;
+    @Enumerated(EnumType.STRING)
+    private SoptLetterColor color;
 
     @Enumerated(EnumType.STRING)
     private SoptLetterShapeType shapeType;

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -39,4 +39,6 @@ public class SoptLetter extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private SoptLetterShapeType shapeType;
+
+    private Integer likeCount;
 }

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterLike.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterLike.java
@@ -4,12 +4,23 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.app.domain.entity.BaseEntity;
 
 @Entity
+@Table(
+    name = "sopt_letter_like",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_sopt_letter_like_sopt_letter_user",
+            columnNames = {"letter_id", "user_id"}
+        )
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SoptLetterLike extends BaseEntity {

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterLike.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterLike.java
@@ -1,0 +1,25 @@
+package org.sopt.app.domain.entity.soptletter;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.app.domain.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SoptLetterLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private Long letterId;
+
+}

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterProfile.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterProfile.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +14,15 @@ import lombok.NoArgsConstructor;
 import org.sopt.app.domain.entity.BaseEntity;
 
 @Entity
+@Table(
+    name = "sopt_letter_profile",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_sopt_letter_profile_user",
+            columnNames = {"user_id"}
+        )
+    }
+)
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterProfile.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterProfile.java
@@ -1,0 +1,29 @@
+package org.sopt.app.domain.entity.soptletter;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.app.domain.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SoptLetterProfile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String nickname;
+
+}

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
@@ -1,0 +1,23 @@
+package org.sopt.app.domain.entity.soptletter;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.app.domain.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SoptLetterTopic extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+}

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
@@ -1,5 +1,6 @@
 package org.sopt.app.domain.entity.soptletter;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,6 +19,7 @@ public class SoptLetterTopic extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String content;
+    @Column(nullable = false)
+    private String title;
 
 }

--- a/src/main/java/org/sopt/app/domain/enums/SoptLetterColor.java
+++ b/src/main/java/org/sopt/app/domain/enums/SoptLetterColor.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SoptLetterColor {
 
-    BLUE("#C8E1FF"),
-    YELLOW("#FFF4D4"),
-    GREEN("#CCFFEC"),
-    RED("#FFD1D3"),
+    BLUE_50("#C8E1FF"),
+    YELLOW_50("#FFF4D4"),
+    GREEN_50("#CCFFEC"),
+    RED_50("#FFD1D3"),
     ;
 
     private final String hexCode;

--- a/src/main/java/org/sopt/app/domain/enums/SoptLetterColor.java
+++ b/src/main/java/org/sopt/app/domain/enums/SoptLetterColor.java
@@ -1,0 +1,18 @@
+package org.sopt.app.domain.enums;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SoptLetterColor {
+
+    BLUE("#C8E1FF"),
+    YELLOW("#FFF4D4"),
+    GREEN("#CCFFEC"),
+    RED("#FFD1D3"),
+    ;
+
+    private final String hexCode;
+}

--- a/src/main/java/org/sopt/app/domain/enums/SoptLetterShapeType.java
+++ b/src/main/java/org/sopt/app/domain/enums/SoptLetterShapeType.java
@@ -1,0 +1,12 @@
+package org.sopt.app.domain.enums;
+
+public enum SoptLetterShapeType {
+    SMOOTH,
+    SHARP,
+    POINT,
+    CLOUD,
+    ;
+
+
+
+}

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.app.interfaces.postgres.soptletter;
+
+import org.sopt.app.domain.entity.soptletter.SoptLetterLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, Long> {
+
+}

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterProfileRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterProfileRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.app.interfaces.postgres.soptletter;
+
+import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SoptLetterProfileRepository extends JpaRepository<SoptLetterProfile, Long> {
+
+}

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.app.interfaces.postgres.soptletter;
+
+
+import org.sopt.app.domain.entity.soptletter.SoptLetter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SoptLetterRepository extends JpaRepository<SoptLetter, Long> {
+
+}

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.app.interfaces.postgres.soptletter;
+
+import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic, Long> {
+
+}

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -1,0 +1,14 @@
+package org.sopt.app.presentation.soptletter;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/sopt-letter")
+@SecurityRequirement(name = "Authorization")
+public class SoptLetterController {
+
+}

--- a/src/test/java/org/sopt/app/facade/AppjamRankFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/AppjamRankFacadeTest.java
@@ -1,13 +1,16 @@
 package org.sopt.app.facade;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -19,10 +22,9 @@ import org.sopt.app.application.appjamrank.AppjamRankService;
 import org.sopt.app.application.playground.PlaygroundAuthService;
 import org.sopt.app.common.utils.CurrentDate;
 import org.sopt.app.domain.entity.AppjamUser;
+import org.sopt.app.domain.enums.AppjamTeamSortType;
 import org.sopt.app.domain.enums.TeamNumber;
 import org.sopt.app.interfaces.postgres.StampRepositoryCustom;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class AppjamRankFacadeTest {
@@ -80,7 +82,8 @@ class AppjamRankFacadeTest {
 			));
 
 		// when
-		AppjamRankInfo.TodayTeamRankList result = appjamRankFacade.findTodayTeamRanks(10);
+		AppjamRankInfo.TodayTeamRankList result = appjamRankFacade.findTodayTeamRanks(10,
+            AppjamTeamSortType.SCORE);
 
 		// then: 팀 랭킹은 2팀(FIRST, SECOND)만 존재
 		assertThat(result).isNotNull();


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #765 

## Work Description ✏️



- 도메인 엔티티 구현
  * `SoptLetter`: 프로필 ID, 토픽 ID, 각도(Double), 메시지, 색상 및 모양 타입을 필드로 가지는 메인 엔티티 
  * `SoptLetterLike`: 좋아요 데이터 적재를 위한 엔티티 구현 및 `likeCount` 필드 연동
  * `SoptLetterProfile`: 토픽별 확장성을 고려한 사용자 프로필 엔티티 구현
  * `SoptLetterTopic`: 솝래터 주제 관리를 위한 엔티티 구현


- 인덱스 및 제약 조건 명시
  * `SoptLetterLike`: 동일 사용자의 중복 좋아요 방지를 위해 `letter_id`, `user_id` 복합 유니크 인덱스 생성
  * `SoptLetterProfile`: 당장은 1인 1프로필 정책이므로 `user_id` 유니크 인덱스 설정


<!-- 작업 내용을 간단히 소개주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢
@kyoooooong 
- 디폴트 토픽 관리 방식을 어떤 방향으로 가져갈지.. 지금은 후자가 좋아보이긴 해요. 
  - 아래처럼 Enum으로 관리하는 방식
    ``` java
    @Getter
    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
    public enum SoptLetterTopicStatus {
    
        NORMAL("일반적인 주제"),
        DEFAULT("기본값으로 반환되는 주제. DB 내에서 Default인 주제는 하나만 존재"),
        ;
    
        private final String description;
    }
    ```
  - OperationConfig에서 key-value(예: `DEFAULT_SOPT_LETTER_TOPIC_ID`) 형태로 디폴트 ID를 관리하는 방식

- 색상 데이터 타입 결정 (String hexCode vs Enum)
  * 확장성을 고려해서 String(hexCode) 관리 방식을 고민했으나, 현재 기획상 정해진 색상 내에서 선택한다는 점과 잘못된 문자열의 유입 차단, 메타데이터 관리의 용이성을 위해 Enum으로 관리하도록 했는데, 의견 주세요~

- SoptLetterProfile PK
  * `userId`를 그대로 PK로 사용하지 않고 인조 식별자를 별도로 생성했습니다. 추후 토픽마다 프로필이 달라지거나 다중 프로필 구조로 유연하게 확장될 가능성을 대비하기 위함,,입니다. 당장은 유연성을 확보하되 1인 1프로필 무결성을 위해 `user_id`에 유니크 인덱스를 명시해뒀습니다.

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->