### PR TITLE
[Feat] #762: 앱잼 오늘의 팀 랭킹 팀명 가나다 순 정렬 파라미터 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/appjamrank/AppjamRankCalculator.java
+++ b/src/main/java/org/sopt/app/application/appjamrank/AppjamRankCalculator.java
@@ -93,8 +93,7 @@ public class AppjamRankCalculator {
 			.sorted(Comparator
 				.comparingLong(TeamAggregate::todayPoints).reversed()
 				.thenComparing(TeamAggregate::firstCertifiedAtToday, Comparator.nullsLast(Comparator.naturalOrder()))
-				.thenComparing(TeamAggregate::teamNumber)
-			)
+				.thenComparing(TeamAggregate::teamNumber))
 			.limit(size)
 			.toList();
 

--- a/src/main/java/org/sopt/app/domain/enums/AppjamTeamSortType.java
+++ b/src/main/java/org/sopt/app/domain/enums/AppjamTeamSortType.java
@@ -1,0 +1,6 @@
+package org.sopt.app.domain.enums;
+
+public enum AppjamTeamSortType {
+    NAME,
+    SCORE
+}

--- a/src/main/java/org/sopt/app/facade/AppjamRankFacade.java
+++ b/src/main/java/org/sopt/app/facade/AppjamRankFacade.java
@@ -1,6 +1,7 @@
 package org.sopt.app.facade;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -13,6 +14,7 @@ import org.sopt.app.application.playground.PlaygroundAuthService;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
 import org.sopt.app.common.utils.CurrentDate;
 import org.sopt.app.domain.entity.AppjamUser;
+import org.sopt.app.domain.enums.AppjamTeamSortType;
 import org.sopt.app.domain.enums.TeamNumber;
 import org.sopt.app.interfaces.postgres.StampRepositoryCustom;
 import org.springframework.data.domain.PageRequest;
@@ -58,7 +60,7 @@ public class AppjamRankFacade {
 	 * 오늘 팀 랭킹 (캐시 없이 DB 기반)
 	 * - 전체 팀을 항상 보여주기 위해 effectiveSize는 teamCount 이상 보장
 	 */
-	public AppjamRankInfo.TodayTeamRankList findTodayTeamRanks(int size) {
+	public AppjamRankInfo.TodayTeamRankList findTodayTeamRanks(int size, AppjamTeamSortType sort) {
 		LocalDateTime todayStart = CurrentDate.now().atStartOfDay();
 		LocalDateTime tomorrowStart = todayStart.plusDays(1);
 
@@ -88,12 +90,21 @@ public class AppjamRankFacade {
 			Map.of()
 		);
 
-		return calculator.calculateTodayTeamRanks(
+		AppjamRankInfo.TodayTeamRankList result = calculator.calculateTodayTeamRanks(
 			todayUserRanks,
 			totalPointsByUserId,
 			allAppjamUsers,
 			effectiveSize
 		);
+
+		if (sort == AppjamTeamSortType.NAME) {
+			return AppjamRankInfo.TodayTeamRankList.of(
+				result.getRanks().stream()
+					.sorted(Comparator.comparing(AppjamRankInfo.TodayTeamRank::getTeamName))
+					.toList()
+			);
+		}
+		return result;
 	}
 
 	public Integer findMyTeamRank(final Long userId) {
@@ -103,7 +114,7 @@ public class AppjamRankFacade {
 		}
 
 		TeamNumber myTeamNumber = myAppjamUser.getTeamNumber();
-		AppjamRankInfo.TodayTeamRankList ranks = findTodayTeamRanks(0);
+		AppjamRankInfo.TodayTeamRankList ranks = findTodayTeamRanks(0, AppjamTeamSortType.SCORE);
 
 		return ranks.getRanks().stream()
 			.filter(r -> r.getTeamNumber() == myTeamNumber)

--- a/src/main/java/org/sopt/app/presentation/appjamrank/AppjamRankController.java
+++ b/src/main/java/org/sopt/app/presentation/appjamrank/AppjamRankController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import org.sopt.app.application.appjamrank.AppjamRankInfo;
+import org.sopt.app.domain.enums.AppjamTeamSortType;
 import org.sopt.app.facade.AppjamRankFacade;
 import org.sopt.app.presentation.appjamtamp.AppjamtampResponseMapper;
 import org.springframework.http.ResponseEntity;
@@ -45,9 +46,10 @@ public class AppjamRankController {
 	})
 	@GetMapping("/today")
 	public ResponseEntity<AppjamRankResponse.AppjamTodayRankListResponse> getTodayTeamRanks(
-		@RequestParam(defaultValue = "11") @Min(1) int size
+		@RequestParam(defaultValue = "11") @Min(1) int size,
+		@RequestParam(defaultValue = "NAME") AppjamTeamSortType sort
 	) {
-		AppjamRankInfo.TodayTeamRankList appjamTodayTeamRankList = appjamRankFacade.findTodayTeamRanks(size);
+		AppjamRankInfo.TodayTeamRankList appjamTodayTeamRankList = appjamRankFacade.findTodayTeamRanks(size, sort);
 		AppjamRankResponse.AppjamTodayRankListResponse response = appjamtampResponseMapper.of(appjamTodayTeamRankList);
 
 		return ResponseEntity.ok(response);


### PR DESCRIPTION
## Related issue 🛠

- closes #762

## Work Description ✏️

`GET /api/v2/appjamrank/today` API에 `sort` 쿼리 파라미터 추가

- `sort=NAME` (기본값): 팀명 가나다 순 정렬
- `sort=SCORE`: 오늘 획득 점수 내림차순 (기존 동작)

## Related ScreenShot 📷

## To Reviewers 📢