### PR TITLE
[Fix] #791: 솝레터 좋아요 관련 DB 스키마 명시

### DIFF
--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -16,7 +16,7 @@ public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, 
     @Modifying
     @Query(
         value = """
-            INSERT INTO sopt_letter_like (user_id, letter_id, created_at, updated_at)
+            INSERT INTO ${spring.jpa.properties.hibernate.default_schema}.sopt_letter_like (user_id, letter_id, created_at, updated_at)
             VALUES (:userId, :letterId, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
             ON CONFLICT (letter_id, user_id) DO NOTHING
             """,


### PR DESCRIPTION
## Related issue 🛠

- closes #791

## Work Description ✏️

- 솝레터 좋아요 추가 native query에서 sopt_letter_like 테이블 앞에 설정 기반 schema를 명시했습니다.
- dev/prod 환경별 spring.jpa.properties.hibernate.default_schema 값을 사용하도록 수정했습니다.

## Related ScreenShot 📷

N/A

## To Reviewers 📢

기존 ON CONFLICT DO NOTHING 방식은 유지하고, native query가 명시 스키마의 테이블을 바라보도록 수정했습니다.

검증: ./gradlew test 통과

현재 app-dev 배포 전 원격 API는 기존 코드로 동작하므로, 배포 후 좋아요 추가 API 재확인이 필요합니다.