### PR TITLE
[Feat] #770: 솝레터 좋아요 추가/삭제 기능 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -139,9 +139,35 @@ public class SoptLetterService {
         soptLetterRepository.delete(letter);
     }
 
+    @Transactional
+    public void addLike(Long userId, Long topicId, Long soptLetterId) {
+        validateSoptLetterExistsForLike(topicId, soptLetterId);
+
+        val insertedCount = soptLetterLikeRepository.insertIgnore(userId, soptLetterId);
+        if (insertedCount > 0) {
+            soptLetterRepository.increaseLikeCount(soptLetterId);
+        }
+    }
+
+    @Transactional
+    public void removeLike(Long userId, Long topicId, Long soptLetterId) {
+        validateSoptLetterExistsForLike(topicId, soptLetterId);
+
+        val deletedCount = soptLetterLikeRepository.deleteByLetterIdAndUserId(soptLetterId, userId);
+        if (deletedCount > 0) {
+            soptLetterRepository.decreaseLikeCount(soptLetterId);
+        }
+    }
+
     public SoptLetter getSoptLetter(Long soptLetterId) {
         return soptLetterRepository.findById(soptLetterId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
+    }
+
+    private void validateSoptLetterExistsForLike(Long topicId, Long soptLetterId) {
+        if (!soptLetterRepository.existsByIdAndTopicId(soptLetterId, topicId)) {
+            throw new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND);
+        }
     }
 
     public SoptLetterProfile getProfileByUserId(Long userId) {
@@ -149,4 +175,3 @@ public class SoptLetterService {
             .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
     }
 }
-

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -31,4 +31,12 @@ public class SoptLetterFacade {
     public void deleteSoptLetter(Long userId, Long soptLetterId) {
         soptLetterService.deleteSoptLetter(userId, soptLetterId);
     }
+
+    public void addLike(Long userId, Long topicId, Long soptLetterId) {
+        soptLetterService.addLike(userId, topicId, soptLetterId);
+    }
+
+    public void removeLike(Long userId, Long topicId, Long soptLetterId) {
+        soptLetterService.removeLike(userId, topicId, soptLetterId);
+    }
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -10,6 +10,21 @@ public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, 
     boolean existsByLetterIdAndUserId(Long letterId, Long userId);
 
     @Modifying
+    @Query(
+        value = """
+            INSERT INTO sopt_letter_like (user_id, letter_id, created_at, updated_at)
+            VALUES (:userId, :letterId, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ON CONFLICT (letter_id, user_id) DO NOTHING
+            """,
+        nativeQuery = true
+    )
+    int insertIgnore(@Param("userId") Long userId, @Param("letterId") Long letterId);
+
+    @Modifying
+    @Query("DELETE FROM SoptLetterLike l WHERE l.letterId = :letterId AND l.userId = :userId")
+    int deleteByLetterIdAndUserId(@Param("letterId") Long letterId, @Param("userId") Long userId);
+
+    @Modifying
     @Query("DELETE From SoptLetterLike l WHERE l.letterId = :letterId")
     void deleteAllByLetterIdInQuery(@Param("letterId") Long letterId);
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
@@ -5,10 +5,30 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SoptLetterRepository extends JpaRepository<SoptLetter, Long> {
 
     Optional<SoptLetter> findFirstByTopicIdOrderByIdDesc(Long topicId);
 
+    boolean existsByIdAndTopicId(Long id, Long topicId);
+
     long countByAuthorProfileIdAndCreatedAtGreaterThanEqual(Long authorProfileId, LocalDateTime startOfDay);
+
+    @Modifying
+    @Query("UPDATE SoptLetter l SET l.likeCount = COALESCE(l.likeCount, 0) + 1 WHERE l.id = :soptLetterId")
+    int increaseLikeCount(@Param("soptLetterId") Long soptLetterId);
+
+    @Modifying
+    @Query("""
+        UPDATE SoptLetter l
+        SET l.likeCount = CASE
+            WHEN l.likeCount IS NULL OR l.likeCount <= 0 THEN 0
+            ELSE l.likeCount - 1
+        END
+        WHERE l.id = :soptLetterId
+        """)
+    int decreaseLikeCount(@Param("soptLetterId") Long soptLetterId);
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -110,4 +110,38 @@ public class SoptLetterController {
         soptLetterFacade.deleteSoptLetter(userId, messageId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "솝레터 메시지 좋아요 추가")
+    @PostMapping("/topics/{topicId}/messages/{messageId}/likes")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<Void> addLike(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long topicId,
+        @PathVariable Long messageId
+    ) {
+        soptLetterFacade.addLike(userId, topicId, messageId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "솝레터 메시지 좋아요 삭제")
+    @DeleteMapping("/topics/{topicId}/messages/{messageId}/likes")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<Void> removeLike(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long topicId,
+        @PathVariable Long messageId
+    ) {
+        soptLetterFacade.removeLike(userId, topicId, messageId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -644,4 +644,114 @@ class SoptLetterServiceTest {
                     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
                 });
     }
+
+    @Test
+    @DisplayName("SUCCESS_좋아요를 누르지 않은 메시지에 좋아요를 추가하면 좋아요 수가 증가한다")
+    void SUCCESS_addLike() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 125L;
+        when(soptLetterRepository.existsByIdAndTopicId(messageId, topicId)).thenReturn(true);
+        when(soptLetterLikeRepository.insertIgnore(userId, messageId)).thenReturn(1);
+
+        // when
+        soptLetterService.addLike(userId, topicId, messageId);
+
+        // then
+        verify(soptLetterLikeRepository, times(1)).insertIgnore(userId, messageId);
+        verify(soptLetterRepository, times(1)).increaseLikeCount(messageId);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_이미 좋아요를 누른 메시지에 좋아요를 추가하면 현재 상태를 그대로 성공 처리한다")
+    void SUCCESS_addLike_alreadyLiked() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 125L;
+        when(soptLetterRepository.existsByIdAndTopicId(messageId, topicId)).thenReturn(true);
+        when(soptLetterLikeRepository.insertIgnore(userId, messageId)).thenReturn(0);
+
+        // when
+        soptLetterService.addLike(userId, topicId, messageId);
+
+        // then
+        verify(soptLetterLikeRepository, times(1)).insertIgnore(userId, messageId);
+        verify(soptLetterRepository, never()).increaseLikeCount(messageId);
+    }
+
+    @Test
+    @DisplayName("FAIL_존재하지 않는 메시지에 좋아요 추가 시 NotFoundException이 발생한다")
+    void FAIL_addLike_letterNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 999L;
+        when(soptLetterRepository.existsByIdAndTopicId(messageId, topicId)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.addLike(userId, topicId, messageId))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_NOT_FOUND);
+        });
+        verify(soptLetterLikeRepository, never()).insertIgnore(userId, messageId);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_좋아요를 누른 메시지의 좋아요를 삭제하면 좋아요 수가 감소한다")
+    void SUCCESS_removeLike() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 125L;
+        when(soptLetterRepository.existsByIdAndTopicId(messageId, topicId)).thenReturn(true);
+        when(soptLetterLikeRepository.deleteByLetterIdAndUserId(messageId, userId)).thenReturn(1);
+
+        // when
+        soptLetterService.removeLike(userId, topicId, messageId);
+
+        // then
+        verify(soptLetterLikeRepository, times(1)).deleteByLetterIdAndUserId(messageId, userId);
+        verify(soptLetterRepository, times(1)).decreaseLikeCount(messageId);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_좋아요가 없는 메시지의 좋아요를 삭제하면 현재 상태를 그대로 성공 처리한다")
+    void SUCCESS_removeLike_notLiked() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 125L;
+        when(soptLetterRepository.existsByIdAndTopicId(messageId, topicId)).thenReturn(true);
+        when(soptLetterLikeRepository.deleteByLetterIdAndUserId(messageId, userId)).thenReturn(0);
+
+        // when
+        soptLetterService.removeLike(userId, topicId, messageId);
+
+        // then
+        verify(soptLetterLikeRepository, times(1)).deleteByLetterIdAndUserId(messageId, userId);
+        verify(soptLetterRepository, never()).decreaseLikeCount(messageId);
+    }
+
+    @Test
+    @DisplayName("FAIL_존재하지 않는 메시지에 좋아요 삭제 시 NotFoundException이 발생한다")
+    void FAIL_removeLike_letterNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 999L;
+        when(soptLetterRepository.existsByIdAndTopicId(messageId, topicId)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.removeLike(userId, topicId, messageId))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_NOT_FOUND);
+        });
+        verify(soptLetterLikeRepository, never()).deleteByLetterIdAndUserId(messageId, userId);
+    }
 }

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -151,4 +151,34 @@ class SoptLetterFacadeTest {
         // then
         verify(soptLetterService, times(1)).deleteSoptLetter(eq(userId), eq(messageId));
     }
+
+    @Test
+    @DisplayName("SUCCESS_좋아요 추가 파사드가 서비스 메서드를 정상 호출한다")
+    void SUCCESS_addLike() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 125L;
+
+        // when
+        soptLetterFacade.addLike(userId, topicId, messageId);
+
+        // then
+        verify(soptLetterService, times(1)).addLike(eq(userId), eq(topicId), eq(messageId));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_좋아요 삭제 파사드가 서비스 메서드를 정상 호출한다")
+    void SUCCESS_removeLike() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long messageId = 125L;
+
+        // when
+        soptLetterFacade.removeLike(userId, topicId, messageId);
+
+        // then
+        verify(soptLetterService, times(1)).removeLike(eq(userId), eq(topicId), eq(messageId));
+    }
 }


### PR DESCRIPTION
## Related issue 🛠

- closes #770

## Work Description ✏️

- 솝레터 메시지 좋아요 추가 API 구현
- 솝레터 메시지 좋아요 삭제 API 구현
- topicId, messageId 조합으로 좋아요 대상 메시지 존재 여부 검증
- 중복 좋아요 추가/삭제 요청은 현재 상태 그대로 성공 처리
- 좋아요 추가/삭제 시 메시지 likeCount 증가/감소 처리

## Related ScreenShot 📷

N/A

## To Reviewers 📢

- 응답은 기존과 동일하게 body 없이 200 OK로 처리했습니다.