### PR TITLE
[Feat] #773: 익명 신고 폼 주소 조회 기능 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
+++ b/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
@@ -27,6 +27,14 @@ public class OperationConfigService {
     }
 
     @Transactional(readOnly = true)
+    public String getOperationConfigValue(OperationConfigCategory category, String key) {
+        return operationConfigRepository
+            .findByOperationConfigCategoryAndKey(category, key)
+            .map(OperationConfig::getValue)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
     public String getSoptampUpsertCron() {
         return operationConfigRepository
             .findByOperationConfigCategoryAndKey(OperationConfigCategory.SOPTAMP_BATCH, SOPTAMP_UPSERT_CRON_KEY)

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
@@ -34,6 +34,21 @@ public class SoptLetterInfo {
     @Builder
     @ToString
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ReportFormResult {
+
+        private String reportFormUrl;
+
+        public static ReportFormResult from(String reportFormUrl) {
+            return ReportFormResult.builder()
+                .reportFormUrl(reportFormUrl)
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class MessageResult {
         private Long messageId;
         private Long topicId;

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -34,7 +34,7 @@ public class SoptLetterService {
     private static final int MAX_NICKNAME_RETRY_COUNT = 3;
     private static final int NICKNAME_CANDIDATE_SIZE = 3;
     private static final int DAILY_MESSAGE_LIMIT = 10;
-    private static final String REPORT_FORM_URL_KEY = "reportFormUrl";
+    private static final String REPORT_FORM_URL_KEY = "linkUrl";
 
     private final SoptLetterProfileRepository soptLetterProfileRepository;
     private final AnonymousNameGenerator anonymousNameGenerator;

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -8,7 +8,9 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.sopt.app.application.appservice.OperationConfigService;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
+import org.sopt.app.common.config.OperationConfigCategory;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.ConflictException;
 import org.sopt.app.common.exception.NotFoundException;
@@ -32,6 +34,7 @@ public class SoptLetterService {
     private static final int MAX_NICKNAME_RETRY_COUNT = 3;
     private static final int NICKNAME_CANDIDATE_SIZE = 3;
     private static final int DAILY_MESSAGE_LIMIT = 10;
+    private static final String REPORT_FORM_URL_KEY = "reportFormUrl";
 
     private final SoptLetterProfileRepository soptLetterProfileRepository;
     private final AnonymousNameGenerator anonymousNameGenerator;
@@ -39,6 +42,7 @@ public class SoptLetterService {
     private final SoptLetterTopicRepository soptLetterTopicRepository;
     private final SoptLetterLikeRepository soptLetterLikeRepository;
     private final SoptLetterGenerator soptLetterGenerator;
+    private final OperationConfigService operationConfigService;
     private final Clock clock;
 
     public boolean isOnboarded(Long userId) {
@@ -144,9 +148,17 @@ public class SoptLetterService {
             .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public SoptLetterInfo.ReportFormResult getReportForm() {
+        val reportFormUrl = operationConfigService.getOperationConfigValue(
+            OperationConfigCategory.REVIEW_FORM,
+            REPORT_FORM_URL_KEY
+        );
+        return SoptLetterInfo.ReportFormResult.from(reportFormUrl);
+    }
+
     public SoptLetterProfile getProfileByUserId(Long userId) {
         return soptLetterProfileRepository.findByUserId(userId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
     }
 }
-

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -151,7 +151,7 @@ public class SoptLetterService {
     @Transactional(readOnly = true)
     public SoptLetterInfo.ReportFormResult getReportForm() {
         val reportFormUrl = operationConfigService.getOperationConfigValue(
-            OperationConfigCategory.REVIEW_FORM,
+            OperationConfigCategory.SOPT_LETTER,
             REPORT_FORM_URL_KEY
         );
         return SoptLetterInfo.ReportFormResult.from(reportFormUrl);

--- a/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
+++ b/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
@@ -4,5 +4,6 @@ public enum OperationConfigCategory {
     FLOATING_BUTTON,
     REVIEW_FORM,
     PLAYGROUND_POST,
+    SOPT_LETTER,
     SOPTAMP_BATCH
 }

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -20,6 +20,10 @@ public class SoptLetterFacade {
         return soptLetterService.completeOnboarding(userId);
     }
 
+    public SoptLetterInfo.ReportFormResult getReportForm() {
+        return soptLetterService.getReportForm();
+    }
+
     public SoptLetterInfo.MessageResult createSoptLetter(Long userId, Long topicId, String content) {
         return soptLetterService.createSoptLetter(userId, topicId, content);
     }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -59,6 +59,19 @@ public class SoptLetterController {
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 
+    @Operation(summary = "솝레터 익명 신고 폼 주소 조회")
+    @GetMapping("/report-form")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<SoptLetterResponse.ReportFormResponse> getReportForm() {
+        val result = soptLetterFacade.getReportForm();
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+    }
+
     @Operation(summary = "개별 주제 솝레터 메시지 작성")
     @PostMapping("/topics/{topicId}/messages")
     @ApiResponses(value = {

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
@@ -17,5 +17,7 @@ public interface SoptLetterResponseMapper {
     @Mapping(source = "onboarded", target = "isOnboarded")
     SoptLetterResponse.OnboardingProfileResponse of(SoptLetterInfo.Profile info);
 
+    SoptLetterResponse.ReportFormResponse of(SoptLetterInfo.ReportFormResult info);
+
     SoptLetterResponse.WriteMessageResponse of(SoptLetterInfo.MessageResult result);
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -16,6 +16,13 @@ public class SoptLetterResponse {
     ) {
     }
 
+    @Schema(description = "솝레터 익명 신고 폼 주소 조회 응답")
+    public record ReportFormResponse(
+        @Schema(description = "익명 신고 폼 URL", example = "https://example.com/sopt-letter-report")
+        String reportFormUrl
+    ) {
+    }
+
     @Schema(description = "솝레터 개별 주제 메시지 작성 응답")
     public record WriteMessageResponse(
         @Schema(description = "생성된 메시지 ID", example = "125")

--- a/src/test/java/org/sopt/app/application/appservice/OperationConfigServiceTest.java
+++ b/src/test/java/org/sopt/app/application/appservice/OperationConfigServiceTest.java
@@ -32,7 +32,7 @@ class OperationConfigServiceTest {
     @DisplayName("SUCCESS_운영 설정 카테고리와 key로 value를 조회한다")
     void SUCCESS_getOperationConfigValue() {
         // given
-        final String key = "reportFormUrl";
+        final String key = "linkUrl";
         final String value = "https://example.com/sopt-letter-report";
         OperationConfig operationConfig = OperationConfig.of(
                 OperationConfigCategory.REVIEW_FORM,
@@ -56,7 +56,7 @@ class OperationConfigServiceTest {
     @DisplayName("FAIL_운영 설정이 존재하지 않으면 NotFoundException이 발생한다")
     void FAIL_getOperationConfigValue_notFound() {
         // given
-        final String key = "reportFormUrl";
+        final String key = "linkUrl";
         when(operationConfigRepository.findByOperationConfigCategoryAndKey(OperationConfigCategory.REVIEW_FORM, key))
                 .thenReturn(Optional.empty());
 

--- a/src/test/java/org/sopt/app/application/appservice/OperationConfigServiceTest.java
+++ b/src/test/java/org/sopt/app/application/appservice/OperationConfigServiceTest.java
@@ -1,0 +1,71 @@
+package org.sopt.app.application.appservice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.common.config.OperationConfig;
+import org.sopt.app.common.config.OperationConfigCategory;
+import org.sopt.app.common.exception.NotFoundException;
+import org.sopt.app.common.response.ErrorCode;
+import org.sopt.app.interfaces.postgres.OperationConfigRepository;
+
+@ExtendWith(MockitoExtension.class)
+class OperationConfigServiceTest {
+
+    @Mock
+    private OperationConfigRepository operationConfigRepository;
+
+    @InjectMocks
+    private OperationConfigService operationConfigService;
+
+    @Test
+    @DisplayName("SUCCESS_운영 설정 카테고리와 key로 value를 조회한다")
+    void SUCCESS_getOperationConfigValue() {
+        // given
+        final String key = "reportFormUrl";
+        final String value = "https://example.com/sopt-letter-report";
+        OperationConfig operationConfig = OperationConfig.of(
+                OperationConfigCategory.REVIEW_FORM,
+                key,
+                value,
+                "솝레터 익명 신고 폼 URL"
+        );
+        when(operationConfigRepository.findByOperationConfigCategoryAndKey(OperationConfigCategory.REVIEW_FORM, key))
+                .thenReturn(Optional.of(operationConfig));
+
+        // when
+        String result = operationConfigService.getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, key);
+
+        // then
+        assertThat(result).isEqualTo(value);
+        verify(operationConfigRepository, times(1))
+                .findByOperationConfigCategoryAndKey(OperationConfigCategory.REVIEW_FORM, key);
+    }
+
+    @Test
+    @DisplayName("FAIL_운영 설정이 존재하지 않으면 NotFoundException이 발생한다")
+    void FAIL_getOperationConfigValue_notFound() {
+        // given
+        final String key = "reportFormUrl";
+        when(operationConfigRepository.findByOperationConfigCategoryAndKey(OperationConfigCategory.REVIEW_FORM, key))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> operationConfigService.getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, key))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+                });
+    }
+}

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -25,7 +25,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.appservice.OperationConfigService;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
+import org.sopt.app.common.config.OperationConfigCategory;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.ConflictException;
 import org.sopt.app.common.exception.ForbiddenException;
@@ -63,6 +65,9 @@ class SoptLetterServiceTest {
 
     @Mock
     private SoptLetterGenerator soptLetterGenerator;
+
+    @Mock
+    private OperationConfigService operationConfigService;
 
     @Mock
     private Clock clock;
@@ -244,6 +249,23 @@ class SoptLetterServiceTest {
                     NotFoundException exception = (NotFoundException) e;
                     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
                 });
+    }
+
+    @Test
+    @DisplayName("SUCCESS_솝레터 익명 신고 폼 주소를 조회한다")
+    void SUCCESS_getReportForm() {
+        // given
+        final String reportFormUrl = "https://example.com/sopt-letter-report";
+        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "reportFormUrl"))
+                .thenReturn(reportFormUrl);
+
+        // when
+        SoptLetterInfo.ReportFormResult result = soptLetterService.getReportForm();
+
+        // then
+        assertThat(result.getReportFormUrl()).isEqualTo(reportFormUrl);
+        verify(operationConfigService, times(1))
+                .getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "reportFormUrl");
     }
 
     @Test

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -256,7 +256,7 @@ class SoptLetterServiceTest {
     void SUCCESS_getReportForm() {
         // given
         final String reportFormUrl = "https://example.com/sopt-letter-report";
-        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "reportFormUrl"))
+        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "linkUrl"))
                 .thenReturn(reportFormUrl);
 
         // when
@@ -265,7 +265,7 @@ class SoptLetterServiceTest {
         // then
         assertThat(result.getReportFormUrl()).isEqualTo(reportFormUrl);
         verify(operationConfigService, times(1))
-                .getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "reportFormUrl");
+                .getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "linkUrl");
     }
 
     @Test

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -256,7 +256,7 @@ class SoptLetterServiceTest {
     void SUCCESS_getReportForm() {
         // given
         final String reportFormUrl = "https://example.com/sopt-letter-report";
-        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "linkUrl"))
+        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.SOPT_LETTER, "linkUrl"))
                 .thenReturn(reportFormUrl);
 
         // when
@@ -265,7 +265,7 @@ class SoptLetterServiceTest {
         // then
         assertThat(result.getReportFormUrl()).isEqualTo(reportFormUrl);
         verify(operationConfigService, times(1))
-                .getOperationConfigValue(OperationConfigCategory.REVIEW_FORM, "linkUrl");
+                .getOperationConfigValue(OperationConfigCategory.SOPT_LETTER, "linkUrl");
     }
 
     @Test

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -69,6 +69,24 @@ class SoptLetterFacadeTest {
     }
 
     @Test
+    @DisplayName("SUCCESS_익명 신고 폼 주소 조회 파사드가 서비스 메서드를 정상 호출하고 반환한다")
+    void SUCCESS_getReportForm() {
+        // given
+        final String reportFormUrl = "https://example.com/sopt-letter-report";
+        SoptLetterInfo.ReportFormResult expected = SoptLetterInfo.ReportFormResult.builder()
+                .reportFormUrl(reportFormUrl)
+                .build();
+        when(soptLetterService.getReportForm()).thenReturn(expected);
+
+        // when
+        SoptLetterInfo.ReportFormResult result = soptLetterFacade.getReportForm();
+
+        // then
+        assertThat(result.getReportFormUrl()).isEqualTo(reportFormUrl);
+        verify(soptLetterService, times(1)).getReportForm();
+    }
+
+    @Test
     @DisplayName("SUCCESS_메시지 작성 파사드가 서비스 메서드를 정상 호출하고 반환한다")
     void SUCCESS_createSoptLetter() {
         // given


### PR DESCRIPTION
## Related issue 🛠

- closes #773

## Work Description ✏️

- 솝레터 익명 신고 폼 주소 조회 API 구현
- operation_configs에서 신고 폼 URL을 조회하도록 구현
- OperationConfigService에 category/key 기반 단건 value 조회 메서드 추가
- 신고 폼 조회 서비스/파사드 및 operation config 조회 테스트 추가

## Related ScreenShot 📷

N/A

## To Reviewers 📢

- 신고 폼 URL은 operation_configs의 REVIEW_FORM category와 linkUrl key로 조회하도록 구현했습니다.
- 기존 REVIEW_FORM category와 linkUrl key를 재사용하는 방식으로 두었는데, 솝레터 신고 폼 설정을 별도 category/key로 분리하는 편이 더 나을까요..?