### PR TITLE
[Feat] #789: 솝레터 주제 목록 조회시 default 주제 조회

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
@@ -104,12 +104,14 @@ public class SoptLetterInfo {
 
         private Long topicId;
         private String title;
+        private boolean isDefault;
         private LocalDateTime createdAt;
 
         public static TopicSummary from(SoptLetterTopic topic) {
             return TopicSummary.builder()
                 .topicId(topic.getId())
                 .title(topic.getTitle())
+                .isDefault(topic.isDefault())
                 .createdAt(topic.getCreatedAt())
                 .build();
         }

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -22,6 +22,7 @@ import org.sopt.app.common.response.ErrorCode;
 import org.sopt.app.common.utils.AnonymousNameGenerator;
 import org.sopt.app.domain.entity.soptletter.SoptLetter;
 import org.sopt.app.domain.entity.soptletter.SoptLetterProfile;
+import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterLikeRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterProfileRepository;
 import org.sopt.app.interfaces.postgres.soptletter.SoptLetterRepository;
@@ -123,9 +124,19 @@ public class SoptLetterService {
     }
 
     @Transactional(readOnly = true)
-    public SoptLetterInfo.TopicListResult getTopics() {
-        val topics = soptLetterTopicRepository.findAllByOrderByCreatedAtDesc();
+    public SoptLetterInfo.TopicListResult getTopics(String type) {
+        val topics = getTopicsByType(type);
         return SoptLetterInfo.TopicListResult.from(topics);
+    }
+
+    private List<SoptLetterTopic> getTopicsByType(String type) {
+        if (type == null) {
+            return soptLetterTopicRepository.findAllByOrderByCreatedAtDesc();
+        }
+        if ("default".equalsIgnoreCase(type)) {
+            return soptLetterTopicRepository.findAllDefaultTopicsOrderByCreatedAtDesc();
+        }
+        throw new BadRequestException(ErrorCode.INVALID_PARAMETER);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
@@ -24,6 +24,9 @@ public class SoptLetterTopic extends BaseEntity {
     private String title;
 
     @Column(nullable = false)
+    private boolean isDefault;
+
+    @Column(nullable = false)
     private LocalDateTime startedAt;
 
     @Column(nullable = false)

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -28,8 +28,8 @@ public class SoptLetterFacade {
         return soptLetterService.getReportForm();
     }
 
-    public SoptLetterInfo.TopicListResult getTopics() {
-        return soptLetterService.getTopics();
+    public SoptLetterInfo.TopicListResult getTopics(String type) {
+        return soptLetterService.getTopics(type);
     }
 
     public SoptLetterInfo.TopicDetail getTopic(Long topicId) {

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
@@ -3,8 +3,12 @@ package org.sopt.app.interfaces.postgres.soptletter;
 import java.util.List;
 import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic, Long> {
 
     List<SoptLetterTopic> findAllByOrderByCreatedAtDesc();
+
+    @Query("SELECT t FROM SoptLetterTopic t WHERE t.isDefault = true ORDER BY t.createdAt DESC")
+    List<SoptLetterTopic> findAllDefaultTopicsOrderByCreatedAtDesc();
 }

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -77,11 +77,14 @@ public class SoptLetterController {
     @GetMapping("/topics")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "400", description = "bad request", content = @Content),
         @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
         @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    public ResponseEntity<SoptLetterResponse.TopicsResponse> getTopics() {
-        val result = soptLetterFacade.getTopics();
+    public ResponseEntity<SoptLetterResponse.TopicsResponse> getTopics(
+        @RequestParam(required = false) String type
+    ) {
+        val result = soptLetterFacade.getTopics(type);
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
@@ -25,6 +25,7 @@ public interface SoptLetterResponseMapper {
 
     SoptLetterResponse.TopicsResponse of(SoptLetterInfo.TopicListResult result);
 
+    @Mapping(source = "default", target = "isDefault")
     SoptLetterResponse.TopicResponse of(SoptLetterInfo.TopicSummary result);
 
     SoptLetterResponse.TopicDetailResponse of(SoptLetterInfo.TopicDetail result);

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -38,6 +38,8 @@ public class SoptLetterResponse {
         Long topicId,
         @Schema(description = "주제 제목", example = "36기 회고")
         String title,
+        @Schema(description = "기본 주제 여부", example = "false")
+        boolean isDefault,
         @Schema(description = "주제 생성 시각")
         LocalDateTime createdAt
     ) {

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -278,9 +278,11 @@ class SoptLetterServiceTest {
         SoptLetterTopic secondTopic = mock(SoptLetterTopic.class);
         when(firstTopic.getId()).thenReturn(2L);
         when(firstTopic.getTitle()).thenReturn("36기 앱잼 회고");
+        when(firstTopic.isDefault()).thenReturn(false);
         when(firstTopic.getCreatedAt()).thenReturn(firstCreatedAt);
         when(secondTopic.getId()).thenReturn(1L);
         when(secondTopic.getTitle()).thenReturn("36기 회고");
+        when(secondTopic.isDefault()).thenReturn(true);
         when(secondTopic.getCreatedAt()).thenReturn(secondCreatedAt);
         when(soptLetterTopicRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(firstTopic, secondTopic));
 
@@ -291,8 +293,10 @@ class SoptLetterServiceTest {
         assertThat(result.getTopics()).hasSize(2);
         assertThat(result.getTopics().get(0).getTopicId()).isEqualTo(2L);
         assertThat(result.getTopics().get(0).getTitle()).isEqualTo("36기 앱잼 회고");
+        assertThat(result.getTopics().get(0).isDefault()).isFalse();
         assertThat(result.getTopics().get(0).getCreatedAt()).isEqualTo(firstCreatedAt);
         assertThat(result.getTopics().get(1).getTopicId()).isEqualTo(1L);
+        assertThat(result.getTopics().get(1).isDefault()).isTrue();
         verify(soptLetterTopicRepository, times(1)).findAllByOrderByCreatedAtDesc();
     }
 

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -287,7 +287,7 @@ class SoptLetterServiceTest {
         when(soptLetterTopicRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(firstTopic, secondTopic));
 
         // when
-        SoptLetterInfo.TopicListResult result = soptLetterService.getTopics();
+        SoptLetterInfo.TopicListResult result = soptLetterService.getTopics(null);
 
         // then
         assertThat(result.getTopics()).hasSize(2);
@@ -298,6 +298,46 @@ class SoptLetterServiceTest {
         assertThat(result.getTopics().get(1).getTopicId()).isEqualTo(1L);
         assertThat(result.getTopics().get(1).isDefault()).isTrue();
         verify(soptLetterTopicRepository, times(1)).findAllByOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllDefaultTopicsOrderByCreatedAtDesc();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_type이 default면 기본 솝레터 주제만 조회한다")
+    void SUCCESS_getTopics_defaultType() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2026, 4, 18, 0, 0);
+        SoptLetterTopic defaultTopic = mock(SoptLetterTopic.class);
+        when(defaultTopic.getId()).thenReturn(1L);
+        when(defaultTopic.getTitle()).thenReturn("36기 솝레터");
+        when(defaultTopic.isDefault()).thenReturn(true);
+        when(defaultTopic.getCreatedAt()).thenReturn(createdAt);
+        when(soptLetterTopicRepository.findAllDefaultTopicsOrderByCreatedAtDesc()).thenReturn(List.of(defaultTopic));
+
+        // when
+        SoptLetterInfo.TopicListResult result = soptLetterService.getTopics("default");
+
+        // then
+        assertThat(result.getTopics()).hasSize(1);
+        assertThat(result.getTopics().get(0).getTopicId()).isEqualTo(1L);
+        assertThat(result.getTopics().get(0).getTitle()).isEqualTo("36기 솝레터");
+        assertThat(result.getTopics().get(0).isDefault()).isTrue();
+        assertThat(result.getTopics().get(0).getCreatedAt()).isEqualTo(createdAt);
+        verify(soptLetterTopicRepository, times(1)).findAllDefaultTopicsOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllByOrderByCreatedAtDesc();
+    }
+
+    @Test
+    @DisplayName("FAIL_지원하지 않는 주제 목록 조회 type이면 BadRequestException이 발생한다")
+    void FAIL_getTopics_invalidType() {
+        // when & then
+        assertThatThrownBy(() -> soptLetterService.getTopics("invalid"))
+                .isInstanceOf(BadRequestException.class)
+                .satisfies(e -> {
+                    BadRequestException exception = (BadRequestException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_PARAMETER);
+                });
+        verify(soptLetterTopicRepository, never()).findAllByOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllDefaultTopicsOrderByCreatedAtDesc();
     }
 
     @Test

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -137,6 +137,7 @@ class SoptLetterFacadeTest {
         SoptLetterInfo.TopicSummary topic = SoptLetterInfo.TopicSummary.builder()
                 .topicId(3L)
                 .title("36기 회고")
+                .isDefault(true)
                 .createdAt(LocalDateTime.of(2026, 4, 18, 0, 0))
                 .build();
         SoptLetterInfo.TopicListResult expected = SoptLetterInfo.TopicListResult.builder()
@@ -151,6 +152,7 @@ class SoptLetterFacadeTest {
         assertThat(result.getTopics()).hasSize(1);
         assertThat(result.getTopics().get(0).getTopicId()).isEqualTo(3L);
         assertThat(result.getTopics().get(0).getTitle()).isEqualTo("36기 회고");
+        assertThat(result.getTopics().get(0).isDefault()).isTrue();
         verify(soptLetterService, times(1)).getTopics();
     }
 

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -143,17 +143,17 @@ class SoptLetterFacadeTest {
         SoptLetterInfo.TopicListResult expected = SoptLetterInfo.TopicListResult.builder()
                 .topics(List.of(topic))
                 .build();
-        when(soptLetterService.getTopics()).thenReturn(expected);
+        when(soptLetterService.getTopics(null)).thenReturn(expected);
 
         // when
-        SoptLetterInfo.TopicListResult result = soptLetterFacade.getTopics();
+        SoptLetterInfo.TopicListResult result = soptLetterFacade.getTopics(null);
 
         // then
         assertThat(result.getTopics()).hasSize(1);
         assertThat(result.getTopics().get(0).getTopicId()).isEqualTo(3L);
         assertThat(result.getTopics().get(0).getTitle()).isEqualTo("36기 회고");
         assertThat(result.getTopics().get(0).isDefault()).isTrue();
-        verify(soptLetterService, times(1)).getTopics();
+        verify(soptLetterService, times(1)).getTopics(null);
     }
 
     @Test


### PR DESCRIPTION
## Related issue 🛠

- closes #789

## Work Description ✏️

- 솝레터 주제 목록 조회 응답에 기본 주제 여부를 추가했습니다.
- SoptLetterTopic에 isDefault 필드를 추가하고, 주제 요약/응답 DTO까지 매핑했습니다.
- GET /api/v2/sopt-letter/topics?type=default 요청 시 기본 주제만 조회할 수 있도록 타입 필터를 추가했습니다.
- isDefault 응답 매핑 및 주제 목록 조회 테스트를 보강했습니다.

## Related ScreenShot 📷

N/A

## To Reviewers 📢.