### PR TITLE
[Feat] #772: 주제별 솝레터 메시지 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
@@ -1,6 +1,7 @@
 package org.sopt.app.application.soptletter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,9 +10,12 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
+import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SoptLetterInfo {
+
+    private static final int PREVIEW_CONTENT_LENGTH = 50;
 
     @Getter
     @Builder
@@ -27,6 +31,77 @@ public class SoptLetterInfo {
                 .nickname(profile.getNickname())
                 .isOnboarded(profile.isOnboarded())
                 .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class TopicMessageListResult {
+        private Long topicId;
+        private String title;
+        private Integer totalCount;
+        private Long nextCursor;
+        private Boolean hasNext;
+        private List<TopicMessageSummary> messages;
+
+        public static TopicMessageListResult of(
+            SoptLetterTopic topic,
+            Integer totalCount,
+            Long nextCursor,
+            Boolean hasNext,
+            List<TopicMessageSummary> messages
+        ) {
+            return TopicMessageListResult.builder()
+                .topicId(topic.getId())
+                .title(topic.getTitle())
+                .totalCount(totalCount)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .messages(messages)
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class TopicMessageSummary {
+        private Long messageId;
+        private String authorNickname;
+        private String previewContent;
+        private String colorCode;
+        private Double rotationDegree;
+        private String shapeType;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private Integer likeCount;
+        private Boolean likedByMe;
+        private Boolean mine;
+
+        public static TopicMessageSummary of(SoptLetter letter, String nickname, Boolean likedByMe, Boolean mine) {
+            return TopicMessageSummary.builder()
+                .messageId(letter.getId())
+                .authorNickname(nickname)
+                .previewContent(toPreviewContent(letter.getMessage()))
+                .colorCode(letter.getColor().getHexCode())
+                .rotationDegree(letter.getDegree())
+                .shapeType(letter.getShapeType().name())
+                .createdAt(letter.getCreatedAt())
+                .updatedAt(letter.getUpdatedAt())
+                .likeCount(letter.getLikeCount())
+                .likedByMe(likedByMe)
+                .mine(mine)
+                .build();
+        }
+
+        private static String toPreviewContent(String content) {
+            if (content.length() <= PREVIEW_CONTENT_LENGTH) {
+                return content;
+            }
+            return content.substring(0, PREVIEW_CONTENT_LENGTH);
         }
     }
 

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -217,7 +217,7 @@ public class SoptLetterService {
         }
         val letterIds = letters.stream()
             .map(SoptLetter::getId)
-            .toList();
+            .collect(Collectors.toSet());
         return soptLetterLikeRepository.findLikedLetterIdsByUserIdAndLetterIdIn(userId, letterIds);
     }
 

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -3,12 +3,16 @@ package org.sopt.app.application.soptletter;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
+import org.sopt.app.application.soptletter.SoptLetterInfo.TopicMessageListResult;
+import org.sopt.app.application.soptletter.SoptLetterInfo.TopicMessageSummary;
 import org.sopt.app.common.exception.BadRequestException;
 import org.sopt.app.common.exception.ConflictException;
 import org.sopt.app.common.exception.NotFoundException;
@@ -21,6 +25,7 @@ import org.sopt.app.interfaces.postgres.soptletter.SoptLetterProfileRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterTopicRepository;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,6 +95,27 @@ public class SoptLetterService {
         SoptLetterProfile profile = getProfileByUserId(userId);
         profile.completeOnboarding();
         return Profile.from(profile);
+    }
+
+    @Transactional(readOnly = true)
+    public TopicMessageListResult getTopicMessages(Long userId, Long topicId, Long cursor, Integer size) {
+        validateTopicMessagePageSize(size);
+
+        val topic = soptLetterTopicRepository.findById(topicId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        val requesterProfile = getProfileByUserId(userId);
+
+        val fetchedLetters = getTopicLetters(topicId, cursor, size + 1);
+        val hasNext = fetchedLetters.size() > size;
+        val letters = hasNext ? fetchedLetters.subList(0, size) : fetchedLetters;
+        val nextCursor = resolveNextCursor(letters);
+
+        val likedLetterIds = findLikedLetterIds(userId, letters);
+        val authorNicknamesByProfileId = getAuthorNicknamesByProfileId(letters);
+        val messageSummaries = toTopicMessageSummaries(letters, requesterProfile, likedLetterIds, authorNicknamesByProfileId);
+        val totalCount = Math.toIntExact(soptLetterRepository.countByTopicId(topicId));
+
+        return TopicMessageListResult.of(topic, totalCount, nextCursor, hasNext, messageSummaries);
     }
 
     @Transactional
@@ -162,6 +188,70 @@ public class SoptLetterService {
 
         val likedByMe = soptLetterLikeRepository.existsByLetterIdAndUserId(messageId, userId);
         return SoptLetterInfo.MessageResult.of(letter, authorNickname, likedByMe, mine);
+    }
+
+    private void validateTopicMessagePageSize(Integer size) {
+        if (size == null || size <= 0) {
+            throw new BadRequestException(ErrorCode.INVALID_PARAMETER);
+        }
+    }
+
+    private List<SoptLetter> getTopicLetters(Long topicId, Long cursor, Integer size) {
+        val pageable = PageRequest.of(0, size);
+        if (cursor == null) {
+            return soptLetterRepository.findAllByTopicIdOrderByIdDesc(topicId, pageable);
+        }
+        return soptLetterRepository.findAllByTopicIdAndIdLessThanOrderByIdDesc(topicId, cursor, pageable);
+    }
+
+    private Long resolveNextCursor(List<SoptLetter> letters) {
+        if (letters.isEmpty()) {
+            return null;
+        }
+        return letters.get(letters.size() - 1).getId();
+    }
+
+    private Set<Long> findLikedLetterIds(Long userId, List<SoptLetter> letters) {
+        if (letters.isEmpty()) {
+            return Set.of();
+        }
+        val letterIds = letters.stream()
+            .map(SoptLetter::getId)
+            .toList();
+        return soptLetterLikeRepository.findLikedLetterIdsByUserIdAndLetterIdIn(userId, letterIds);
+    }
+
+    private Map<Long, String> getAuthorNicknamesByProfileId(List<SoptLetter> letters) {
+        if (letters.isEmpty()) {
+            return Map.of();
+        }
+
+        val authorProfileIds = letters.stream()
+            .map(SoptLetter::getAuthorProfileId)
+            .collect(Collectors.toSet());
+        val authorNicknamesByProfileId = soptLetterProfileRepository.findAllById(authorProfileIds).stream()
+            .collect(Collectors.toMap(SoptLetterProfile::getId, SoptLetterProfile::getNickname));
+
+        if (authorNicknamesByProfileId.size() != authorProfileIds.size()) {
+            throw new NotFoundException(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
+        }
+        return authorNicknamesByProfileId;
+    }
+
+    private List<TopicMessageSummary> toTopicMessageSummaries(
+        List<SoptLetter> letters,
+        SoptLetterProfile requesterProfile,
+        Set<Long> likedLetterIds,
+        Map<Long, String> authorNicknamesByProfileId
+    ) {
+        return letters.stream()
+            .map(letter -> TopicMessageSummary.of(
+                letter,
+                authorNicknamesByProfileId.get(letter.getAuthorProfileId()),
+                likedLetterIds.contains(letter.getId()),
+                letter.isAuthor(requesterProfile.getId())
+            ))
+            .toList();
     }
 
     private String resolveAuthorNickname(

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -20,6 +20,10 @@ public class SoptLetterFacade {
         return soptLetterService.completeOnboarding(userId);
     }
 
+    public SoptLetterInfo.TopicMessageListResult getTopicMessages(Long userId, Long topicId, Long cursor, Integer size) {
+        return soptLetterService.getTopicMessages(userId, topicId, cursor, size);
+    }
+
     public SoptLetterInfo.MessageResult createSoptLetter(Long userId, Long topicId, String content) {
         return soptLetterService.createSoptLetter(userId, topicId, content);
     }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -1,6 +1,5 @@
 package org.sopt.app.interfaces.postgres.soptletter;
 
-import java.util.List;
 import java.util.Set;
 import org.sopt.app.domain.entity.soptletter.SoptLetterLike;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,7 +11,7 @@ public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, 
     boolean existsByLetterIdAndUserId(Long letterId, Long userId);
 
     @Query("SELECT l.letterId FROM SoptLetterLike l WHERE l.userId = :userId AND l.letterId IN :letterIds")
-    Set<Long> findLikedLetterIdsByUserIdAndLetterIdIn(@Param("userId") Long userId, @Param("letterIds") List<Long> letterIds);
+    Set<Long> findLikedLetterIdsByUserIdAndLetterIdIn(@Param("userId") Long userId, @Param("letterIds") Set<Long> letterIds);
 
     @Modifying
     @Query("DELETE From SoptLetterLike l WHERE l.letterId = :letterId")

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -1,5 +1,7 @@
 package org.sopt.app.interfaces.postgres.soptletter;
 
+import java.util.List;
+import java.util.Set;
 import org.sopt.app.domain.entity.soptletter.SoptLetterLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -8,6 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, Long> {
     boolean existsByLetterIdAndUserId(Long letterId, Long userId);
+
+    @Query("SELECT l.letterId FROM SoptLetterLike l WHERE l.userId = :userId AND l.letterId IN :letterIds")
+    Set<Long> findLikedLetterIdsByUserIdAndLetterIdIn(@Param("userId") Long userId, @Param("letterIds") List<Long> letterIds);
 
     @Modifying
     @Query("DELETE From SoptLetterLike l WHERE l.letterId = :letterId")

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterRepository.java
@@ -1,14 +1,21 @@
 package org.sopt.app.interfaces.postgres.soptletter;
 
-
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SoptLetterRepository extends JpaRepository<SoptLetter, Long> {
 
     Optional<SoptLetter> findFirstByTopicIdOrderByIdDesc(Long topicId);
+
+    List<SoptLetter> findAllByTopicIdOrderByIdDesc(Long topicId, Pageable pageable);
+
+    List<SoptLetter> findAllByTopicIdAndIdLessThanOrderByIdDesc(Long topicId, Long cursor, Pageable pageable);
+
+    long countByTopicId(Long topicId);
 
     long countByAuthorProfileIdAndCreatedAtGreaterThanEqual(Long authorProfileId, LocalDateTime startOfDay);
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -56,6 +57,24 @@ public class SoptLetterController {
         @AuthenticationPrincipal Long userId
     ) {
         val result = soptLetterFacade.completeOnboardingProfile(userId);
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+    }
+
+    @Operation(summary = "개별 주제 솝레터 메시지 목록 조회")
+    @GetMapping("/topics/{topicId}/messages")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "400", description = "bad request", content = @Content),
+        @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<SoptLetterResponse.TopicMessagesResponse> getTopicMessages(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable Long topicId,
+        @RequestParam(required = false) Long cursor,
+        @RequestParam(defaultValue = "20") Integer size
+    ) {
+        val result = soptLetterFacade.getTopicMessages(userId, topicId, cursor, size);
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
@@ -17,6 +17,10 @@ public interface SoptLetterResponseMapper {
     @Mapping(source = "onboarded", target = "isOnboarded")
     SoptLetterResponse.OnboardingProfileResponse of(SoptLetterInfo.Profile info);
 
+    SoptLetterResponse.TopicMessagesResponse of(SoptLetterInfo.TopicMessageListResult result);
+
+    SoptLetterResponse.TopicMessageResponse of(SoptLetterInfo.TopicMessageSummary result);
+
     SoptLetterResponse.WriteMessageResponse of(SoptLetterInfo.MessageResult result);
 
     SoptLetterResponse.MessageDetailResponse ofDetail(SoptLetterInfo.MessageResult result);

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -2,6 +2,7 @@ package org.sopt.app.presentation.soptletter.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,50 @@ public class SoptLetterResponse {
         String nickname,
         @Schema(description = "온보딩 완료 여부", example = "false")
         boolean isOnboarded
+    ) {
+    }
+
+    @Schema(description = "개별 주제 솝레터 메시지 목록 조회 응답")
+    public record TopicMessagesResponse(
+        @Schema(description = "주제 ID", example = "3")
+        Long topicId,
+        @Schema(description = "주제 제목", example = "36기 회고")
+        String title,
+        @Schema(description = "해당 주제 메시지 개수", example = "2")
+        Integer totalCount,
+        @Schema(description = "다음 페이지 조회 커서", example = "91")
+        Long nextCursor,
+        @Schema(description = "다음 페이지 존재 여부", example = "false")
+        Boolean hasNext,
+        @Schema(description = "해당 주제 메시지 목록")
+        List<TopicMessageResponse> messages
+    ) {
+    }
+
+    @Schema(description = "개별 주제 솝레터 메시지 목록 아이템")
+    public record TopicMessageResponse(
+        @Schema(description = "메시지 ID", example = "91")
+        Long messageId,
+        @Schema(description = "작성자 익명 닉네임", example = "반짝이는 고래")
+        String authorNickname,
+        @Schema(description = "공백 포함 50자 미리보기", example = "앱잼 때 같이 밤새면서 고생했던 게 아직도 기억나...")
+        String previewContent,
+        @Schema(description = "메모 색상 hex code", example = "#CCFFEC")
+        String colorCode,
+        @Schema(description = "메모 회전 각도", example = "4.0")
+        Double rotationDegree,
+        @Schema(description = "메모 모양 타입", example = "POINT")
+        String shapeType,
+        @Schema(description = "생성 시각")
+        LocalDateTime createdAt,
+        @Schema(description = "수정 시각")
+        LocalDateTime updatedAt,
+        @Schema(description = "좋아요 수", example = "5")
+        Integer likeCount,
+        @Schema(description = "내가 좋아요 눌렀는지 여부", example = "false")
+        Boolean likedByMe,
+        @Schema(description = "내가 작성한 메시지인지 여부", example = "false")
+        Boolean mine
     ) {
     }
 

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -873,4 +873,266 @@ class SoptLetterServiceTest {
                     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_NOT_FOUND);
                 });
     }
+
+    @Test
+    @DisplayName("SUCCESS_주제별 솝레터 메시지 목록을 최신순으로 조회한다")
+    void SUCCESS_getTopicMessages() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final int size = 2;
+        final String longContent = "1234567890".repeat(6);
+
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        when(topic.getId()).thenReturn(topicId);
+        when(topic.getTitle()).thenReturn("36기 회고");
+
+        SoptLetterProfile requesterProfile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("내 닉네임")
+                .build();
+        SoptLetterProfile otherProfile = SoptLetterProfile.builder()
+                .id(20L)
+                .userId(2L)
+                .nickname("반짝이는 고래")
+                .build();
+
+        SoptLetter firstLetter = SoptLetter.builder()
+                .id(125L)
+                .topicId(topicId)
+                .authorProfileId(20L)
+                .message(longContent)
+                .color(SoptLetterColor.GREEN_50)
+                .shapeType(SoptLetterShapeType.POINT)
+                .degree(4.0)
+                .likeCount(5)
+                .build();
+        SoptLetter secondLetter = SoptLetter.builder()
+                .id(124L)
+                .topicId(topicId)
+                .authorProfileId(10L)
+                .message("내가 쓴 메시지")
+                .color(SoptLetterColor.YELLOW_50)
+                .shapeType(SoptLetterShapeType.CLOUD)
+                .degree(0.0)
+                .likeCount(1)
+                .build();
+        SoptLetter extraLetter = SoptLetter.builder()
+                .id(123L)
+                .topicId(topicId)
+                .authorProfileId(20L)
+                .message("다음 페이지 메시지")
+                .color(SoptLetterColor.RED_50)
+                .shapeType(SoptLetterShapeType.POINT)
+                .degree(-4.0)
+                .likeCount(0)
+                .build();
+
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(requesterProfile));
+        when(soptLetterRepository.findAllByTopicIdOrderByIdDesc(anyLong(), any()))
+                .thenReturn(List.of(firstLetter, secondLetter, extraLetter));
+        when(soptLetterLikeRepository.findLikedLetterIdsByUserIdAndLetterIdIn(anyLong(), any()))
+                .thenReturn(Set.of(125L));
+        when(soptLetterProfileRepository.findAllById(any())).thenReturn(List.of(requesterProfile, otherProfile));
+        when(soptLetterRepository.countByTopicId(topicId)).thenReturn(3L);
+
+        // when
+        SoptLetterInfo.TopicMessageListResult result = soptLetterService.getTopicMessages(userId, topicId, null, size);
+
+        // then
+        assertThat(result.getTopicId()).isEqualTo(topicId);
+        assertThat(result.getTitle()).isEqualTo("36기 회고");
+        assertThat(result.getTotalCount()).isEqualTo(3);
+        assertThat(result.getHasNext()).isTrue();
+        assertThat(result.getNextCursor()).isEqualTo(124L);
+        assertThat(result.getMessages()).hasSize(2);
+        assertThat(result.getMessages().get(0).getMessageId()).isEqualTo(125L);
+        assertThat(result.getMessages().get(0).getAuthorNickname()).isEqualTo("반짝이는 고래");
+        assertThat(result.getMessages().get(0).getPreviewContent()).isEqualTo(longContent.substring(0, 50));
+        assertThat(result.getMessages().get(0).getLikedByMe()).isTrue();
+        assertThat(result.getMessages().get(0).getMine()).isFalse();
+        assertThat(result.getMessages().get(1).getMessageId()).isEqualTo(124L);
+        assertThat(result.getMessages().get(1).getAuthorNickname()).isEqualTo("내 닉네임");
+        assertThat(result.getMessages().get(1).getLikedByMe()).isFalse();
+        assertThat(result.getMessages().get(1).getMine()).isTrue();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_커서가 있으면 커서보다 작은 메시지만 조회한다")
+    void SUCCESS_getTopicMessages_withCursor() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long cursor = 120L;
+        final int size = 20;
+
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        when(topic.getId()).thenReturn(topicId);
+        when(topic.getTitle()).thenReturn("36기 회고");
+
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("반짝이는 고래")
+                .build();
+        SoptLetter letter = SoptLetter.builder()
+                .id(119L)
+                .topicId(topicId)
+                .authorProfileId(10L)
+                .message("커서 이후 메시지")
+                .color(SoptLetterColor.BLUE_50)
+                .shapeType(SoptLetterShapeType.CLOUD)
+                .degree(0.0)
+                .likeCount(0)
+                .build();
+
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(soptLetterRepository.findAllByTopicIdAndIdLessThanOrderByIdDesc(topicId, cursor, org.springframework.data.domain.PageRequest.of(0, 21)))
+                .thenReturn(List.of(letter));
+        when(soptLetterLikeRepository.findLikedLetterIdsByUserIdAndLetterIdIn(anyLong(), any()))
+                .thenReturn(Set.of());
+        when(soptLetterProfileRepository.findAllById(any())).thenReturn(List.of(profile));
+        when(soptLetterRepository.countByTopicId(topicId)).thenReturn(1L);
+
+        // when
+        SoptLetterInfo.TopicMessageListResult result = soptLetterService.getTopicMessages(userId, topicId, cursor, size);
+
+        // then
+        assertThat(result.getMessages()).hasSize(1);
+        assertThat(result.getMessages().get(0).getMessageId()).isEqualTo(119L);
+        assertThat(result.getHasNext()).isFalse();
+        assertThat(result.getNextCursor()).isEqualTo(119L);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_주제별 솝레터 메시지가 없으면 빈 목록을 반환한다")
+    void SUCCESS_getTopicMessages_empty() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        when(topic.getId()).thenReturn(topicId);
+        when(topic.getTitle()).thenReturn("36기 회고");
+
+        SoptLetterProfile profile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("반짝이는 고래")
+                .build();
+
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(soptLetterRepository.findAllByTopicIdOrderByIdDesc(anyLong(), any())).thenReturn(List.of());
+        when(soptLetterRepository.countByTopicId(topicId)).thenReturn(0L);
+
+        // when
+        SoptLetterInfo.TopicMessageListResult result = soptLetterService.getTopicMessages(userId, topicId, null, 20);
+
+        // then
+        assertThat(result.getMessages()).isEmpty();
+        assertThat(result.getTotalCount()).isZero();
+        assertThat(result.getHasNext()).isFalse();
+        assertThat(result.getNextCursor()).isNull();
+        verify(soptLetterLikeRepository, never()).findLikedLetterIdsByUserIdAndLetterIdIn(anyLong(), any());
+        verify(soptLetterProfileRepository, never()).findAllById(any());
+    }
+
+    @Test
+    @DisplayName("FAIL_주제별 솝레터 메시지 목록 조회 시 size가 0 이하이면 BadRequestException이 발생한다")
+    void FAIL_getTopicMessages_zeroSize() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.getTopicMessages(userId, topicId, null, 0))
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(e -> {
+                    BadRequestException exception = (BadRequestException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_PARAMETER);
+                });
+        verify(soptLetterTopicRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("FAIL_주제별 솝레터 메시지 목록 조회 시 토픽이 없으면 NotFoundException이 발생한다")
+    void FAIL_getTopicMessages_topicNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 999L;
+
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.getTopicMessages(userId, topicId, null, 20))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_주제별 솝레터 메시지 목록 조회 시 프로필이 없으면 NotFoundException이 발생한다")
+    void FAIL_getTopicMessages_profileNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.getTopicMessages(userId, topicId, null, 20))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("FAIL_주제별 솝레터 메시지 목록 조회 시 작성자 프로필이 없으면 NotFoundException이 발생한다")
+    void FAIL_getTopicMessages_authorProfileNotFound() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        SoptLetterProfile requesterProfile = SoptLetterProfile.builder()
+                .id(10L)
+                .userId(userId)
+                .nickname("내 닉네임")
+                .build();
+        SoptLetter letter = SoptLetter.builder()
+                .id(125L)
+                .topicId(topicId)
+                .authorProfileId(20L)
+                .message("작성자 프로필이 없는 메시지")
+                .color(SoptLetterColor.GREEN_50)
+                .shapeType(SoptLetterShapeType.POINT)
+                .degree(4.0)
+                .likeCount(0)
+                .build();
+
+        when(soptLetterTopicRepository.findById(topicId)).thenReturn(Optional.of(topic));
+        when(soptLetterProfileRepository.findByUserId(userId)).thenReturn(Optional.of(requesterProfile));
+        when(soptLetterRepository.findAllByTopicIdOrderByIdDesc(anyLong(), any())).thenReturn(List.of(letter));
+        when(soptLetterLikeRepository.findLikedLetterIdsByUserIdAndLetterIdIn(anyLong(), any()))
+                .thenReturn(Set.of());
+        when(soptLetterProfileRepository.findAllById(any())).thenReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.getTopicMessages(userId, topicId, null, 20))
+                .isInstanceOf(NotFoundException.class)
+                .satisfies(e -> {
+                    NotFoundException exception = (NotFoundException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SOPT_LETTER_PROFILE_NOT_FOUND);
+                });
+    }
 }

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +67,49 @@ class SoptLetterFacadeTest {
         assertThat(result.getNickname()).isEqualTo(nickname);
         assertThat(result.isOnboarded()).isTrue();
         verify(soptLetterService, times(1)).completeOnboarding(userId);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_주제별 메시지 목록 조회 파사드가 서비스 메서드를 정상 호출하고 반환한다")
+    void SUCCESS_getTopicMessages() {
+        // given
+        final Long userId = 1L;
+        final Long topicId = 3L;
+        final Long cursor = 120L;
+        final Integer size = 20;
+
+        SoptLetterInfo.TopicMessageSummary message = SoptLetterInfo.TopicMessageSummary.builder()
+                .messageId(119L)
+                .authorNickname("반짝이는 고래")
+                .previewContent("커서 이후 메시지")
+                .colorCode("#CCFFEC")
+                .rotationDegree(4.0)
+                .shapeType("POINT")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .likeCount(0)
+                .likedByMe(false)
+                .mine(false)
+                .build();
+        SoptLetterInfo.TopicMessageListResult expected = SoptLetterInfo.TopicMessageListResult.builder()
+                .topicId(topicId)
+                .title("36기 회고")
+                .totalCount(1)
+                .nextCursor(119L)
+                .hasNext(false)
+                .messages(List.of(message))
+                .build();
+
+        when(soptLetterService.getTopicMessages(eq(userId), eq(topicId), eq(cursor), eq(size))).thenReturn(expected);
+
+        // when
+        SoptLetterInfo.TopicMessageListResult result = soptLetterFacade.getTopicMessages(userId, topicId, cursor, size);
+
+        // then
+        assertThat(result.getTopicId()).isEqualTo(topicId);
+        assertThat(result.getMessages()).hasSize(1);
+        assertThat(result.getNextCursor()).isEqualTo(119L);
+        verify(soptLetterService, times(1)).getTopicMessages(eq(userId), eq(topicId), eq(cursor), eq(size));
     }
 
     @Test


### PR DESCRIPTION
## Related issue 🛠

- closes #772

## Work Description ✏️

- 개별 주제 솝레터 메시지 목록 조회 API를 구현했습니다.
- 메시지 ID 기반 커서 페이지네이션으로 최신순 목록을 조회합니다.
- 목록 응답에 작성자 닉네임, 50자 미리보기, 카드 스타일, 좋아요 수/여부, 내 글 여부를 포함했습니다.
- 현재 페이지의 좋아요 여부와 작성자 프로필은 묶어서 조회하도록 처리했습니다.

## Related ScreenShot 📷

N/A

## To Reviewers 📢

- nextCursor는 조회된 메시지가 있으면 마지막 메시지 ID를 내려주고, 빈 목록이면 null로 내려주도록 했습니다.
- size는 명세의 잘못된 size 값 케이스에 맞춰 0 이하일 때 INVALID_PARAMETER로 처리했습니다.