### PR TITLE
[Feat] #771: 솝레터 주제 단일/목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
@@ -1,6 +1,7 @@
 package org.sopt.app.application.soptletter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
+import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SoptLetterInfo {
@@ -26,6 +28,67 @@ public class SoptLetterInfo {
             return Profile.builder()
                 .nickname(profile.getNickname())
                 .isOnboarded(profile.isOnboarded())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class TopicListResult {
+
+        private List<TopicSummary> topics;
+
+        public static TopicListResult from(List<SoptLetterTopic> topics) {
+            return TopicListResult.builder()
+                .topics(topics.stream()
+                    .map(TopicSummary::from)
+                    .toList())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class TopicSummary {
+
+        private Long topicId;
+        private String title;
+        private LocalDateTime createdAt;
+
+        public static TopicSummary from(SoptLetterTopic topic) {
+            return TopicSummary.builder()
+                .topicId(topic.getId())
+                .title(topic.getTitle())
+                .createdAt(topic.getCreatedAt())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class TopicDetail {
+
+        private Long topicId;
+        private String title;
+        private Boolean active;
+        private LocalDateTime startedAt;
+        private LocalDateTime endedAt;
+        private LocalDateTime createdAt;
+
+        public static TopicDetail of(SoptLetterTopic topic, LocalDateTime now) {
+            return TopicDetail.builder()
+                .topicId(topic.getId())
+                .title(topic.getTitle())
+                .active(topic.isActiveAt(now))
+                .startedAt(topic.getStartedAt())
+                .endedAt(topic.getEndedAt())
+                .createdAt(topic.getCreatedAt())
                 .build();
         }
     }

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -92,6 +92,19 @@ public class SoptLetterService {
         return Profile.from(profile);
     }
 
+    @Transactional(readOnly = true)
+    public SoptLetterInfo.TopicListResult getTopics() {
+        val topics = soptLetterTopicRepository.findAllByOrderByCreatedAtDesc();
+        return SoptLetterInfo.TopicListResult.from(topics);
+    }
+
+    @Transactional(readOnly = true)
+    public SoptLetterInfo.TopicDetail getTopic(Long topicId) {
+        val topic = soptLetterTopicRepository.findById(topicId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_TOPIC_NOT_FOUND));
+        return SoptLetterInfo.TopicDetail.of(topic, LocalDateTime.now(clock));
+    }
+
     @Transactional
     public SoptLetterInfo.MessageResult createSoptLetter(Long userId, Long topicId, String content) {
         val topic = soptLetterTopicRepository.findById(topicId)
@@ -149,4 +162,3 @@ public class SoptLetterService {
             .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND));
     }
 }
-

--- a/src/main/java/org/sopt/app/common/response/ErrorCode.java
+++ b/src/main/java/org/sopt/app/common/response/ErrorCode.java
@@ -114,6 +114,7 @@ public enum ErrorCode {
     SOPT_LETTER_PROFILE_NOT_FOUND("솝레터 프로필이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     SOPT_LETTER_DAILY_LIMIT_EXCEEDED("일일 솝레터 작성 제한을 초과했습니다.", HttpStatus.BAD_REQUEST),
     SOPT_LETTER_NOT_FOUND("존재하지 않는 솝레터입니다.", HttpStatus.NOT_FOUND),
+    SOPT_LETTER_TOPIC_NOT_FOUND("존재하지 않는 솝레터 주제입니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String message;

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,4 +23,16 @@ public class SoptLetterTopic extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
+    @Column(nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endedAt;
+
+    public boolean isActiveAt(LocalDateTime now) {
+        if (startedAt == null || endedAt == null) {
+            return false;
+        }
+        return !now.isBefore(startedAt) && !now.isAfter(endedAt);
+    }
 }

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -20,6 +20,14 @@ public class SoptLetterFacade {
         return soptLetterService.completeOnboarding(userId);
     }
 
+    public SoptLetterInfo.TopicListResult getTopics() {
+        return soptLetterService.getTopics();
+    }
+
+    public SoptLetterInfo.TopicDetail getTopic(Long topicId) {
+        return soptLetterService.getTopic(topicId);
+    }
+
     public SoptLetterInfo.MessageResult createSoptLetter(Long userId, Long topicId, String content) {
         return soptLetterService.createSoptLetter(userId, topicId, content);
     }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
@@ -1,8 +1,10 @@
 package org.sopt.app.interfaces.postgres.soptletter;
 
+import java.util.List;
 import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic, Long> {
 
+    List<SoptLetterTopic> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -59,6 +59,33 @@ public class SoptLetterController {
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 
+    @Operation(summary = "솝레터 주제 목록 조회")
+    @GetMapping("/topics")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<SoptLetterResponse.TopicsResponse> getTopics() {
+        val result = soptLetterFacade.getTopics();
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+    }
+
+    @Operation(summary = "솝레터 주제 단일 조회")
+    @GetMapping("/topics/{topicId}")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<SoptLetterResponse.TopicDetailResponse> getTopic(
+        @PathVariable Long topicId
+    ) {
+        val result = soptLetterFacade.getTopic(topicId);
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+    }
+
     @Operation(summary = "개별 주제 솝레터 메시지 작성")
     @PostMapping("/topics/{topicId}/messages")
     @ApiResponses(value = {

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
@@ -17,5 +17,11 @@ public interface SoptLetterResponseMapper {
     @Mapping(source = "onboarded", target = "isOnboarded")
     SoptLetterResponse.OnboardingProfileResponse of(SoptLetterInfo.Profile info);
 
+    SoptLetterResponse.TopicsResponse of(SoptLetterInfo.TopicListResult result);
+
+    SoptLetterResponse.TopicResponse of(SoptLetterInfo.TopicSummary result);
+
+    SoptLetterResponse.TopicDetailResponse of(SoptLetterInfo.TopicDetail result);
+
     SoptLetterResponse.WriteMessageResponse of(SoptLetterInfo.MessageResult result);
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.app.presentation.soptletter.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +15,41 @@ public class SoptLetterResponse {
         String nickname,
         @Schema(description = "온보딩 완료 여부", example = "false")
         boolean isOnboarded
+    ) {
+    }
+
+    @Schema(description = "솝레터 주제 목록 조회 응답")
+    public record TopicsResponse(
+        @Schema(description = "주제 목록")
+        List<TopicResponse> topics
+    ) {
+    }
+
+    @Schema(description = "솝레터 주제 응답")
+    public record TopicResponse(
+        @Schema(description = "주제 ID", example = "3")
+        Long topicId,
+        @Schema(description = "주제 제목", example = "36기 회고")
+        String title,
+        @Schema(description = "주제 생성 시각")
+        LocalDateTime createdAt
+    ) {
+    }
+
+    @Schema(description = "솝레터 주제 단일 조회 응답")
+    public record TopicDetailResponse(
+        @Schema(description = "주제 ID", example = "3")
+        Long topicId,
+        @Schema(description = "주제 제목", example = "36기 회고")
+        String title,
+        @Schema(description = "현재 메인 CTA 노출 기간 내 활성 주제인지 여부", example = "true")
+        Boolean active,
+        @Schema(description = "주제 CTA 노출 시작 시각")
+        LocalDateTime startedAt,
+        @Schema(description = "주제 CTA 노출 종료 시각")
+        LocalDateTime endedAt,
+        @Schema(description = "주제 생성 시각")
+        LocalDateTime createdAt
     ) {
     }
 

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -247,6 +247,82 @@ class SoptLetterServiceTest {
     }
 
     @Test
+    @DisplayName("SUCCESS_솝레터 주제 목록을 최신순으로 조회한다")
+    void SUCCESS_getTopics() {
+        // given
+        LocalDateTime firstCreatedAt = LocalDateTime.of(2026, 4, 20, 0, 0);
+        LocalDateTime secondCreatedAt = LocalDateTime.of(2026, 4, 18, 0, 0);
+        SoptLetterTopic firstTopic = mock(SoptLetterTopic.class);
+        SoptLetterTopic secondTopic = mock(SoptLetterTopic.class);
+        when(firstTopic.getId()).thenReturn(2L);
+        when(firstTopic.getTitle()).thenReturn("36기 앱잼 회고");
+        when(firstTopic.getCreatedAt()).thenReturn(firstCreatedAt);
+        when(secondTopic.getId()).thenReturn(1L);
+        when(secondTopic.getTitle()).thenReturn("36기 회고");
+        when(secondTopic.getCreatedAt()).thenReturn(secondCreatedAt);
+        when(soptLetterTopicRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(firstTopic, secondTopic));
+
+        // when
+        SoptLetterInfo.TopicListResult result = soptLetterService.getTopics();
+
+        // then
+        assertThat(result.getTopics()).hasSize(2);
+        assertThat(result.getTopics().get(0).getTopicId()).isEqualTo(2L);
+        assertThat(result.getTopics().get(0).getTitle()).isEqualTo("36기 앱잼 회고");
+        assertThat(result.getTopics().get(0).getCreatedAt()).isEqualTo(firstCreatedAt);
+        assertThat(result.getTopics().get(1).getTopicId()).isEqualTo(1L);
+        verify(soptLetterTopicRepository, times(1)).findAllByOrderByCreatedAtDesc();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_솝레터 주제를 단일 조회한다")
+    void SUCCESS_getTopic() {
+        // given
+        final Long topicId = 3L;
+        LocalDateTime now = LocalDateTime.of(2026, 4, 20, 12, 0);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 18, 0, 0);
+        LocalDateTime endedAt = LocalDateTime.of(2026, 4, 28, 23, 59, 59);
+        LocalDateTime createdAt = LocalDateTime.of(2026, 4, 18, 0, 0);
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        when(topic.getId()).thenReturn(topicId);
+        when(topic.getTitle()).thenReturn("36기 회고");
+        when(topic.getStartedAt()).thenReturn(startedAt);
+        when(topic.getEndedAt()).thenReturn(endedAt);
+        when(topic.getCreatedAt()).thenReturn(createdAt);
+        when(topic.isActiveAt(now)).thenReturn(true);
+        when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+
+        // when
+        SoptLetterInfo.TopicDetail result = soptLetterService.getTopic(topicId);
+
+        // then
+        assertThat(result.getTopicId()).isEqualTo(topicId);
+        assertThat(result.getTitle()).isEqualTo("36기 회고");
+        assertThat(result.getActive()).isTrue();
+        assertThat(result.getStartedAt()).isEqualTo(startedAt);
+        assertThat(result.getEndedAt()).isEqualTo(endedAt);
+        assertThat(result.getCreatedAt()).isEqualTo(createdAt);
+        verify(soptLetterTopicRepository, times(1)).findById(topicId);
+    }
+
+    @Test
+    @DisplayName("FAIL_솝레터 주제 단일 조회 시 주제가 존재하지 않으면 NotFoundException이 발생한다")
+    void FAIL_getTopic_notFound() {
+        // given
+        final Long topicId = 999L;
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.getTopic(topicId))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_TOPIC_NOT_FOUND);
+                });
+    }
+
+    @Test
     @DisplayName("SUCCESS_첫 번째 메시지 작성 시 기본 색상인 BLUE_50으로 편지를 성공적으로 작성한다")
     void SUCCESS_createSoptLetter() {
         // given

--- a/src/test/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopicTest.java
+++ b/src/test/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopicTest.java
@@ -1,0 +1,40 @@
+package org.sopt.app.domain.entity.soptletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SoptLetterTopicTest {
+
+    @Test
+    @DisplayName("SUCCESS_현재 시각이 주제 노출 기간 내에 있으면 활성 상태를 반환한다")
+    void SUCCESS_isActiveAt() {
+        // given
+        SoptLetterTopic topic = new SoptLetterTopic();
+        ReflectionTestUtils.setField(topic, "startedAt", LocalDateTime.of(2026, 4, 18, 0, 0));
+        ReflectionTestUtils.setField(topic, "endedAt", LocalDateTime.of(2026, 4, 28, 23, 59, 59));
+
+        // when
+        boolean result = topic.isActiveAt(LocalDateTime.of(2026, 4, 20, 12, 0));
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_종료 시각이 없으면 비활성 상태를 반환한다")
+    void SUCCESS_isActiveAt_endedAtNull() {
+        // given
+        SoptLetterTopic topic = new SoptLetterTopic();
+        ReflectionTestUtils.setField(topic, "startedAt", LocalDateTime.of(2026, 4, 18, 0, 0));
+
+        // when
+        boolean result = topic.isActiveAt(LocalDateTime.of(2026, 4, 20, 12, 0));
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +67,55 @@ class SoptLetterFacadeTest {
         assertThat(result.getNickname()).isEqualTo(nickname);
         assertThat(result.isOnboarded()).isTrue();
         verify(soptLetterService, times(1)).completeOnboarding(userId);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_솝레터 주제 목록 조회 파사드가 서비스 메서드를 정상 호출하고 반환한다")
+    void SUCCESS_getTopics() {
+        // given
+        SoptLetterInfo.TopicSummary topic = SoptLetterInfo.TopicSummary.builder()
+                .topicId(3L)
+                .title("36기 회고")
+                .createdAt(LocalDateTime.of(2026, 4, 18, 0, 0))
+                .build();
+        SoptLetterInfo.TopicListResult expected = SoptLetterInfo.TopicListResult.builder()
+                .topics(List.of(topic))
+                .build();
+        when(soptLetterService.getTopics()).thenReturn(expected);
+
+        // when
+        SoptLetterInfo.TopicListResult result = soptLetterFacade.getTopics();
+
+        // then
+        assertThat(result.getTopics()).hasSize(1);
+        assertThat(result.getTopics().get(0).getTopicId()).isEqualTo(3L);
+        assertThat(result.getTopics().get(0).getTitle()).isEqualTo("36기 회고");
+        verify(soptLetterService, times(1)).getTopics();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_솝레터 주제 단일 조회 파사드가 서비스 메서드를 정상 호출하고 반환한다")
+    void SUCCESS_getTopic() {
+        // given
+        final Long topicId = 3L;
+        SoptLetterInfo.TopicDetail expected = SoptLetterInfo.TopicDetail.builder()
+                .topicId(topicId)
+                .title("36기 회고")
+                .active(true)
+                .startedAt(LocalDateTime.of(2026, 4, 18, 0, 0))
+                .endedAt(LocalDateTime.of(2026, 4, 28, 23, 59, 59))
+                .createdAt(LocalDateTime.of(2026, 4, 18, 0, 0))
+                .build();
+        when(soptLetterService.getTopic(eq(topicId))).thenReturn(expected);
+
+        // when
+        SoptLetterInfo.TopicDetail result = soptLetterFacade.getTopic(topicId);
+
+        // then
+        assertThat(result.getTopicId()).isEqualTo(topicId);
+        assertThat(result.getTitle()).isEqualTo("36기 회고");
+        assertThat(result.getActive()).isTrue();
+        verify(soptLetterService, times(1)).getTopic(eq(topicId));
     }
 
     @Test


### PR DESCRIPTION
## Related issue 🛠

- closes #771

## Work Description ✏️

- 솝레터 주제 목록 조회 API 구현
- 솝레터 주제 단일 조회 API 구현
- 주제 목록 최신순 조회를 위한 repository 메서드 추가
- 주제 노출 기간 기반 active 계산 로직 추가
- 주제 조회 서비스/파사드/도메인 테스트 추가

## Related ScreenShot 📷

N/A

## To Reviewers 📢

- 주제 CTA 노출 기간을 표현하기 위해 SoptLetterTopic에 startedAt, endedAt 필드를 추가했습니다.
- 명세상 주제 노출 기간은 생성 시 정해지는 것으로 이해해서 endedAt은 정상 데이터에서 필수로 보았고, 누락 시 active=false로 방어 처리했습니다.