### PR TITLE
[Feat] #775: 솝레터 작성/수정/삭제 기능 구현 

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterGenerator.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterGenerator.java
@@ -12,6 +12,11 @@ public class SoptLetterGenerator {
 
     private static final List<Double> ROTATION_DEGREES = List.of(-10.0, 0.0, 10.0);
 
+    private static class ShapeHolder {
+        private static final SoptLetterShapeType[] VALUES = SoptLetterShapeType.values();
+    }
+
+
     public SoptLetter generate(Long authorProfileId, Long topicId, String message, SoptLetterColor previousColor) {
         return SoptLetter.builder()
                 .authorProfileId(authorProfileId)
@@ -41,9 +46,9 @@ public class SoptLetterGenerator {
         return ROTATION_DEGREES.get(randomIndex);
     }
 
+
     private SoptLetterShapeType getRandomShapeType() {
-        SoptLetterShapeType[] shapes = SoptLetterShapeType.values();
-        int randomIndex = ThreadLocalRandom.current().nextInt(shapes.length);
-        return shapes[randomIndex];
+        return ShapeHolder.VALUES[ThreadLocalRandom.current().nextInt(ShapeHolder.VALUES.length)];
     }
+
 }

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterGenerator.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterGenerator.java
@@ -1,0 +1,49 @@
+package org.sopt.app.application.soptletter;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.sopt.app.domain.entity.soptletter.SoptLetter;
+import org.sopt.app.domain.enums.SoptLetterColor;
+import org.sopt.app.domain.enums.SoptLetterShapeType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SoptLetterGenerator {
+
+    private static final List<Double> ROTATION_DEGREES = List.of(-10.0, 0.0, 10.0);
+
+    public SoptLetter generate(Long authorProfileId, Long topicId, String message, SoptLetterColor previousColor) {
+        return SoptLetter.builder()
+                .authorProfileId(authorProfileId)
+                .topicId(topicId)
+                .degree(getRandomDegree())
+                .message(message)
+                .color(getNextColor(previousColor))
+                .shapeType(getRandomShapeType())
+                .likeCount(0)
+                .build();
+    }
+
+    private SoptLetterColor getNextColor(SoptLetterColor currentColor) {
+        if (currentColor == null) {
+            return SoptLetterColor.BLUE_50;
+        }
+        return switch (currentColor) {
+            case BLUE_50 -> SoptLetterColor.GREEN_50;
+            case GREEN_50 -> SoptLetterColor.YELLOW_50;
+            case YELLOW_50 -> SoptLetterColor.RED_50;
+            case RED_50 -> SoptLetterColor.BLUE_50;
+        };
+    }
+
+    private Double getRandomDegree() {
+        int randomIndex = ThreadLocalRandom.current().nextInt(ROTATION_DEGREES.size());
+        return ROTATION_DEGREES.get(randomIndex);
+    }
+
+    private SoptLetterShapeType getRandomShapeType() {
+        SoptLetterShapeType[] shapes = SoptLetterShapeType.values();
+        int randomIndex = ThreadLocalRandom.current().nextInt(shapes.length);
+        return shapes[randomIndex];
+    }
+}

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
@@ -1,11 +1,13 @@
 package org.sopt.app.application.soptletter;
 
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -24,6 +26,42 @@ public class SoptLetterInfo {
             return Profile.builder()
                 .nickname(profile.getNickname())
                 .isOnboarded(profile.isOnboarded())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class MessageResult {
+        private Long messageId;
+        private Long topicId;
+        private String authorNickname;
+        private String content;
+        private String colorCode;
+        private Double rotationDegree;
+        private String shapeType;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private Integer likeCount;
+        private Boolean likedByMe;
+        private Boolean mine;
+
+        public static MessageResult of(SoptLetter letter, String nickname, Boolean likedByMe, Boolean mine) {
+            return MessageResult.builder()
+                .messageId(letter.getId())
+                .topicId(letter.getTopicId())
+                .authorNickname(nickname)
+                .content(letter.getMessage())
+                .colorCode(letter.getColor().getHexCode())
+                .rotationDegree(letter.getDegree())
+                .shapeType(letter.getShapeType().name())
+                .createdAt(letter.getCreatedAt())
+                .updatedAt(letter.getUpdatedAt())
+                .likeCount(letter.getLikeCount())
+                .likedByMe(likedByMe)
+                .mine(mine)
                 .build();
         }
     }

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -131,5 +131,18 @@ public class SoptLetterService {
         val likedByMe = soptLetterLikeRepository.existsByLetterIdAndUserId(messageId, userId);
         return SoptLetterInfo.MessageResult.of(letter, profile.getNickname(), likedByMe, true);
     }
+
+    @Transactional
+    public void deleteSoptLetter(Long userId, Long messageId) {
+        val letter = soptLetterRepository.findById(messageId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
+        val profile = soptLetterProfileRepository.findByUserId(userId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
+
+        letter.validateDeletable(profile.getId());
+
+        soptLetterLikeRepository.deleteAllByLetterIdInQuery(letter.getId());
+        soptLetterRepository.delete(letter);
+    }
 }
 

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -87,8 +87,7 @@ public class SoptLetterService {
 
     @Transactional
     public Profile completeOnboarding(Long userId) {
-        SoptLetterProfile profile = soptLetterProfileRepository.findByUserId(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
+        SoptLetterProfile profile = getProfileByUserId(userId);
         profile.completeOnboarding();
         return Profile.from(profile);
     }
@@ -97,8 +96,7 @@ public class SoptLetterService {
     public SoptLetterInfo.MessageResult createSoptLetter(Long userId, Long topicId, String content) {
         val topic = soptLetterTopicRepository.findById(topicId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-        val profile = soptLetterProfileRepository.findByUserId(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
+        val profile = getProfileByUserId(userId);
 
         validateDailyMessageLimit(profile.getId(), LocalDateTime.now(clock));
 
@@ -120,29 +118,35 @@ public class SoptLetterService {
     }
 
     @Transactional
-    public SoptLetterInfo.MessageResult updateSoptLetter(Long userId, Long messageId, String content) {
-        val letter = soptLetterRepository.findById(messageId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
-        val profile = soptLetterProfileRepository.findByUserId(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
+    public SoptLetterInfo.MessageResult updateSoptLetter(Long userId, Long soptLetterId, String content) {
+        val letter = getSoptLetter(soptLetterId);
+        val profile = getProfileByUserId(userId);
 
         letter.updateMessage(profile.getId(), content);
 
-        val likedByMe = soptLetterLikeRepository.existsByLetterIdAndUserId(messageId, userId);
+        val likedByMe = soptLetterLikeRepository.existsByLetterIdAndUserId(soptLetterId, userId);
         return SoptLetterInfo.MessageResult.of(letter, profile.getNickname(), likedByMe, true);
     }
 
     @Transactional
-    public void deleteSoptLetter(Long userId, Long messageId) {
-        val letter = soptLetterRepository.findById(messageId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
-        val profile = soptLetterProfileRepository.findByUserId(userId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
+    public void deleteSoptLetter(Long userId, Long soptLetterId) {
+        val letter = getSoptLetter(soptLetterId);
+        val profile = getProfileByUserId(userId);
 
         letter.validateDeletable(profile.getId());
 
         soptLetterLikeRepository.deleteAllByLetterIdInQuery(letter.getId());
         soptLetterRepository.delete(letter);
+    }
+
+    public SoptLetter getSoptLetter(Long soptLetterId) {
+        return soptLetterRepository.findById(soptLetterId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
+    }
+
+    public SoptLetterProfile getProfileByUserId(Long userId) {
+        return soptLetterProfileRepository.findByUserId(userId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
     }
 }
 

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -111,7 +111,7 @@ public class SoptLetterService {
 
     private void validateDailyMessageLimit(Long profileId, LocalDateTime now) {
         val startOfDay = now.toLocalDate().atStartOfDay();
-        val todayCount = soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(profileId, startOfDay);
+        val todayCount = soptLetterRepository.countByAuthorProfileIdAndCreatedAtGreaterThanEqual(profileId, startOfDay);
         if (todayCount >= DAILY_MESSAGE_LIMIT) {
             throw new BadRequestException(ErrorCode.SOPT_LETTER_DAILY_LIMIT_EXCEEDED);
         }

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -5,13 +5,23 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
+import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.ConflictException;
 import org.sopt.app.common.exception.NotFoundException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.common.utils.AnonymousNameGenerator;
+import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
+import org.sopt.app.domain.enums.SoptLetterColor;
+import org.sopt.app.domain.enums.SoptLetterShapeType;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterProfileRepository;
+import org.sopt.app.interfaces.postgres.soptletter.SoptLetterRepository;
+import org.sopt.app.interfaces.postgres.soptletter.SoptLetterTopicRepository;
+import java.time.LocalDateTime;
+import java.time.Clock;
+import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,9 +33,14 @@ public class SoptLetterService {
 
     private static final int MAX_NICKNAME_RETRY_COUNT = 3;
     private static final int NICKNAME_CANDIDATE_SIZE = 3;
+    private static final int DAILY_MESSAGE_LIMIT = 10;
 
     private final SoptLetterProfileRepository soptLetterProfileRepository;
     private final AnonymousNameGenerator anonymousNameGenerator;
+    private final SoptLetterRepository soptLetterRepository;
+    private final SoptLetterTopicRepository soptLetterTopicRepository;
+    private final SoptLetterGenerator soptLetterGenerator;
+    private final Clock clock;
 
     public boolean isOnboarded(Long userId) {
         return soptLetterProfileRepository.existsByUserId(userId);
@@ -78,6 +93,35 @@ public class SoptLetterService {
         profile.completeOnboarding();
         return Profile.from(profile);
     }
+
+    @Transactional
+    public SoptLetterInfo.MessageResult writeMessage(Long userId, Long topicId, String content) {
+        val topic = soptLetterTopicRepository.findById(topicId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        val profile = soptLetterProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
+
+        val now = LocalDateTime.now(clock);
+        validateDailyMessageLimit(profile.getId(), now);
+
+        val latestLetterOpt = soptLetterRepository.findFirstByTopicIdOrderByIdDesc(topicId);
+        val latestColor = latestLetterOpt.map(SoptLetter::getColor).orElse(null);
+
+        val newLetter = soptLetterGenerator.generate(profile.getId(), topicId, content, latestColor);
+
+        val savedLetter = soptLetterRepository.save(newLetter);
+        return SoptLetterInfo.MessageResult.of(savedLetter, profile.getNickname(), false, true);
+    }
+
+    private void validateDailyMessageLimit(Long profileId, LocalDateTime now) {
+        val startOfDay = now.toLocalDate().atStartOfDay();
+        val todayCount = soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(profileId, startOfDay);
+        if (todayCount >= DAILY_MESSAGE_LIMIT) {
+            throw new BadRequestException(ErrorCode.SOPT_LETTER_DAILY_LIMIT_EXCEEDED);
+        }
+    }
+
 
 }
 

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -1,5 +1,7 @@
 package org.sopt.app.application.soptletter;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -14,14 +16,10 @@ import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.common.utils.AnonymousNameGenerator;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
-import org.sopt.app.domain.enums.SoptLetterColor;
-import org.sopt.app.domain.enums.SoptLetterShapeType;
+import org.sopt.app.interfaces.postgres.soptletter.SoptLetterLikeRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterProfileRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterTopicRepository;
-import java.time.LocalDateTime;
-import java.time.Clock;
-import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +37,7 @@ public class SoptLetterService {
     private final AnonymousNameGenerator anonymousNameGenerator;
     private final SoptLetterRepository soptLetterRepository;
     private final SoptLetterTopicRepository soptLetterTopicRepository;
+    private final SoptLetterLikeRepository soptLetterLikeRepository;
     private final SoptLetterGenerator soptLetterGenerator;
     private final Clock clock;
 
@@ -98,12 +97,10 @@ public class SoptLetterService {
     public SoptLetterInfo.MessageResult writeMessage(Long userId, Long topicId, String content) {
         val topic = soptLetterTopicRepository.findById(topicId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
         val profile = soptLetterProfileRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
 
-        val now = LocalDateTime.now(clock);
-        validateDailyMessageLimit(profile.getId(), now);
+        validateDailyMessageLimit(profile.getId(), LocalDateTime.now(clock));
 
         val latestLetterOpt = soptLetterRepository.findFirstByTopicIdOrderByIdDesc(topicId);
         val latestColor = latestLetterOpt.map(SoptLetter::getColor).orElse(null);
@@ -122,6 +119,17 @@ public class SoptLetterService {
         }
     }
 
+    @Transactional
+    public SoptLetterInfo.MessageResult updateMessage(Long userId, Long messageId, String content) {
+        val letter = soptLetterRepository.findById(messageId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
+        val profile = soptLetterProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
 
+        letter.updateMessage(profile.getId(), content);
+
+        val likedByMe = soptLetterLikeRepository.existsByLetterIdAndUserId(messageId, userId);
+        return SoptLetterInfo.MessageResult.of(letter, profile.getNickname(), likedByMe, true);
+    }
 }
 

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -94,7 +94,7 @@ public class SoptLetterService {
     }
 
     @Transactional
-    public SoptLetterInfo.MessageResult writeMessage(Long userId, Long topicId, String content) {
+    public SoptLetterInfo.MessageResult createSoptLetter(Long userId, Long topicId, String content) {
         val topic = soptLetterTopicRepository.findById(topicId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
         val profile = soptLetterProfileRepository.findByUserId(userId)
@@ -120,7 +120,7 @@ public class SoptLetterService {
     }
 
     @Transactional
-    public SoptLetterInfo.MessageResult updateMessage(Long userId, Long messageId, String content) {
+    public SoptLetterInfo.MessageResult updateSoptLetter(Long userId, Long messageId, String content) {
         val letter = soptLetterRepository.findById(messageId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
         val profile = soptLetterProfileRepository.findByUserId(userId)

--- a/src/main/java/org/sopt/app/common/config/ClockConfig.java
+++ b/src/main/java/org/sopt/app/common/config/ClockConfig.java
@@ -1,0 +1,14 @@
+package org.sopt.app.common.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/org/sopt/app/common/config/ClockConfig.java
+++ b/src/main/java/org/sopt/app/common/config/ClockConfig.java
@@ -1,6 +1,7 @@
 package org.sopt.app.common.config;
 
 import java.time.Clock;
+import java.time.ZoneId;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,6 +10,6 @@ public class ClockConfig {
 
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.system(ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/org/sopt/app/common/response/ErrorCode.java
+++ b/src/main/java/org/sopt/app/common/response/ErrorCode.java
@@ -112,6 +112,7 @@ public enum ErrorCode {
     //SoptLetter
     SOPT_LETTER_NICKNAME_IS_FULL("사용 가능한 솝레터 닉네임이 없습니다.", HttpStatus.CONFLICT),
     SOPT_LETTER_PROFILE_NOT_FOUND("솝레터 프로필이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    SOPT_LETTER_DAILY_LIMIT_EXCEEDED("일일 솝레터 작성 제한을 초과했습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String message;

--- a/src/main/java/org/sopt/app/common/response/ErrorCode.java
+++ b/src/main/java/org/sopt/app/common/response/ErrorCode.java
@@ -113,6 +113,7 @@ public enum ErrorCode {
     SOPT_LETTER_NICKNAME_IS_FULL("사용 가능한 솝레터 닉네임이 없습니다.", HttpStatus.CONFLICT),
     SOPT_LETTER_PROFILE_NOT_FOUND("솝레터 프로필이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     SOPT_LETTER_DAILY_LIMIT_EXCEEDED("일일 솝레터 작성 제한을 초과했습니다.", HttpStatus.BAD_REQUEST),
+    SOPT_LETTER_NOT_FOUND("존재하지 않는 솝레터입니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String message;

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,7 +58,7 @@ public class SoptLetter extends BaseEntity {
     }
 
     private void validateAuthor(Long profileId) {
-        if (!this.authorProfileId.equals(profileId)) {
+        if (!Objects.equals(this.authorProfileId, profileId)) {
             throw new ForbiddenException(ErrorCode.FORBIDDEN);
         }
     }

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -12,6 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.app.common.exception.ForbiddenException;
+import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.domain.entity.BaseEntity;
 import org.sopt.app.domain.enums.SoptLetterColor;
 import org.sopt.app.domain.enums.SoptLetterShapeType;
@@ -44,4 +46,15 @@ public class SoptLetter extends BaseEntity {
     private SoptLetterShapeType shapeType;
 
     private Integer likeCount;
+
+    public void updateMessage(Long requesterProfileId, String message) {
+        validateAuthor(requesterProfileId);
+        this.message = message;
+    }
+
+    public void validateAuthor(Long profileId) {
+        if (!this.authorProfileId.equals(profileId)) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        }
+    }
 }

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -52,7 +52,11 @@ public class SoptLetter extends BaseEntity {
         this.message = message;
     }
 
-    public void validateAuthor(Long profileId) {
+    public void validateDeletable(Long requesterProfileId) {
+        validateAuthor(requesterProfileId);
+    }
+
+    private void validateAuthor(Long profileId) {
         if (!this.authorProfileId.equals(profileId)) {
             throw new ForbiddenException(ErrorCode.FORBIDDEN);
         }

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -27,4 +27,8 @@ public class SoptLetterFacade {
     public SoptLetterInfo.MessageResult updateSoptLetter(Long userId, Long messageId, String content) {
         return soptLetterService.updateSoptLetter(userId, messageId, content);
     }
+
+    public void deleteSoptLetter(Long userId, Long messageId) {
+        soptLetterService.deleteSoptLetter(userId, messageId);
+    }
 }

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -23,4 +23,8 @@ public class SoptLetterFacade {
     public SoptLetterInfo.MessageResult writeMessage(Long userId, Long topicId, String content) {
         return soptLetterService.writeMessage(userId, topicId, content);
     }
+
+    public SoptLetterInfo.MessageResult updateMessage(Long userId, Long messageId, String content) {
+        return soptLetterService.updateMessage(userId, messageId, content);
+    }
 }

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -1,6 +1,7 @@
 package org.sopt.app.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.app.application.soptletter.SoptLetterInfo;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
 import org.sopt.app.application.soptletter.SoptLetterService;
 import org.springframework.stereotype.Service;
@@ -17,5 +18,9 @@ public class SoptLetterFacade {
 
     public Profile completeOnboardingProfile(Long userId) {
         return soptLetterService.completeOnboarding(userId);
+    }
+
+    public SoptLetterInfo.MessageResult writeMessage(Long userId, Long topicId, String content) {
+        return soptLetterService.writeMessage(userId, topicId, content);
     }
 }

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -20,11 +20,11 @@ public class SoptLetterFacade {
         return soptLetterService.completeOnboarding(userId);
     }
 
-    public SoptLetterInfo.MessageResult writeMessage(Long userId, Long topicId, String content) {
-        return soptLetterService.writeMessage(userId, topicId, content);
+    public SoptLetterInfo.MessageResult createSoptLetter(Long userId, Long topicId, String content) {
+        return soptLetterService.createSoptLetter(userId, topicId, content);
     }
 
-    public SoptLetterInfo.MessageResult updateMessage(Long userId, Long messageId, String content) {
-        return soptLetterService.updateMessage(userId, messageId, content);
+    public SoptLetterInfo.MessageResult updateSoptLetter(Long userId, Long messageId, String content) {
+        return soptLetterService.updateSoptLetter(userId, messageId, content);
     }
 }

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -24,11 +24,11 @@ public class SoptLetterFacade {
         return soptLetterService.createSoptLetter(userId, topicId, content);
     }
 
-    public SoptLetterInfo.MessageResult updateSoptLetter(Long userId, Long messageId, String content) {
-        return soptLetterService.updateSoptLetter(userId, messageId, content);
+    public SoptLetterInfo.MessageResult updateSoptLetter(Long userId, Long soptLetterId, String content) {
+        return soptLetterService.updateSoptLetter(userId, soptLetterId, content);
     }
 
-    public void deleteSoptLetter(Long userId, Long messageId) {
-        soptLetterService.deleteSoptLetter(userId, messageId);
+    public void deleteSoptLetter(Long userId, Long soptLetterId) {
+        soptLetterService.deleteSoptLetter(userId, soptLetterId);
     }
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -4,5 +4,5 @@ import org.sopt.app.domain.entity.soptletter.SoptLetterLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, Long> {
-
+    boolean existsByLetterIdAndUserId(Long letterId, Long userId);
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -2,7 +2,15 @@ package org.sopt.app.interfaces.postgres.soptletter;
 
 import org.sopt.app.domain.entity.soptletter.SoptLetterLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, Long> {
     boolean existsByLetterIdAndUserId(Long letterId, Long userId);
+    void deleteByLetterId(Long letterId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE From SoptLetterLike l WHERE l.letterId = :letterId")
+    void deleteAllByLetterIdInQuery(@Param("letterId") Long letterId);
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -8,9 +8,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, Long> {
     boolean existsByLetterIdAndUserId(Long letterId, Long userId);
-    void deleteByLetterId(Long letterId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query("DELETE From SoptLetterLike l WHERE l.letterId = :letterId")
     void deleteAllByLetterIdInQuery(@Param("letterId") Long letterId);
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
@@ -1,9 +1,14 @@
 package org.sopt.app.interfaces.postgres.soptletter;
 
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SoptLetterRepository extends JpaRepository<SoptLetter, Long> {
 
+    Optional<SoptLetter> findFirstByTopicIdOrderByIdDesc(Long topicId);
+
+    long countByAuthorProfileIdAndCreatedAtAfter(Long authorProfileId, LocalDateTime startOfDay);
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
@@ -10,5 +10,5 @@ public interface SoptLetterRepository extends JpaRepository<SoptLetter, Long> {
 
     Optional<SoptLetter> findFirstByTopicIdOrderByIdDesc(Long topicId);
 
-    long countByAuthorProfileIdAndCreatedAtAfter(Long authorProfileId, LocalDateTime startOfDay);
+    long countByAuthorProfileIdAndCreatedAtGreaterThanEqual(Long authorProfileId, LocalDateTime startOfDay);
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -5,14 +5,18 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.sopt.app.facade.SoptLetterFacade;
-import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse.OnboardingProfileResponse;
+import org.sopt.app.presentation.soptletter.dto.SoptLetterRequest;
+import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,7 +36,7 @@ public class SoptLetterController {
         @ApiResponse(responseCode = "409", description = "conflict"),
         @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    public ResponseEntity<OnboardingProfileResponse> getOrCreateOnboardingProfile(
+    public ResponseEntity<SoptLetterResponse.OnboardingProfileResponse> getOrCreateOnboardingProfile(
         @AuthenticationPrincipal Long userId
     ) {
         val result = soptLetterFacade.getOrCreateOnboardingProfile(userId);
@@ -46,10 +50,27 @@ public class SoptLetterController {
         @ApiResponse(responseCode = "404", description = "not found", content = @Content),
         @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    public ResponseEntity<OnboardingProfileResponse> completeOnboardingProfile(
+    public ResponseEntity<SoptLetterResponse.OnboardingProfileResponse> completeOnboardingProfile(
         @AuthenticationPrincipal Long userId
     ) {
         val result = soptLetterFacade.completeOnboardingProfile(userId);
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+    }
+
+    @Operation(summary = "개별 주제 솝레터 메시지 작성")
+    @PostMapping("/topics/{topicId}/messages")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "400", description = "bad request", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<SoptLetterResponse.WriteMessageResponse> writeMessage(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long topicId,
+        @Valid @RequestBody SoptLetterRequest.WriteMessageRequest request
+    ) {
+        val result = soptLetterFacade.writeMessage(userId, topicId, request.getContent());
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -71,6 +72,24 @@ public class SoptLetterController {
         @Valid @RequestBody SoptLetterRequest.WriteMessageRequest request
     ) {
         val result = soptLetterFacade.writeMessage(userId, topicId, request.getContent());
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+    }
+
+    @Operation(summary = "내가 작성한 솝레터 메시지 수정")
+    @PatchMapping("/messages/{messageId}")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "400", description = "bad request", content = @Content),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<SoptLetterResponse.WriteMessageResponse> updateMessage(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long messageId,
+        @Valid @RequestBody SoptLetterRequest.UpdateMessageRequest request
+    ) {
+        val result = soptLetterFacade.updateMessage(userId, messageId, request.getContent());
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -13,10 +13,11 @@ import org.sopt.app.presentation.soptletter.dto.SoptLetterRequest;
 import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -71,7 +72,7 @@ public class SoptLetterController {
         @PathVariable Long topicId,
         @Valid @RequestBody SoptLetterRequest.WriteMessageRequest request
     ) {
-        val result = soptLetterFacade.writeMessage(userId, topicId, request.getContent());
+        val result = soptLetterFacade.createSoptLetter(userId, topicId, request.getContent());
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 
@@ -89,7 +90,7 @@ public class SoptLetterController {
         @PathVariable Long messageId,
         @Valid @RequestBody SoptLetterRequest.UpdateMessageRequest request
     ) {
-        val result = soptLetterFacade.updateMessage(userId, messageId, request.getContent());
+        val result = soptLetterFacade.updateSoptLetter(userId, messageId, request.getContent());
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -93,4 +93,21 @@ public class SoptLetterController {
         val result = soptLetterFacade.updateSoptLetter(userId, messageId, request.getContent());
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
+
+    @Operation(summary = "내가 작성한 솝레터 메시지 삭제")
+    @DeleteMapping("/messages/{messageId}")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "400", description = "bad request", content = @Content),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<Void> deleteMessage(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long messageId
+    ) {
+        soptLetterFacade.deleteSoptLetter(userId, messageId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
@@ -5,7 +5,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.sopt.app.application.soptletter.SoptLetterInfo;
-import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse.OnboardingProfileResponse;
+import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse;
 
 @Mapper(
     componentModel = "spring",
@@ -15,5 +15,7 @@ import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse.OnboardingPro
 public interface SoptLetterResponseMapper {
 
     @Mapping(source = "onboarded", target = "isOnboarded")
-    OnboardingProfileResponse of(SoptLetterInfo.Profile info);
+    SoptLetterResponse.OnboardingProfileResponse of(SoptLetterInfo.Profile info);
+
+    SoptLetterResponse.WriteMessageResponse of(SoptLetterInfo.MessageResult result);
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequest.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequest.java
@@ -1,0 +1,20 @@
+package org.sopt.app.presentation.soptletter.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SoptLetterRequest {
+
+    @Getter
+    @ToString
+    public static class WriteMessageRequest {
+        @NotBlank(message = "메시지 내용은 필수입니다.")
+        @Size(min = 1, max = 350, message = "메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다.")
+        private String content;
+    }
+}

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequest.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequest.java
@@ -17,4 +17,12 @@ public class SoptLetterRequest {
         @Size(min = 1, max = 350, message = "메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다.")
         private String content;
     }
+
+    @Getter
+    @ToString
+    public static class UpdateMessageRequest {
+        @NotBlank(message = "메시지 내용은 필수입니다.")
+        @Size(min = 1, max = 350, message = "메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다.")
+        private String content;
+    }
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -15,4 +15,33 @@ public class SoptLetterResponse {
         boolean isOnboarded
     ) {
     }
+
+    @Schema(description = "솝레터 개별 주제 메시지 작성 응답")
+    public record WriteMessageResponse(
+        @Schema(description = "생성된 메시지 ID", example = "125")
+        Long messageId,
+        @Schema(description = "주제 ID", example = "3")
+        Long topicId,
+        @Schema(description = "작성자 익명 닉네임", example = "반짝이는 고래")
+        String authorNickname,
+        @Schema(description = "저장된 메시지 본문", example = "앱잼 때 같이 밤새면서 고생했던 게 아직도 기억나...")
+        String content,
+        @Schema(description = "메세지 색상 hex code", example = "#CCFFEC")
+        String colorCode,
+        @Schema(description = "회전 각도", example = "10.0")
+        Double rotationDegree,
+        @Schema(description = "모양 타입", example = "POINT")
+        String shapeType,
+        @Schema(description = "생성 시각")
+        java.time.LocalDateTime createdAt,
+        @Schema(description = "수정 시각")
+        java.time.LocalDateTime updatedAt,
+        @Schema(description = "초기 좋아요 수", example = "0")
+        Integer likeCount,
+        @Schema(description = "내가 좋아요를 눌렀는지 여부", example = "false")
+        Boolean likedByMe,
+        @Schema(description = "내가 작성한 메시지 여부", example = "true")
+        Boolean mine
+    ) {
+    }
 }

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterGeneratorTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterGeneratorTest.java
@@ -1,0 +1,64 @@
+package org.sopt.app.application.soptletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.app.domain.entity.soptletter.SoptLetter;
+import org.sopt.app.domain.enums.SoptLetterColor;
+import org.sopt.app.domain.enums.SoptLetterShapeType;
+
+class SoptLetterGeneratorTest {
+
+    private final SoptLetterGenerator soptLetterGenerator = new SoptLetterGenerator();
+
+    @Test
+    @DisplayName("편지 생성 시 전달받은 기본 속성들이 엔티티에 올바르게 설정된다")
+    void shouldMapBasicPropertiesCorrectly() {
+        // given
+        Long authorProfileId = 1L;
+        Long topicId = 10L;
+        String message = "테스트 편지 내용";
+
+        // when
+        SoptLetter result = soptLetterGenerator.generate(authorProfileId, topicId, message, null);
+
+        // then
+        assertThat(result.getAuthorProfileId()).isEqualTo(authorProfileId);
+        assertThat(result.getTopicId()).isEqualTo(topicId);
+        assertThat(result.getMessage()).isEqualTo(message);
+        assertThat(result.getLikeCount()).isEqualTo(0);
+        assertThat(result.getDegree()).isIn(-10.0, 0.0, 10.0);
+        assertThat(result.getShapeType()).isIn((Object[]) SoptLetterShapeType.values());
+    }
+
+    @Test
+    @DisplayName("이전 편지 색상이 null이면 첫 번째 색상인 BLUE_50이 지정된다")
+    void shouldAssignInitialColorWhenPreviousIsNull() {
+        // when
+        SoptLetter result = soptLetterGenerator.generate(1L, 1L, "테스트", null);
+
+        // then
+        assertThat(result.getColor()).isEqualTo(SoptLetterColor.BLUE_50);
+    }
+
+    @Test
+    @DisplayName("이전 편지 색상에 따라 다음 순서의 색상이 순환하여 지정된다")
+    void shouldRotateColorsCorrectly() {
+        // BLUE_50 -> GREEN_50
+        SoptLetter color1 = soptLetterGenerator.generate(1L, 1L, "테스트", SoptLetterColor.BLUE_50);
+        assertThat(color1.getColor()).isEqualTo(SoptLetterColor.GREEN_50);
+
+        // GREEN_50 -> YELLOW_50
+        SoptLetter color2 = soptLetterGenerator.generate(1L, 1L, "테스트", SoptLetterColor.GREEN_50);
+        assertThat(color2.getColor()).isEqualTo(SoptLetterColor.YELLOW_50);
+
+        // YELLOW_50 -> RED_50
+        SoptLetter color3 = soptLetterGenerator.generate(1L, 1L, "테스트", SoptLetterColor.YELLOW_50);
+        assertThat(color3.getColor()).isEqualTo(SoptLetterColor.RED_50);
+
+        // RED_50 -> BLUE_50
+        SoptLetter color4 = soptLetterGenerator.generate(1L, 1L, "테스트", SoptLetterColor.RED_50);
+        assertThat(color4.getColor()).isEqualTo(SoptLetterColor.BLUE_50);
+    }
+}

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -489,7 +489,7 @@ class SoptLetterServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .satisfies(e -> {
                     NotFoundException exception = (NotFoundException) e;
-                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_NOT_FOUND);
                 });
     }
 
@@ -539,6 +539,105 @@ class SoptLetterServiceTest {
 
         // when & then
         assertThatThrownBy(() -> soptLetterService.updateSoptLetter(userId, messageId, "수정 내용"))
+                .isInstanceOf(ForbiddenException.class)
+                .satisfies(e -> {
+                    ForbiddenException exception = (ForbiddenException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
+                });
+    }
+
+    @Test
+    @DisplayName("SUCCESS_솝레터 메시지를 성공적으로 삭제한다")
+    void SUCCESS_deleteSoptLetter() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+
+        SoptLetter letter = SoptLetter.builder()
+                .id(messageId)
+                .authorProfileId(10L)
+                .build();
+
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .build();
+
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.of(letter));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+
+        // when
+        soptLetterService.deleteSoptLetter(userId, messageId);
+
+        // then
+        verify(soptLetterLikeRepository, times(1)).deleteAllByLetterIdInQuery(messageId);
+        verify(soptLetterRepository, times(1)).delete(letter);
+    }
+
+    @Test
+    @DisplayName("FAIL_삭제 시 솝레터 메시지가 존재하지 않으면 NotFoundException이 발생한다")
+    void FAIL_deleteSoptLetter_letterNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 999L;
+
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.deleteSoptLetter(userId, messageId))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_삭제 시 솝레터 프로필이 존재하지 않으면 NotFoundException이 발생한다")
+    void FAIL_deleteSoptLetter_profileNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+
+        SoptLetter letter = SoptLetter.builder()
+                .id(messageId)
+                .authorProfileId(10L)
+                .build();
+
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.of(letter));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.deleteSoptLetter(userId, messageId))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_삭제 시 본인 글이 아니면 ForbiddenException이 발생한다")
+    void FAIL_deleteSoptLetter_forbidden() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+
+        SoptLetter letter = SoptLetter.builder()
+                .id(messageId)
+                .authorProfileId(99L)
+                .build();
+
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .build();
+
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.of(letter));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.deleteSoptLetter(userId, messageId))
                 .isInstanceOf(ForbiddenException.class)
                 .satisfies(e -> {
                     ForbiddenException exception = (ForbiddenException) e;

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -3,14 +3,20 @@ package org.sopt.app.application.soptletter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.ZoneId;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,12 +26,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
+import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.ConflictException;
 import org.sopt.app.common.exception.NotFoundException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.common.utils.AnonymousNameGenerator;
+import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
+import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
+import org.sopt.app.domain.enums.SoptLetterColor;
+import org.sopt.app.domain.enums.SoptLetterShapeType;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterProfileRepository;
+import org.sopt.app.interfaces.postgres.soptletter.SoptLetterRepository;
+import org.sopt.app.interfaces.postgres.soptletter.SoptLetterTopicRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,8 +50,26 @@ class SoptLetterServiceTest {
     @Mock
     private AnonymousNameGenerator anonymousNameGenerator;
 
+    @Mock
+    private SoptLetterRepository soptLetterRepository;
+
+    @Mock
+    private SoptLetterTopicRepository soptLetterTopicRepository;
+
+    @Mock
+    private SoptLetterGenerator soptLetterGenerator;
+
+    @Mock
+    private Clock clock;
+
     @InjectMocks
     private SoptLetterService soptLetterService;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUpClock() {
+        lenient().when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+        lenient().when(clock.instant()).thenAnswer(invocation -> java.time.Instant.now());
+    }
 
     @Test
     @DisplayName("SUCCESS_이미 온보딩된 유저이면 true를 반환한다")
@@ -207,6 +238,196 @@ class SoptLetterServiceTest {
                 .satisfies(e -> {
                     NotFoundException exception = (NotFoundException) e;
                     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("SUCCESS_첫 번째 메시지 작성 시 기본 색상인 BLUE_50으로 편지를 성공적으로 작성한다")
+    void SUCCESS_writeMessage_firstMessage() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final String content = "첫 편지 내용입니다.";
+        final LocalDateTime now = LocalDateTime.now();
+
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("반짝이는 고래")
+                .build();
+
+        when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class))).thenReturn(0L);
+        when(soptLetterRepository.findFirstByTopicIdOrderByIdDesc(topicId)).thenReturn(Optional.empty());
+        when(soptLetterGenerator.generate(anyLong(), anyLong(), any(String.class), any())).thenAnswer(invocation -> {
+            Long authorProfileId = invocation.getArgument(0);
+            Long tId = invocation.getArgument(1);
+            String msg = invocation.getArgument(2);
+            return SoptLetter.builder()
+                    .authorProfileId(authorProfileId)
+                    .topicId(tId)
+                    .degree(0.0)
+                    .message(msg)
+                    .color(SoptLetterColor.BLUE_50)
+                    .shapeType(SoptLetterShapeType.POINT)
+                    .likeCount(0)
+                    .build();
+        });
+        when(soptLetterRepository.save(any(SoptLetter.class))).thenAnswer(invocation -> {
+            SoptLetter letter = invocation.getArgument(0);
+            return SoptLetter.builder()
+                    .id(125L)
+                    .authorProfileId(letter.getAuthorProfileId())
+                    .topicId(letter.getTopicId())
+                    .degree(letter.getDegree())
+                    .message(letter.getMessage())
+                    .color(letter.getColor())
+                    .shapeType(letter.getShapeType())
+                    .likeCount(0)
+                    .build();
+        });
+
+        // when
+        SoptLetterInfo.MessageResult result = soptLetterService.writeMessage(userId, topicId, content);
+
+        // then
+        assertThat(result.getMessageId()).isEqualTo(125L);
+        assertThat(result.getColorCode()).isEqualTo(SoptLetterColor.BLUE_50.getHexCode());
+        assertThat(result.getContent()).isEqualTo(content);
+        assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
+        assertThat(result.getLikedByMe()).isFalse();
+        assertThat(result.getMine()).isTrue();
+        verify(soptLetterRepository, times(1)).save(any(SoptLetter.class));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_이전 메시지가 BLUE_50인 경우 다음 색상인 GREEN_50으로 순환하여 작성한다")
+    void SUCCESS_writeMessage_cycleColors() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final String content = "두 번째 편지 내용입니다.";
+        final LocalDateTime now = LocalDateTime.now();
+
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("반짝이는 고래")
+                .build();
+        SoptLetter latestLetter = SoptLetter.builder()
+                .color(SoptLetterColor.BLUE_50)
+                .build();
+
+        when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class))).thenReturn(0L);
+        when(soptLetterRepository.findFirstByTopicIdOrderByIdDesc(topicId)).thenReturn(Optional.of(latestLetter));
+        when(soptLetterGenerator.generate(anyLong(), anyLong(), any(String.class), any())).thenAnswer(invocation -> {
+            Long authorProfileId = invocation.getArgument(0);
+            Long tId = invocation.getArgument(1);
+            String msg = invocation.getArgument(2);
+            SoptLetterColor prevColor = invocation.getArgument(3);
+            return SoptLetter.builder()
+                    .authorProfileId(authorProfileId)
+                    .topicId(tId)
+                    .degree(0.0)
+                    .message(msg)
+                    .color(prevColor == SoptLetterColor.BLUE_50 ? SoptLetterColor.GREEN_50 : SoptLetterColor.BLUE_50)
+                    .shapeType(SoptLetterShapeType.POINT)
+                    .likeCount(0)
+                    .build();
+        });
+        when(soptLetterRepository.save(any(SoptLetter.class))).thenAnswer(invocation -> {
+            SoptLetter letter = invocation.getArgument(0);
+            return SoptLetter.builder()
+                    .id(126L)
+                    .authorProfileId(letter.getAuthorProfileId())
+                    .topicId(letter.getTopicId())
+                    .degree(letter.getDegree())
+                    .message(letter.getMessage())
+                    .color(letter.getColor())
+                    .shapeType(letter.getShapeType())
+                    .likeCount(0)
+                    .build();
+        });
+
+        // when
+        SoptLetterInfo.MessageResult result = soptLetterService.writeMessage(userId, topicId, content);
+
+        // then
+        assertThat(result.getMessageId()).isEqualTo(126L);
+        assertThat(result.getColorCode()).isEqualTo(SoptLetterColor.GREEN_50.getHexCode());
+        verify(soptLetterRepository, times(1)).save(any(SoptLetter.class));
+    }
+
+    @Test
+    @DisplayName("FAIL_존재하지 않는 토픽 ID로 작성 시도 시 NotFoundException이 발생한다")
+    void FAIL_writeMessage_topicNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 999L;
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.writeMessage(userId, topicId, "테스트"))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_온보딩하지 않은 유저가 작성 시도 시 NotFoundException이 발생한다")
+    void FAIL_writeMessage_profileNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.writeMessage(userId, topicId, "테스트"))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_일일 솝레터 작성 제한 초과 시 BadRequestException이 발생한다")
+    void FAIL_writeMessage_dailyLimitExceeded() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final LocalDateTime now = LocalDateTime.now();
+
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("반짝이는 고래")
+                .build();
+
+        when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class))).thenReturn(10L);
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.writeMessage(userId, topicId, "테스트"))
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(e -> {
+                    BadRequestException exception = (BadRequestException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_DAILY_LIMIT_EXCEEDED);
                 });
     }
 }

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -5,18 +5,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.lenient;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
-import java.time.LocalDateTime;
-import java.time.Clock;
-import java.time.ZoneId;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,8 +28,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.ConflictException;
-import org.sopt.app.common.exception.NotFoundException;
 import org.sopt.app.common.exception.ForbiddenException;
+import org.sopt.app.common.exception.NotFoundException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.common.utils.AnonymousNameGenerator;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
@@ -37,10 +37,10 @@ import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
 import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
 import org.sopt.app.domain.enums.SoptLetterColor;
 import org.sopt.app.domain.enums.SoptLetterShapeType;
+import org.sopt.app.interfaces.postgres.soptletter.SoptLetterLikeRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterProfileRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterTopicRepository;
-import org.sopt.app.interfaces.postgres.soptletter.SoptLetterLikeRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
@@ -248,7 +248,7 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("SUCCESS_첫 번째 메시지 작성 시 기본 색상인 BLUE_50으로 편지를 성공적으로 작성한다")
-    void SUCCESS_writeMessage_firstMessage() {
+    void SUCCESS_createSoptLetter() {
         // given
         final Long userId = 1L;
         final Long topicId = 3L;
@@ -296,7 +296,7 @@ class SoptLetterServiceTest {
         });
 
         // when
-        SoptLetterInfo.MessageResult result = soptLetterService.writeMessage(userId, topicId, content);
+        SoptLetterInfo.MessageResult result = soptLetterService.createSoptLetter(userId, topicId, content);
 
         // then
         assertThat(result.getMessageId()).isEqualTo(125L);
@@ -310,7 +310,7 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("SUCCESS_이전 메시지가 BLUE_50인 경우 다음 색상인 GREEN_50으로 순환하여 작성한다")
-    void SUCCESS_writeMessage_cycleColors() {
+    void SUCCESS_createSoptLetter_cycleColors() {
         // given
         final Long userId = 1L;
         final Long topicId = 3L;
@@ -362,7 +362,7 @@ class SoptLetterServiceTest {
         });
 
         // when
-        SoptLetterInfo.MessageResult result = soptLetterService.writeMessage(userId, topicId, content);
+        SoptLetterInfo.MessageResult result = soptLetterService.createSoptLetter(userId, topicId, content);
 
         // then
         assertThat(result.getMessageId()).isEqualTo(126L);
@@ -372,14 +372,14 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("FAIL_존재하지 않는 토픽 ID로 작성 시도 시 NotFoundException이 발생한다")
-    void FAIL_writeMessage_topicNotFound() {
+    void FAIL_createSoptLetter_topicNotFound() {
         // given
         final Long userId = 1L;
         final Long topicId = 999L;
         when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> soptLetterService.writeMessage(userId, topicId, "테스트"))
+        assertThatThrownBy(() -> soptLetterService.createSoptLetter(userId, topicId, "테스트"))
                 .isInstanceOf(NotFoundException.class)
                 .satisfies(e -> {
                     NotFoundException exception = (NotFoundException) e;
@@ -389,7 +389,7 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("FAIL_온보딩하지 않은 유저가 작성 시도 시 NotFoundException이 발생한다")
-    void FAIL_writeMessage_profileNotFound() {
+    void FAIL_createSoptLetter_profileNotFound() {
         // given
         final Long userId = 1L;
         final Long topicId = 3L;
@@ -399,7 +399,7 @@ class SoptLetterServiceTest {
         when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> soptLetterService.writeMessage(userId, topicId, "테스트"))
+        assertThatThrownBy(() -> soptLetterService.createSoptLetter(userId, topicId, "테스트"))
                 .isInstanceOf(NotFoundException.class)
                 .satisfies(e -> {
                     NotFoundException exception = (NotFoundException) e;
@@ -409,7 +409,7 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("FAIL_일일 솝레터 작성 제한 초과 시 BadRequestException이 발생한다")
-    void FAIL_writeMessage_dailyLimitExceeded() {
+    void FAIL_createSoptLetter_dailyLimitExceeded() {
         // given
         final Long userId = 1L;
         final Long topicId = 3L;
@@ -428,7 +428,7 @@ class SoptLetterServiceTest {
         when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class))).thenReturn(10L);
 
         // when & then
-        assertThatThrownBy(() -> soptLetterService.writeMessage(userId, topicId, "테스트"))
+        assertThatThrownBy(() -> soptLetterService.createSoptLetter(userId, topicId, "테스트"))
                 .isInstanceOf(BadRequestException.class)
                 .satisfies(e -> {
                     BadRequestException exception = (BadRequestException) e;
@@ -438,7 +438,7 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("SUCCESS_메시지를 정상적으로 수정하고 결과를 반환한다")
-    void SUCCESS_updateMessage() {
+    void SUCCESS_updateSoptLetter() {
         // given
         final Long userId = 1L;
         final Long messageId = 125L;
@@ -466,7 +466,7 @@ class SoptLetterServiceTest {
         when(soptLetterLikeRepository.existsByLetterIdAndUserId(messageId, userId)).thenReturn(false);
 
         // when
-        SoptLetterInfo.MessageResult result = soptLetterService.updateMessage(userId, messageId, newContent);
+        SoptLetterInfo.MessageResult result = soptLetterService.updateSoptLetter(userId, messageId, newContent);
 
         // then
         assertThat(result.getMessageId()).isEqualTo(messageId);
@@ -478,14 +478,14 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("FAIL_수정 시 솝레터 메시지가 존재하지 않으면 NotFoundException이 발생한다")
-    void FAIL_updateMessage_letterNotFound() {
+    void FAIL_updateSoptLetter_letterNotFound() {
         // given
         final Long userId = 1L;
         final Long messageId = 999L;
         when(soptLetterRepository.findById(messageId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> soptLetterService.updateMessage(userId, messageId, "수정 내용"))
+        assertThatThrownBy(() -> soptLetterService.updateSoptLetter(userId, messageId, "수정 내용"))
                 .isInstanceOf(NotFoundException.class)
                 .satisfies(e -> {
                     NotFoundException exception = (NotFoundException) e;
@@ -495,7 +495,7 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("FAIL_수정 시 솝레터 프로필이 존재하지 않으면 NotFoundException이 발생한다")
-    void FAIL_updateMessage_profileNotFound() {
+    void FAIL_updateSoptLetter_profileNotFound() {
         // given
         final Long userId = 1L;
         final Long messageId = 125L;
@@ -509,7 +509,7 @@ class SoptLetterServiceTest {
         when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> soptLetterService.updateMessage(userId, messageId, "수정 내용"))
+        assertThatThrownBy(() -> soptLetterService.updateSoptLetter(userId, messageId, "수정 내용"))
                 .isInstanceOf(NotFoundException.class)
                 .satisfies(e -> {
                     NotFoundException exception = (NotFoundException) e;
@@ -519,7 +519,7 @@ class SoptLetterServiceTest {
 
     @Test
     @DisplayName("FAIL_수정 시 본인 글이 아니면 ForbiddenException이 발생한다")
-    void FAIL_updateMessage_forbidden() {
+    void FAIL_updateSoptLetter_forbidden() {
         // given
         final Long userId = 1L;
         final Long messageId = 125L;
@@ -538,7 +538,7 @@ class SoptLetterServiceTest {
         when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
 
         // when & then
-        assertThatThrownBy(() -> soptLetterService.updateMessage(userId, messageId, "수정 내용"))
+        assertThatThrownBy(() -> soptLetterService.updateSoptLetter(userId, messageId, "수정 내용"))
                 .isInstanceOf(ForbiddenException.class)
                 .satisfies(e -> {
                     ForbiddenException exception = (ForbiddenException) e;

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -29,6 +29,7 @@ import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.ConflictException;
 import org.sopt.app.common.exception.NotFoundException;
+import org.sopt.app.common.exception.ForbiddenException;
 import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.common.utils.AnonymousNameGenerator;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
@@ -39,6 +40,7 @@ import org.sopt.app.domain.enums.SoptLetterShapeType;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterProfileRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterTopicRepository;
+import org.sopt.app.interfaces.postgres.soptletter.SoptLetterLikeRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,6 +57,9 @@ class SoptLetterServiceTest {
 
     @Mock
     private SoptLetterTopicRepository soptLetterTopicRepository;
+
+    @Mock
+    private SoptLetterLikeRepository soptLetterLikeRepository;
 
     @Mock
     private SoptLetterGenerator soptLetterGenerator;
@@ -428,6 +433,116 @@ class SoptLetterServiceTest {
                 .satisfies(e -> {
                     BadRequestException exception = (BadRequestException) e;
                     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_DAILY_LIMIT_EXCEEDED);
+                });
+    }
+
+    @Test
+    @DisplayName("SUCCESS_메시지를 정상적으로 수정하고 결과를 반환한다")
+    void SUCCESS_updateMessage() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+        final String newContent = "수정된 편지 내용입니다.";
+
+        SoptLetter letter = SoptLetter.builder()
+                .id(messageId)
+                .authorProfileId(10L)
+                .topicId(3L)
+                .degree(0.0)
+                .message("이전 편지 내용")
+                .color(SoptLetterColor.BLUE_50)
+                .shapeType(SoptLetterShapeType.POINT)
+                .likeCount(0)
+                .build();
+
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("반짝이는 고래")
+                .build();
+
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.of(letter));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(soptLetterLikeRepository.existsByLetterIdAndUserId(messageId, userId)).thenReturn(false);
+
+        // when
+        SoptLetterInfo.MessageResult result = soptLetterService.updateMessage(userId, messageId, newContent);
+
+        // then
+        assertThat(result.getMessageId()).isEqualTo(messageId);
+        assertThat(result.getContent()).isEqualTo(newContent);
+        assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
+        assertThat(result.getMine()).isTrue();
+        assertThat(letter.getMessage()).isEqualTo(newContent);
+    }
+
+    @Test
+    @DisplayName("FAIL_수정 시 솝레터 메시지가 존재하지 않으면 NotFoundException이 발생한다")
+    void FAIL_updateMessage_letterNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 999L;
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.updateMessage(userId, messageId, "수정 내용"))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_수정 시 솝레터 프로필이 존재하지 않으면 NotFoundException이 발생한다")
+    void FAIL_updateMessage_profileNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+
+        SoptLetter letter = SoptLetter.builder()
+                .id(messageId)
+                .authorProfileId(10L)
+                .build();
+
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.of(letter));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.updateMessage(userId, messageId, "수정 내용"))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_수정 시 본인 글이 아니면 ForbiddenException이 발생한다")
+    void FAIL_updateMessage_forbidden() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+
+        SoptLetter letter = SoptLetter.builder()
+                .id(messageId)
+                .authorProfileId(99L) // 다른 유저의 프로필 ID
+                .build();
+
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L) // 요청 유저의 프로필 ID
+                .userId(userId)
+                .build();
+
+        when(soptLetterRepository.findById(messageId)).thenReturn(Optional.of(letter));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.updateMessage(userId, messageId, "수정 내용"))
+                .isInstanceOf(ForbiddenException.class)
+                .satisfies(e -> {
+                    ForbiddenException exception = (ForbiddenException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
                 });
     }
 }

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -265,7 +265,7 @@ class SoptLetterServiceTest {
         when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
         when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
         when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
-        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class))).thenReturn(0L);
+        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtGreaterThanEqual(anyLong(), any(LocalDateTime.class))).thenReturn(0L);
         when(soptLetterRepository.findFirstByTopicIdOrderByIdDesc(topicId)).thenReturn(Optional.empty());
         when(soptLetterGenerator.generate(anyLong(), anyLong(), any(String.class), any())).thenAnswer(invocation -> {
             Long authorProfileId = invocation.getArgument(0);
@@ -330,7 +330,7 @@ class SoptLetterServiceTest {
         when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
         when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
         when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
-        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class))).thenReturn(0L);
+        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtGreaterThanEqual(anyLong(), any(LocalDateTime.class))).thenReturn(0L);
         when(soptLetterRepository.findFirstByTopicIdOrderByIdDesc(topicId)).thenReturn(Optional.of(latestLetter));
         when(soptLetterGenerator.generate(anyLong(), anyLong(), any(String.class), any())).thenAnswer(invocation -> {
             Long authorProfileId = invocation.getArgument(0);
@@ -425,7 +425,7 @@ class SoptLetterServiceTest {
         when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
         when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
         when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
-        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class))).thenReturn(10L);
+        when(soptLetterRepository.countByAuthorProfileIdAndCreatedAtGreaterThanEqual(anyLong(), any(LocalDateTime.class))).thenReturn(10L);
 
         // when & then
         assertThatThrownBy(() -> soptLetterService.createSoptLetter(userId, topicId, "테스트"))

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import java.time.LocalDateTime;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.soptletter.SoptLetterInfo;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
 import org.sopt.app.application.soptletter.SoptLetterService;
 
@@ -63,5 +67,40 @@ class SoptLetterFacadeTest {
         assertThat(result.getNickname()).isEqualTo(nickname);
         assertThat(result.isOnboarded()).isTrue();
         verify(soptLetterService, times(1)).completeOnboarding(userId);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_메시지 작성 파사드가 서비스 메서드를 정상 호출하고 반환한다")
+    void SUCCESS_writeMessage() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final String content = "편지 내용";
+
+        SoptLetterInfo.MessageResult expected = SoptLetterInfo.MessageResult.builder()
+                .messageId(125L)
+                .topicId(topicId)
+                .authorNickname("반짝이는 고래")
+                .content(content)
+                .colorCode("#CCFFEC")
+                .rotationDegree(4.0)
+                .shapeType("POINT")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .likeCount(0)
+                .likedByMe(false)
+                .mine(true)
+                .build();
+
+        when(soptLetterService.writeMessage(eq(userId), eq(topicId), eq(content))).thenReturn(expected);
+
+        // when
+        SoptLetterInfo.MessageResult result = soptLetterFacade.writeMessage(userId, topicId, content);
+
+        // then
+        assertThat(result.getMessageId()).isEqualTo(125L);
+        assertThat(result.getContent()).isEqualTo(content);
+        assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
+        verify(soptLetterService, times(1)).writeMessage(eq(userId), eq(topicId), eq(content));
     }
 }

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -1,18 +1,17 @@
 package org.sopt.app.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import java.time.LocalDateTime;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.app.application.soptletter.SoptLetterInfo;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
@@ -71,7 +70,7 @@ class SoptLetterFacadeTest {
 
     @Test
     @DisplayName("SUCCESS_메시지 작성 파사드가 서비스 메서드를 정상 호출하고 반환한다")
-    void SUCCESS_writeMessage() {
+    void SUCCESS_createSoptLetter() {
         // given
         final Long userId = 1L;
         final Long topicId = 3L;
@@ -92,21 +91,21 @@ class SoptLetterFacadeTest {
                 .mine(true)
                 .build();
 
-        when(soptLetterService.writeMessage(eq(userId), eq(topicId), eq(content))).thenReturn(expected);
+        when(soptLetterService.createSoptLetter(eq(userId), eq(topicId), eq(content))).thenReturn(expected);
 
         // when
-        SoptLetterInfo.MessageResult result = soptLetterFacade.writeMessage(userId, topicId, content);
+        SoptLetterInfo.MessageResult result = soptLetterFacade.createSoptLetter(userId, topicId, content);
 
         // then
         assertThat(result.getMessageId()).isEqualTo(125L);
         assertThat(result.getContent()).isEqualTo(content);
         assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
-        verify(soptLetterService, times(1)).writeMessage(eq(userId), eq(topicId), eq(content));
+        verify(soptLetterService, times(1)).createSoptLetter(eq(userId), eq(topicId), eq(content));
     }
 
     @Test
     @DisplayName("SUCCESS_메시지 수정 파사드가 서비스 메서드를 정상 호출하고 반환한다")
-    void SUCCESS_updateMessage() {
+    void SUCCESS_updateSoptLetter() {
         // given
         final Long userId = 1L;
         final Long messageId = 125L;
@@ -127,15 +126,15 @@ class SoptLetterFacadeTest {
                 .mine(true)
                 .build();
 
-        when(soptLetterService.updateMessage(eq(userId), eq(messageId), eq(content))).thenReturn(expected);
+        when(soptLetterService.updateSoptLetter(eq(userId), eq(messageId), eq(content))).thenReturn(expected);
 
         // when
-        SoptLetterInfo.MessageResult result = soptLetterFacade.updateMessage(userId, messageId, content);
+        SoptLetterInfo.MessageResult result = soptLetterFacade.updateSoptLetter(userId, messageId, content);
 
         // then
         assertThat(result.getMessageId()).isEqualTo(messageId);
         assertThat(result.getContent()).isEqualTo(content);
         assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
-        verify(soptLetterService, times(1)).updateMessage(eq(userId), eq(messageId), eq(content));
+        verify(soptLetterService, times(1)).updateSoptLetter(eq(userId), eq(messageId), eq(content));
     }
 }

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -137,4 +137,18 @@ class SoptLetterFacadeTest {
         assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
         verify(soptLetterService, times(1)).updateSoptLetter(eq(userId), eq(messageId), eq(content));
     }
+
+    @Test
+    @DisplayName("SUCCESS_메시지 삭제 파사드가 서비스 메서드를 정상 호출한다")
+    void SUCCESS_deleteSoptLetter() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+
+        // when
+        soptLetterFacade.deleteSoptLetter(userId, messageId);
+
+        // then
+        verify(soptLetterService, times(1)).deleteSoptLetter(eq(userId), eq(messageId));
+    }
 }

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -103,4 +103,39 @@ class SoptLetterFacadeTest {
         assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
         verify(soptLetterService, times(1)).writeMessage(eq(userId), eq(topicId), eq(content));
     }
+
+    @Test
+    @DisplayName("SUCCESS_메시지 수정 파사드가 서비스 메서드를 정상 호출하고 반환한다")
+    void SUCCESS_updateMessage() {
+        // given
+        final Long userId = 1L;
+        final Long messageId = 125L;
+        final String content = "수정된 편지 내용";
+
+        SoptLetterInfo.MessageResult expected = SoptLetterInfo.MessageResult.builder()
+                .messageId(messageId)
+                .topicId(3L)
+                .authorNickname("반짝이는 고래")
+                .content(content)
+                .colorCode("#CCFFEC")
+                .rotationDegree(4.0)
+                .shapeType("POINT")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .likeCount(0)
+                .likedByMe(false)
+                .mine(true)
+                .build();
+
+        when(soptLetterService.updateMessage(eq(userId), eq(messageId), eq(content))).thenReturn(expected);
+
+        // when
+        SoptLetterInfo.MessageResult result = soptLetterFacade.updateMessage(userId, messageId, content);
+
+        // then
+        assertThat(result.getMessageId()).isEqualTo(messageId);
+        assertThat(result.getContent()).isEqualTo(content);
+        assertThat(result.getAuthorNickname()).isEqualTo("반짝이는 고래");
+        verify(soptLetterService, times(1)).updateMessage(eq(userId), eq(messageId), eq(content));
+    }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #775

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 아래 API 구현
  - 솝레터 작성
    - 작성 일일 한도 10개.
  - 솝레터 수정
  - 솝레터 삭제

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢
- 파사드 레이어를 제대로 사용하지 못하고 있는 걸까? 라는 고민이 있어요. 그렇다고 프로필이나 토픽 조회를 파사드에서 진행한 후 로직에 주입한다면,,, 나중에 트랜잭션을 잘 분리하고 싶을 때 제대로 분리가 안될 것 같은 느낌이 있어서 우선은 현재와 같이 구현했습니다. 의견주세요~
- 시간 부족 이슈로 좀 뚱뚱 PR인점 죄송합니다,,, 😭 
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->