### PR TITLE
[Feat] #806: 앱잼 모드 여부 응답 추가 및 솝레터 온보딩 현재 기수 제공 

### DIFF
--- a/src/main/java/org/sopt/app/facade/UserFacade.java
+++ b/src/main/java/org/sopt/app/facade/UserFacade.java
@@ -23,12 +23,16 @@ import org.sopt.app.domain.enums.UserStatus;
 import org.sopt.app.presentation.user.UserResponse;
 import org.sopt.app.presentation.user.UserResponse.*;
 import org.sopt.app.presentation.user.UserResponseMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserFacade {
+
+    @Value("${makers.app.soptamp.appjam-mode:false}")
+    private boolean appjamMode;
 
     private final PlaygroundAuthService playgroundAuthService;
     private final NotificationService notificationService;
@@ -106,6 +110,7 @@ public class UserFacade {
 
             if (isActive) {
                 return UserResponse.MySoptLog.ofActive(
+                    appjamMode,
                     isAppjamParticipant,
                     isFortuneChecked,
                     todayFortuneText,
@@ -121,6 +126,7 @@ public class UserFacade {
             }
 
             return UserResponse.MySoptLog.ofInactiveAppjamParticipant(
+                appjamMode,
                 isFortuneChecked,
                 todayFortuneText,
                 soptampCount,
@@ -135,6 +141,7 @@ public class UserFacade {
         }
 
         return UserResponse.MySoptLog.ofInactiveNonAppjam(
+            appjamMode,
             isFortuneChecked,
             todayFortuneText,
             totalPokeCount,

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -11,6 +11,7 @@ import lombok.val;
 import org.sopt.app.facade.SoptLetterFacade;
 import org.sopt.app.presentation.soptletter.dto.SoptLetterRequest;
 import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,6 +33,9 @@ public class SoptLetterController {
     private final SoptLetterFacade soptLetterFacade;
     private final SoptLetterResponseMapper soptLetterResponseMapper;
 
+    @Value("${sopt.current.generation}")
+    private Long currentGeneration;
+
     @Operation(summary = "솝레터 온보딩 프로필 조회 (존재하지 않을 경우 생성)")
     @GetMapping("/onboarding")
     @ApiResponses(value = {
@@ -43,7 +47,7 @@ public class SoptLetterController {
         @AuthenticationPrincipal Long userId
     ) {
         val result = soptLetterFacade.getOrCreateOnboardingProfile(userId);
-        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result, currentGeneration));
     }
 
     @Operation(summary = "솝레터 온보딩 완료 처리")
@@ -57,7 +61,7 @@ public class SoptLetterController {
         @AuthenticationPrincipal Long userId
     ) {
         val result = soptLetterFacade.completeOnboardingProfile(userId);
-        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result, currentGeneration));
     }
 
     @Operation(summary = "솝레터 익명 신고 폼 주소 조회")

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
@@ -14,8 +14,8 @@ import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse;
 )
 public interface SoptLetterResponseMapper {
 
-    @Mapping(source = "onboarded", target = "isOnboarded")
-    SoptLetterResponse.OnboardingProfileResponse of(SoptLetterInfo.Profile info);
+    @Mapping(source = "info.onboarded", target = "isOnboarded")
+    SoptLetterResponse.OnboardingProfileResponse of(SoptLetterInfo.Profile info, Long currentGeneration);
 
     SoptLetterResponse.TopicMessagesResponse of(SoptLetterInfo.TopicMessageListResult result);
 

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -14,7 +14,9 @@ public class SoptLetterResponse {
         @Schema(description = "닉네임", example = "익명의 달달한 간장게장")
         String nickname,
         @Schema(description = "온보딩 완료 여부", example = "false")
-        boolean isOnboarded
+        boolean isOnboarded,
+        @Schema(description = "현재 솝트 기수", example = "37")
+        Long currentGeneration
     ) {
     }
 

--- a/src/main/java/org/sopt/app/presentation/user/UserResponse.java
+++ b/src/main/java/org/sopt/app/presentation/user/UserResponse.java
@@ -211,6 +211,9 @@ public class UserResponse {
     @JsonInclude(Include.NON_NULL)
     public record MySoptLog(
 
+        @Schema(description = "앱잼 모드(시즌) 여부 - 전역 플래그")
+        boolean isAppjamMode,
+
         @Schema(description = "활동 기수 여부")
         boolean isActive,
 
@@ -249,6 +252,7 @@ public class UserResponse {
     ) {
 
         public static MySoptLog ofInactiveNonAppjam(
+            boolean isAppjamMode,
             boolean isFortuneChecked,
             String todayFortuneText,
             int totalPokeCount,
@@ -257,6 +261,7 @@ public class UserResponse {
             int soulmatesPokeCount
         ) {
             return new MySoptLog(
+                isAppjamMode,
                 false,
                 false,
                 isFortuneChecked,
@@ -273,6 +278,7 @@ public class UserResponse {
         }
 
         public static MySoptLog ofInactiveAppjamParticipant(
+            boolean isAppjamMode,
             boolean isFortuneChecked,
             String todayFortuneText,
             int soptampCount,
@@ -285,6 +291,7 @@ public class UserResponse {
             int soulmatesPokeCount
         ) {
             return new MySoptLog(
+                isAppjamMode,
                 false,
                 true,
                 isFortuneChecked,
@@ -301,6 +308,7 @@ public class UserResponse {
         }
 
         public static MySoptLog ofActive(
+            boolean isAppjamMode,
             boolean isAppjamParticipant,
             boolean isFortuneChecked,
             String todayFortuneText,
@@ -314,6 +322,7 @@ public class UserResponse {
             int soulmatesPokeCount
         ) {
             return new MySoptLog(
+                isAppjamMode,
                 true,
                 isAppjamParticipant,
                 isFortuneChecked,

--- a/src/test/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapperTest.java
+++ b/src/test/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapperTest.java
@@ -1,0 +1,28 @@
+package org.sopt.app.presentation.soptletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.app.application.soptletter.SoptLetterInfo;
+import org.sopt.app.presentation.soptletter.dto.SoptLetterResponse;
+
+class SoptLetterResponseMapperTest {
+
+    private final SoptLetterResponseMapper mapper = new SoptLetterResponseMapperImpl();
+
+    @Test
+    @DisplayName("온보딩 프로필 매핑 시 currentGeneration이 파라미터로 주입되고 나머지는 info에서 매핑된다")
+    void of_mapsCurrentGeneration() {
+        SoptLetterInfo.Profile profile = SoptLetterInfo.Profile.builder()
+            .nickname("익명의 고래")
+            .isOnboarded(true)
+            .build();
+
+        SoptLetterResponse.OnboardingProfileResponse response = mapper.of(profile, 37L);
+
+        assertThat(response.nickname()).isEqualTo("익명의 고래");
+        assertThat(response.isOnboarded()).isTrue();
+        assertThat(response.currentGeneration()).isEqualTo(37L);
+    }
+}

--- a/src/test/java/org/sopt/app/presentation/user/MySoptLogTest.java
+++ b/src/test/java/org/sopt/app/presentation/user/MySoptLogTest.java
@@ -1,0 +1,55 @@
+package org.sopt.app.presentation.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MySoptLogTest {
+
+    @Test
+    @DisplayName("ofActive는 전달된 isAppjamMode를 그대로 반영한다")
+    void ofActive_reflectsIsAppjamMode() {
+        UserResponse.MySoptLog log = UserResponse.MySoptLog.ofActive(
+            true,   // isAppjamMode
+            false,  // isAppjamParticipant
+            true,   // isFortuneChecked
+            "오늘의 운세",
+            1, 2, 3, 4, 5, 6, 7, 8
+        );
+
+        assertTrue(log.isAppjamMode());
+        assertTrue(log.isActive());
+        assertFalse(log.isAppjamParticipant());
+    }
+
+    @Test
+    @DisplayName("ofInactiveNonAppjam은 isAppjamMode만 반영하고 isActive/isAppjamParticipant는 false다")
+    void ofInactiveNonAppjam_reflectsIsAppjamMode() {
+        UserResponse.MySoptLog log = UserResponse.MySoptLog.ofInactiveNonAppjam(
+            true,   // isAppjamMode
+            false,  // isFortuneChecked
+            "text",
+            10, 11, 12, 13
+        );
+
+        assertTrue(log.isAppjamMode());
+        assertFalse(log.isActive());
+        assertFalse(log.isAppjamParticipant());
+    }
+
+    @Test
+    @DisplayName("record 직렬화 시 JSON 키에 is 접두어가 그대로 유지된다 (isAppjamMode)")
+    void serialization_keepsIsPrefix() {
+        UserResponse.MySoptLog log = UserResponse.MySoptLog.ofActive(
+            true, false, true, "오늘의 운세", 1, 2, 3, 4, 5, 6, 7, 8);
+
+        JsonNode json = new ObjectMapper().valueToTree(log);
+
+        assertTrue(json.has("isAppjamMode"));   // record는 컴포넌트명 그대로 → is 유지
+        assertFalse(json.has("appjamMode"));    // is 벗겨진 형태는 없음
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #806

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 마이솝트로그 응답에 앱잼 모드 여부(isAppjamMode) 추가
- 솝레터 온보딩 응답에 현재 기수(currentGeneration) 추가

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- /app-service에 앱잼 모드를 이번에 넣지 않은 이유                                                                                                                               
    - 현재 app-service에 전역 isAppjamMode를 넣으려면
        - 배열→객체 wrapping = 구버전 API가 영향을 받음, 
        - 또는 (b) 아이템마다 중복 필드로서 생성됨     
    - 또한 탭바 분리 작업이 예정되어 있어 해당 API에서 구조를 다시 잡는게 낫다고 판단함