### PR TITLE
[Feat] #784: 콕찌르기 로그 내가 찌른 콕 집계

### DIFF
--- a/src/main/java/org/sopt/app/application/poke/PokeService.java
+++ b/src/main/java/org/sopt/app/application/poke/PokeService.java
@@ -65,6 +65,6 @@ public class PokeService {
 
     @Transactional(readOnly = true)
     public Long getUserPokeCount(Long userId) {
-        return historyRepository.countByPokerIdOrPokedId(userId, userId);
+        return historyRepository.countByPokerId(userId);
     }
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/PokeHistoryRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/PokeHistoryRepository.java
@@ -41,7 +41,7 @@ public interface PokeHistoryRepository extends JpaRepository<PokeHistory, Long> 
 
     Long countByPokedIdAndIsReplyIsFalse(Long pokedId);
 
-    Long countByPokerIdOrPokedId(@NotNull Long pokerId, @NotNull Long pokedId);
+    Long countByPokerId(@NotNull Long pokerId);
 
     @Query("SELECT ph FROM PokeHistory ph WHERE ph.id IN (SELECT MAX(ph2.id) FROM PokeHistory ph2 WHERE ph2.pokedId = :userId AND ph2.isReply = false AND EXISTS (SELECT 1 FROM User u WHERE u.id = ph2.pokerId) GROUP BY ph2.pokerId) ORDER BY function('RANDOM')")
     List<PokeHistory> findRandomUnRepliedPokeMeHistory(@Param("userId") Long userId, Pageable pageable);

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -151,7 +151,7 @@ public class UserResponse {
         private String profileImage;
         @Schema(description = "파트")
         private String part;
-        @Schema(description = "콕찌르기 횟수")
+        @Schema(description = "내가 찌른 콕 횟수")
         private String pokeCount;
         @Schema(description = "", example = "14등")
         private String soptampRank;
@@ -228,7 +228,7 @@ public class UserResponse {
         @Schema(description = "총 쳐준 박수 개수")
         Integer clapCount,
 
-        @Schema(description = "총 콕찌르기 개수 (활동 기수만 반환)")
+        @Schema(description = "내가 찌른 콕 횟수 총합")
         int totalPokeCount,
 
         @Schema(description = "친한 친구 콕 찌르기 횟수의 총합 (2~4회 찌른 사람 대상, 활동 기수만)")


### PR DESCRIPTION
## Related issue 🛠

closes #784

## Work Description ✏️

마이 솝트로그와 솝트로그에서 사용하는 콕찌르기 집계가 내가 찌른 콕만 계산되도록 `PokeHistoryRepository` 조회 기준을 `pokerId`로 변경했습니다.

기존 `pokerId OR pokedId` 집계에서 받은 콕이 함께 포함되던 문제를 수정하고, 관련 Swagger 설명을 업데이트했습니다.

## Related ScreenShot 📷

N/A

## To Reviewers 📢

N/A