### PR TITLE
[Feat] #804: 탈퇴 폼 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
+++ b/src/main/java/org/sopt/app/application/appservice/OperationConfigService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,10 +29,15 @@ public class OperationConfigService {
 
     @Transactional(readOnly = true)
     public String getOperationConfigValue(OperationConfigCategory category, String key) {
+        return findOperationConfigValue(category, key)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<String> findOperationConfigValue(OperationConfigCategory category, String key) {
         return operationConfigRepository
             .findByOperationConfigCategoryAndKey(category, key)
-            .map(OperationConfig::getValue)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+            .map(OperationConfig::getValue);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/app/application/user/UserWithdrawHistoryService.java
+++ b/src/main/java/org/sopt/app/application/user/UserWithdrawHistoryService.java
@@ -1,0 +1,19 @@
+package org.sopt.app.application.user;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.app.domain.entity.UserWithdrawHistory;
+import org.sopt.app.interfaces.postgres.UserWithdrawHistoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserWithdrawHistoryService {
+
+    private final UserWithdrawHistoryRepository userWithdrawHistoryRepository;
+
+    @Transactional
+    public void recordWithdrawRequest(Long userId) {
+        userWithdrawHistoryRepository.save(UserWithdrawHistory.of(userId));
+    }
+}

--- a/src/main/java/org/sopt/app/application/user/UserWithdrawInfo.java
+++ b/src/main/java/org/sopt/app/application/user/UserWithdrawInfo.java
@@ -1,0 +1,27 @@
+package org.sopt.app.application.user;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserWithdrawInfo {
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class WithdrawFormResult {
+
+        private String withdrawFormUrl;
+
+        public static WithdrawFormResult from(String withdrawFormUrl) {
+            return WithdrawFormResult.builder()
+                .withdrawFormUrl(withdrawFormUrl)
+                .build();
+        }
+    }
+}

--- a/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
+++ b/src/main/java/org/sopt/app/common/config/OperationConfigCategory.java
@@ -5,5 +5,6 @@ public enum OperationConfigCategory {
     REVIEW_FORM,
     PLAYGROUND_POST,
     SOPT_LETTER,
-    SOPTAMP_BATCH
+    SOPTAMP_BATCH,
+    WITHDRAW_FORM
 }

--- a/src/main/java/org/sopt/app/domain/entity/UserWithdrawHistory.java
+++ b/src/main/java/org/sopt/app/domain/entity/UserWithdrawHistory.java
@@ -1,0 +1,31 @@
+package org.sopt.app.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_withdraw_history")
+public class UserWithdrawHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long userId;
+
+    public static UserWithdrawHistory of(Long userId) {
+        return UserWithdrawHistory.builder()
+            .userId(userId)
+            .build();
+    }
+}

--- a/src/main/java/org/sopt/app/facade/UserWithdrawFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserWithdrawFacade.java
@@ -1,12 +1,15 @@
 package org.sopt.app.facade;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.sopt.app.application.appservice.OperationConfigService;
 import org.sopt.app.application.user.UserWithdrawInfo;
+import org.sopt.app.application.user.UserWithdrawHistoryService;
 import org.sopt.app.common.config.OperationConfigCategory;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserWithdrawFacade {
@@ -14,12 +17,22 @@ public class UserWithdrawFacade {
     private static final String WITHDRAW_FORM_URL_KEY = "linkUrl";
 
     private final OperationConfigService operationConfigService;
+    private final UserWithdrawHistoryService userWithdrawHistoryService;
 
-    public UserWithdrawInfo.WithdrawFormResult getWithdrawForm() {
-        val withdrawFormUrl = operationConfigService.getOperationConfigValue(
+    public UserWithdrawInfo.WithdrawFormResult requestWithdraw(Long userId) {
+        userWithdrawHistoryService.recordWithdrawRequest(userId);
+        return getWithdrawFormOrEmpty();
+    }
+
+    private UserWithdrawInfo.WithdrawFormResult getWithdrawFormOrEmpty() {
+        val withdrawFormUrl = operationConfigService.findOperationConfigValue(
             OperationConfigCategory.WITHDRAW_FORM,
             WITHDRAW_FORM_URL_KEY
-        );
+        ).orElse(null);
+        if (withdrawFormUrl == null) {
+            log.warn("탈퇴 요청은 기록되었으나 WITHDRAW_FORM- {} 운영 설정이 존재하지 않음.",
+                WITHDRAW_FORM_URL_KEY);
+        }
         return UserWithdrawInfo.WithdrawFormResult.from(withdrawFormUrl);
     }
 }

--- a/src/main/java/org/sopt/app/facade/UserWithdrawFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserWithdrawFacade.java
@@ -1,0 +1,25 @@
+package org.sopt.app.facade;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.app.application.appservice.OperationConfigService;
+import org.sopt.app.application.user.UserWithdrawInfo;
+import org.sopt.app.common.config.OperationConfigCategory;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserWithdrawFacade {
+
+    private static final String WITHDRAW_FORM_URL_KEY = "linkUrl";
+
+    private final OperationConfigService operationConfigService;
+
+    public UserWithdrawInfo.WithdrawFormResult getWithdrawForm() {
+        val withdrawFormUrl = operationConfigService.getOperationConfigValue(
+            OperationConfigCategory.WITHDRAW_FORM,
+            WITHDRAW_FORM_URL_KEY
+        );
+        return UserWithdrawInfo.WithdrawFormResult.from(withdrawFormUrl);
+    }
+}

--- a/src/main/java/org/sopt/app/interfaces/postgres/UserWithdrawHistoryRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/UserWithdrawHistoryRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.app.interfaces.postgres;
+
+import org.sopt.app.domain.entity.UserWithdrawHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserWithdrawHistoryRepository extends JpaRepository<UserWithdrawHistory, Long> {
+
+}

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -201,6 +201,13 @@ public class UserResponse {
         private Long userId;
     }
 
+    @Schema(description = "탈퇴 폼 주소 조회 응답")
+    public record WithdrawFormResponse(
+        @Schema(description = "탈퇴 폼 URL", example = "https://example.com/withdraw-form")
+        String withdrawFormUrl
+    ) {
+    }
+
     @JsonInclude(Include.NON_NULL)
     public record MySoptLog(
 

--- a/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponseMapper.java
@@ -3,6 +3,7 @@ package org.sopt.app.presentation.user;
 import org.mapstruct.*;
 import org.sopt.app.application.playground.dto.PlaygroundProfileInfo;
 import org.sopt.app.application.user.UserInfo;
+import org.sopt.app.application.user.UserWithdrawInfo;
 import org.sopt.app.presentation.user.UserResponse.*;
 
 @Mapper(
@@ -20,4 +21,6 @@ public interface UserResponseMapper {
     UserResponse.Generation ofGeneration(PlaygroundProfileInfo.UserActiveInfo userActiveInfo);
 
     Create ofCreate(UserInfo userInfo);
+
+    UserResponse.WithdrawFormResponse of(UserWithdrawInfo.WithdrawFormResult info);
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserWithdrawController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserWithdrawController.java
@@ -17,7 +17,7 @@ import org.sopt.app.presentation.notification.PushTokenRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -64,15 +64,26 @@ public class UserWithdrawController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "탈퇴 폼 주소 조회")
+    /**
+     * 서버 레포 통합 이전, 정책 요구사항에 따라 탈퇴를 위한 임시 API를 개발함.
+     * DB에 요청한 유저 ID를 저장한 후, 탈퇴 구글폼 링크를 반환
+     */
+    @Operation(
+            summary = "탈퇴 요청하기 (임시)",
+            description = "인증된 사용자의 탈퇴 요청을 기록하고, 상세 사유 입력용 구글 폼 URL을 응답으로 반환함. "
+                    + "실제 데이터 삭제는 운영자가 각 서비스에서 수동으로 처리하므로, 200은 '탈퇴 완료'가 아니라 "
+                    + "'요청 접수'를 의미. 폼 설정이 없으면 withdrawFormUrl 은 null 로 반환되며 요청 기록은 성공함."
+    )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "success"),
-            @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+            @ApiResponse(responseCode = "200", description = "탈퇴 요청 접수됨 + 폼 URL 반환"),
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
-    @GetMapping(value = "/withdraw/form")
-    public ResponseEntity<UserResponse.WithdrawFormResponse> getWithdrawForm() {
-        val result = userWithdrawFacade.getWithdrawForm();
+    @PostMapping(value = "/withdraw")
+    public ResponseEntity<UserResponse.WithdrawFormResponse> requestWithdraw(
+            @AuthenticationPrincipal Long userId
+    ) {
+        val result = userWithdrawFacade.requestWithdraw(userId);
         return ResponseEntity.ok(userResponseMapper.of(result));
     }
+
 }

--- a/src/main/java/org/sopt/app/presentation/user/UserWithdrawController.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserWithdrawController.java
@@ -5,17 +5,22 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.sopt.app.application.notification.PushTokenService;
 import org.sopt.app.application.user.UserWithdrawService;
 import org.sopt.app.domain.entity.PushToken;
 import org.sopt.app.domain.entity.User;
+import org.sopt.app.facade.UserWithdrawFacade;
 import org.sopt.app.presentation.notification.PushTokenRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,7 +29,9 @@ import jakarta.validation.Valid;
 public class UserWithdrawController {
 
     private final UserWithdrawService userWithdrawService;
+    private final UserWithdrawFacade userWithdrawFacade;
     private final PushTokenService pushTokenService;
+    private final UserResponseMapper userResponseMapper;
 
 
     @Operation(summary = "로그아웃하기")
@@ -55,5 +62,17 @@ public class UserWithdrawController {
     public ResponseEntity<Void> withdraw(@AuthenticationPrincipal User user) {
         userWithdrawService.withdrawUser(user.getId());
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "탈퇴 폼 주소 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "404", description = "not found", content = @Content),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping(value = "/withdraw/form")
+    public ResponseEntity<UserResponse.WithdrawFormResponse> getWithdrawForm() {
+        val result = userWithdrawFacade.getWithdrawForm();
+        return ResponseEntity.ok(userResponseMapper.of(result));
     }
 }

--- a/src/main/resources/database/create.sql
+++ b/src/main/resources/database/create.sql
@@ -200,3 +200,13 @@ create table app_dev.poke_message
     created_at timestamp default now(),
     updated_at timestamp default now()
 );
+
+---
+create table app_dev.user_withdraw_history
+(
+    id         serial
+        primary key,
+    user_id    bigint                  not null,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);

--- a/src/main/resources/database/create.sql
+++ b/src/main/resources/database/create.sql
@@ -201,12 +201,3 @@ create table app_dev.poke_message
     updated_at timestamp default now()
 );
 
----
-create table app_dev.user_withdraw_history
-(
-    id         serial
-        primary key,
-    user_id    bigint                  not null,
-    created_at timestamp default now() not null,
-    updated_at timestamp default now() not null
-);

--- a/src/test/java/org/sopt/app/application/user/UserWithdrawHistoryServiceTest.java
+++ b/src/test/java/org/sopt/app/application/user/UserWithdrawHistoryServiceTest.java
@@ -1,0 +1,40 @@
+package org.sopt.app.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.domain.entity.UserWithdrawHistory;
+import org.sopt.app.interfaces.postgres.UserWithdrawHistoryRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserWithdrawHistoryService 단위 테스트")
+class UserWithdrawHistoryServiceTest {
+
+    @Mock
+    private UserWithdrawHistoryRepository userWithdrawHistoryRepository;
+
+    @InjectMocks
+    private UserWithdrawHistoryService userWithdrawHistoryService;
+
+    @Test
+    @DisplayName("SUCCESS_탈퇴 요청 시 인증된 요청자의 ID로 탈퇴 이력이 저장된다")
+    void SUCCESS_recordWithdrawRequest_savesRequesterId() {
+        // given
+        final Long userId = 1L;
+        // when
+        userWithdrawHistoryService.recordWithdrawRequest(userId);
+
+        // then
+        ArgumentCaptor<UserWithdrawHistory> captor = ArgumentCaptor.forClass(UserWithdrawHistory.class);
+        verify(userWithdrawHistoryRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getUserId()).isEqualTo(userId);
+    }
+}

--- a/src/test/java/org/sopt/app/facade/UserWithdrawFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/UserWithdrawFacadeTest.java
@@ -1,11 +1,11 @@
 package org.sopt.app.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,9 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.app.application.appservice.OperationConfigService;
 import org.sopt.app.application.user.UserWithdrawInfo;
+import org.sopt.app.application.user.UserWithdrawHistoryService;
 import org.sopt.app.common.config.OperationConfigCategory;
-import org.sopt.app.common.exception.NotFoundException;
-import org.sopt.app.common.response.ErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserWithdrawFacade 단위 테스트")
@@ -25,39 +24,42 @@ class UserWithdrawFacadeTest {
     @Mock
     private OperationConfigService operationConfigService;
 
+    @Mock
+    private UserWithdrawHistoryService userWithdrawHistoryService;
+
     @InjectMocks
     private UserWithdrawFacade userWithdrawFacade;
 
     @Test
-    @DisplayName("SUCCESS_운영 설정에서 탈퇴 폼 URL을 조회한다")
-    void SUCCESS_getWithdrawForm() {
+    @DisplayName("SUCCESS_탈퇴 요청 시 요청을 기록하고 폼 URL을 반환한다")
+    void SUCCESS_requestWithdraw_recordsAndReturnsFormUrl() {
         // given
+        final Long userId = 1L;
         final String withdrawFormUrl = "https://example.com/withdraw-form";
-        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl"))
-            .thenReturn(withdrawFormUrl);
+        when(operationConfigService.findOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl"))
+            .thenReturn(Optional.of(withdrawFormUrl));
 
         // when
-        UserWithdrawInfo.WithdrawFormResult result = userWithdrawFacade.getWithdrawForm();
+        UserWithdrawInfo.WithdrawFormResult result = userWithdrawFacade.requestWithdraw(userId);
 
         // then
+        verify(userWithdrawHistoryService, times(1)).recordWithdrawRequest(userId);
         assertThat(result.getWithdrawFormUrl()).isEqualTo(withdrawFormUrl);
-        verify(operationConfigService, times(1))
-            .getOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl");
     }
 
     @Test
-    @DisplayName("FAIL_탈퇴 폼 운영 설정이 존재하지 않으면 NotFoundException이 전파된다")
-    void FAIL_getWithdrawForm_whenConfigNotFound() {
+    @DisplayName("SUCCESS_폼 설정이 없어도 요청은 기록되고 폼 URL은 비어(null) 반환된다")
+    void SUCCESS_requestWithdraw_recordsEvenWhenFormConfigMissing() {
         // given
-        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl"))
-            .thenThrow(new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        final Long userId = 1L;
+        when(operationConfigService.findOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl"))
+            .thenReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> userWithdrawFacade.getWithdrawForm())
-            .isInstanceOf(NotFoundException.class)
-            .satisfies(e -> {
-                NotFoundException exception = (NotFoundException) e;
-                assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
-            });
+        // when
+        UserWithdrawInfo.WithdrawFormResult result = userWithdrawFacade.requestWithdraw(userId);
+
+        // then
+        verify(userWithdrawHistoryService, times(1)).recordWithdrawRequest(userId);
+        assertThat(result.getWithdrawFormUrl()).isNull();
     }
 }

--- a/src/test/java/org/sopt/app/facade/UserWithdrawFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/UserWithdrawFacadeTest.java
@@ -1,0 +1,63 @@
+package org.sopt.app.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.application.appservice.OperationConfigService;
+import org.sopt.app.application.user.UserWithdrawInfo;
+import org.sopt.app.common.config.OperationConfigCategory;
+import org.sopt.app.common.exception.NotFoundException;
+import org.sopt.app.common.response.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserWithdrawFacade 단위 테스트")
+class UserWithdrawFacadeTest {
+
+    @Mock
+    private OperationConfigService operationConfigService;
+
+    @InjectMocks
+    private UserWithdrawFacade userWithdrawFacade;
+
+    @Test
+    @DisplayName("SUCCESS_운영 설정에서 탈퇴 폼 URL을 조회한다")
+    void SUCCESS_getWithdrawForm() {
+        // given
+        final String withdrawFormUrl = "https://example.com/withdraw-form";
+        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl"))
+            .thenReturn(withdrawFormUrl);
+
+        // when
+        UserWithdrawInfo.WithdrawFormResult result = userWithdrawFacade.getWithdrawForm();
+
+        // then
+        assertThat(result.getWithdrawFormUrl()).isEqualTo(withdrawFormUrl);
+        verify(operationConfigService, times(1))
+            .getOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl");
+    }
+
+    @Test
+    @DisplayName("FAIL_탈퇴 폼 운영 설정이 존재하지 않으면 NotFoundException이 전파된다")
+    void FAIL_getWithdrawForm_whenConfigNotFound() {
+        // given
+        when(operationConfigService.getOperationConfigValue(OperationConfigCategory.WITHDRAW_FORM, "linkUrl"))
+            .thenThrow(new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> userWithdrawFacade.getWithdrawForm())
+            .isInstanceOf(NotFoundException.class)
+            .satisfies(e -> {
+                NotFoundException exception = (NotFoundException) e;
+                assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+            });
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #804 

## Work Description ✏️

- 탈퇴 폼 조회 API 구현
  - 서버 통합 전 임의로 구글 폼을 통해 신청할 수 있도록 링크 구현
  - 탈퇴 신청 시 신청한 userId는 UserWithdrawHistory에 저장됨

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->