### PR TITLE
[Fix] #791: 솝레터 좋아요 관련 DB 스키마 명시

### DIFF
--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterLikeRepository.java
@@ -16,7 +16,7 @@ public interface SoptLetterLikeRepository extends JpaRepository<SoptLetterLike, 
     @Modifying
     @Query(
         value = """
-            INSERT INTO sopt_letter_like (user_id, letter_id, created_at, updated_at)
+            INSERT INTO {h-schema}sopt_letter_like (user_id, letter_id, created_at, updated_at)
             VALUES (:userId, :letterId, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
             ON CONFLICT (letter_id, user_id) DO NOTHING
             """,


### PR DESCRIPTION
## Related issue 🛠
closes #791

## Work Description ✏️
- 솝레터 좋아요 추가 native query에서 `sopt_letter_like` 테이블에 스키마를 명시했습니다.
- Hibernate native query 전용 플레이스홀더 `{h-schema}`를 사용해 `hibernate.default_schema` 값을 적용하도록 수정했습니다. (dev: `app_dev` / prod: `app_prod` 자동 적용)

## To Reviewers 📢
