### PR TITLE
[Feat] #783: 마이페이지 파트 정보 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/platform/PlatformService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformService.java
@@ -166,6 +166,18 @@ public class PlatformService {
                 .toList();
     }
 
+    public String getOldestSoptActivityPart(PlatformUserInfoResponse platformUserInfoResponse) {
+        if (platformUserInfoResponse.soptActivities() == null) {
+            return "";
+        }
+        return platformUserInfoResponse.soptActivities().stream()
+            .filter(PlatformUserInfoResponse.SoptActivities::isSoptActivity)
+            .filter(activity -> activity.part() != null && !activity.part().isBlank())
+            .min(Comparator.comparingInt(PlatformUserInfoResponse.SoptActivities::generation))
+            .map(PlatformUserInfoResponse.SoptActivities::part)
+            .orElse("");
+    }
+
     public boolean isCurrentGeneration(Long generation) {
         return generation.equals(currentGeneration);
     }

--- a/src/main/java/org/sopt/app/application/platform/PlatformService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformService.java
@@ -166,16 +166,17 @@ public class PlatformService {
                 .toList();
     }
 
-    public String getOldestSoptActivityPart(PlatformUserInfoResponse platformUserInfoResponse) {
+    public String getSoptActivityParts(PlatformUserInfoResponse platformUserInfoResponse) {
         if (platformUserInfoResponse.soptActivities() == null) {
             return "";
         }
         return platformUserInfoResponse.soptActivities().stream()
             .filter(PlatformUserInfoResponse.SoptActivities::isSoptActivity)
             .filter(activity -> activity.part() != null && !activity.part().isBlank())
-            .min(Comparator.comparingInt(PlatformUserInfoResponse.SoptActivities::generation))
+            .sorted(Comparator.comparingInt(PlatformUserInfoResponse.SoptActivities::generation))
             .map(PlatformUserInfoResponse.SoptActivities::part)
-            .orElse("");
+            .distinct()
+            .collect(Collectors.joining("/"));
     }
 
     public boolean isCurrentGeneration(Long generation) {

--- a/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
+++ b/src/main/java/org/sopt/app/application/playground/dto/PlaygroundProfileInfo.java
@@ -81,6 +81,7 @@ public class PlaygroundProfileInfo {
         private UserStatus status;
         private String name;
         private String profileImage;
+        private String part;
         private List<Long> generationList;
     }
 

--- a/src/main/java/org/sopt/app/facade/UserFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserFacade.java
@@ -52,6 +52,7 @@ public class UserFacade {
             .name(platformUserInfoResponse.name())
             .status(platformService.getStatus(platformUserInfoResponse))
             .profileImage(platformUserInfoResponse.profileImage())
+            .part(platformService.getOldestSoptActivityPart(platformUserInfoResponse))
             .generationList(platformService.getMemberGenerationList(platformUserInfoResponse))
             .build();
 

--- a/src/main/java/org/sopt/app/facade/UserFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserFacade.java
@@ -52,7 +52,7 @@ public class UserFacade {
             .name(platformUserInfoResponse.name())
             .status(platformService.getStatus(platformUserInfoResponse))
             .profileImage(platformUserInfoResponse.profileImage())
-            .part(platformService.getOldestSoptActivityPart(platformUserInfoResponse))
+            .part(platformService.getSoptActivityParts(platformUserInfoResponse))
             .generationList(platformService.getMemberGenerationList(platformUserInfoResponse))
             .build();
 

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -53,6 +53,8 @@ public class UserResponse {
         private String name;
         @Schema(description = "유저 프로필 메세지", example = "1등이 되고 말거야!")
         private String profileImage;
+        @Schema(description = "유저 활동 파트 (여러 SOPT 활동 파트가 있는 경우 가장 오래된 활동 파트)", example = "서버")
+        private String part;
         @Schema(description = "유저 활동 기수 정보", example = "[32,30,29]")
         private List<Long> generationList;
 
@@ -61,6 +63,7 @@ public class UserResponse {
                 .status("UNAUTHENTICATED")
                 .name("")
                 .profileImage("")
+                .part("")
                 .generationList(List.of())
                 .build();
         }

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -53,7 +53,7 @@ public class UserResponse {
         private String name;
         @Schema(description = "유저 프로필 메세지", example = "1등이 되고 말거야!")
         private String profileImage;
-        @Schema(description = "유저 활동 파트 (여러 SOPT 활동 파트가 있는 경우 가장 오래된 활동 파트)", example = "서버")
+        @Schema(description = "유저 활동 파트 (여러 SOPT 활동 파트가 있는 경우 오래된 활동 파트부터 /로 구분)", example = "기획/서버")
         private String part;
         @Schema(description = "유저 활동 기수 정보", example = "[32,30,29]")
         private List<Long> generationList;

--- a/src/test/java/org/sopt/app/application/platform/PlatformServiceTest.java
+++ b/src/test/java/org/sopt/app/application/platform/PlatformServiceTest.java
@@ -110,19 +110,20 @@ class PlatformServiceTest {
     }
 
     @Test
-    @DisplayName("유저의 가장 오래된 SOPT 활동 파트를 조회한다")
-    void SUCCESS_getOldestSoptActivityPart() {
+    @DisplayName("유저의 SOPT 활동 파트를 오래된 기수 순으로 조회한다")
+    void SUCCESS_getSoptActivityParts() {
         // given
         PlatformUserInfoResponse profile = new PlatformUserInfoResponse(1, "testUser", null, null, null, null, 34, List.of(
                 new PlatformUserInfoResponse.SoptActivities(1, 34, "서버", "Team", true),
                 new PlatformUserInfoResponse.SoptActivities(2, 33, "기획", "Team", true),
-                new PlatformUserInfoResponse.SoptActivities(3, 32, "PM", "Team", false)
+                new PlatformUserInfoResponse.SoptActivities(3, 35, "서버", "Team", true),
+                new PlatformUserInfoResponse.SoptActivities(4, 32, "PM", "Team", false)
         ));
 
         // when
-        String part = platformService.getOldestSoptActivityPart(profile);
+        String part = platformService.getSoptActivityParts(profile);
 
         // then
-        assertThat(part).isEqualTo("기획");
+        assertThat(part).isEqualTo("기획/서버");
     }
 }

--- a/src/test/java/org/sopt/app/application/platform/PlatformServiceTest.java
+++ b/src/test/java/org/sopt/app/application/platform/PlatformServiceTest.java
@@ -108,5 +108,21 @@ class PlatformServiceTest {
         assertThat(generations.get(0)).isEqualTo(34L);
         assertThat(generations.get(1)).isEqualTo(33L);
     }
-}
 
+    @Test
+    @DisplayName("유저의 가장 오래된 SOPT 활동 파트를 조회한다")
+    void SUCCESS_getOldestSoptActivityPart() {
+        // given
+        PlatformUserInfoResponse profile = new PlatformUserInfoResponse(1, "testUser", null, null, null, null, 34, List.of(
+                new PlatformUserInfoResponse.SoptActivities(1, 34, "서버", "Team", true),
+                new PlatformUserInfoResponse.SoptActivities(2, 33, "기획", "Team", true),
+                new PlatformUserInfoResponse.SoptActivities(3, 32, "PM", "Team", false)
+        ));
+
+        // when
+        String part = platformService.getOldestSoptActivityPart(profile);
+
+        // then
+        assertThat(part).isEqualTo("기획");
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

closes #783

## Work Description ✏️

마이페이지 메인 응답에서 유저의 활동 파트를 내려줄 수 있도록 `part` 필드를 추가했습니다.

여러 SOPT 활동 파트가 있는 경우 `isSopt=true`인 활동을 오래된 기수 순으로 정렬하고, 중복 파트를 제거한 뒤 `/`로 구분해 내려주도록 구현했습니다. (ex. `기획/서버`)

## Related ScreenShot 📷

N/A

## To Reviewers 📢

N/A