### PR TITLE
[Feat] #800: 솝레터 normal 주제 조회 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -152,6 +152,9 @@ public class SoptLetterService {
         if ("default".equalsIgnoreCase(type)) {
             return soptLetterTopicRepository.findAllDefaultTopicsOrderByCreatedAtDesc();
         }
+        if ("normal".equalsIgnoreCase(type)) {
+            return soptLetterTopicRepository.findAllNormalTopicsOrderByCreatedAtDesc();
+        }
         throw new BadRequestException(ErrorCode.INVALID_PARAMETER);
     }
 

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
@@ -11,4 +11,7 @@ public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic
 
     @Query("SELECT t FROM SoptLetterTopic t WHERE t.isDefault = true ORDER BY t.createdAt DESC")
     List<SoptLetterTopic> findAllDefaultTopicsOrderByCreatedAtDesc();
+
+    @Query("SELECT t FROM SoptLetterTopic t WHERE t.isDefault = false ORDER BY t.createdAt DESC")
+    List<SoptLetterTopic> findAllNormalTopicsOrderByCreatedAtDesc();
 }

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -299,6 +299,7 @@ class SoptLetterServiceTest {
         assertThat(result.getTopics().get(1).isDefault()).isTrue();
         verify(soptLetterTopicRepository, times(1)).findAllByOrderByCreatedAtDesc();
         verify(soptLetterTopicRepository, never()).findAllDefaultTopicsOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllNormalTopicsOrderByCreatedAtDesc();
     }
 
     @Test
@@ -324,6 +325,33 @@ class SoptLetterServiceTest {
         assertThat(result.getTopics().get(0).getCreatedAt()).isEqualTo(createdAt);
         verify(soptLetterTopicRepository, times(1)).findAllDefaultTopicsOrderByCreatedAtDesc();
         verify(soptLetterTopicRepository, never()).findAllByOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllNormalTopicsOrderByCreatedAtDesc();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_type이 normal이면 기본 주제를 제외한 솝레터 주제를 조회한다")
+    void SUCCESS_getTopics_normalType() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2026, 7, 19, 0, 0);
+        SoptLetterTopic normalTopic = mock(SoptLetterTopic.class);
+        when(normalTopic.getId()).thenReturn(2L);
+        when(normalTopic.getTitle()).thenReturn("38기 앱잼 회고");
+        when(normalTopic.isDefault()).thenReturn(false);
+        when(normalTopic.getCreatedAt()).thenReturn(createdAt);
+        when(soptLetterTopicRepository.findAllNormalTopicsOrderByCreatedAtDesc()).thenReturn(List.of(normalTopic));
+
+        // when
+        SoptLetterInfo.TopicListResult result = soptLetterService.getTopics("normal");
+
+        // then
+        assertThat(result.getTopics()).hasSize(1);
+        assertThat(result.getTopics().get(0).getTopicId()).isEqualTo(2L);
+        assertThat(result.getTopics().get(0).getTitle()).isEqualTo("38기 앱잼 회고");
+        assertThat(result.getTopics().get(0).isDefault()).isFalse();
+        assertThat(result.getTopics().get(0).getCreatedAt()).isEqualTo(createdAt);
+        verify(soptLetterTopicRepository, times(1)).findAllNormalTopicsOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllDefaultTopicsOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllByOrderByCreatedAtDesc();
     }
 
     @Test
@@ -338,6 +366,7 @@ class SoptLetterServiceTest {
                 });
         verify(soptLetterTopicRepository, never()).findAllByOrderByCreatedAtDesc();
         verify(soptLetterTopicRepository, never()).findAllDefaultTopicsOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, never()).findAllNormalTopicsOrderByCreatedAtDesc();
     }
 
     @Test


### PR DESCRIPTION
## Related issue 🛠

- closes #800

## Work Description ✏️

- 솝레터 주제 목록 조회 시 type=normal 요청을 지원합니다.
- type=normal인 경우 기본 주제를 제외한 주제 목록만 최신순으로 조회합니다.
- 기존 type 미전달 시 전체 조회, type=default 시 기본 주제 조회 동작은 유지했습니다.
- normal 타입 조회 서비스 테스트를 추가했습니다.

## Related ScreenShot 📷

N/A

## To Reviewers 📢

- type 값을 주지 않으면 기존처럼 전체 주제가 조회되고, type=normal인 경우 isDefault=false인 주제만 내려가도록 구현했습니다.