### PR TITLE
[Feat] #809: 솝레터 이모지 글자 수 제한 적용

### DIFF
--- a/src/main/java/org/sopt/app/common/validation/GraphemeSize.java
+++ b/src/main/java/org/sopt/app/common/validation/GraphemeSize.java
@@ -1,0 +1,71 @@
+package org.sopt.app.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintDeclarationException;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.text.BreakIterator;
+import java.util.Locale;
+
+@Documented
+@Constraint(validatedBy = GraphemeSize.Validator.class)
+@Target({
+    ElementType.METHOD,
+    ElementType.FIELD,
+    ElementType.ANNOTATION_TYPE,
+    ElementType.CONSTRUCTOR,
+    ElementType.PARAMETER,
+    ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphemeSize {
+
+    String message() default "글자 수가 허용 범위를 벗어났습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    int min() default 0;
+
+    int max() default Integer.MAX_VALUE;
+
+    class Validator implements ConstraintValidator<GraphemeSize, String> {
+
+        private int min;
+        private int max;
+
+        @Override
+        public void initialize(GraphemeSize constraintAnnotation) {
+            this.min = constraintAnnotation.min();
+            this.max = constraintAnnotation.max();
+            if (min < 0 || max < min) {
+                throw new ConstraintDeclarationException("min은 0 이상이고 max 이하여야 합니다.");
+            }
+        }
+
+        @Override
+        public boolean isValid(String value, ConstraintValidatorContext context) {
+            if (value == null) {
+                return true;
+            }
+
+            BreakIterator iterator = BreakIterator.getCharacterInstance(Locale.ROOT);
+            iterator.setText(value);
+
+            int graphemeCount = 0;
+            while (iterator.next() != BreakIterator.DONE) {
+                if (++graphemeCount > max) {
+                    return false;
+                }
+            }
+            return graphemeCount >= min;
+        }
+    }
+}

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetter.java
@@ -38,7 +38,7 @@ public class SoptLetter extends BaseEntity {
     @Column(nullable = false)
     private Double degree;
 
-    @Column(length = 350, nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String message;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequest.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequest.java
@@ -1,11 +1,11 @@
 package org.sopt.app.presentation.soptletter.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.sopt.app.common.validation.GraphemeSize;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SoptLetterRequest {
@@ -14,7 +14,7 @@ public class SoptLetterRequest {
     @ToString
     public static class WriteMessageRequest {
         @NotBlank(message = "메시지 내용은 필수입니다.")
-        @Size(min = 1, max = 350, message = "메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다.")
+        @GraphemeSize(max = 350, message = "메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다.")
         private String content;
     }
 
@@ -22,7 +22,7 @@ public class SoptLetterRequest {
     @ToString
     public static class UpdateMessageRequest {
         @NotBlank(message = "메시지 내용은 필수입니다.")
-        @Size(min = 1, max = 350, message = "메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다.")
+        @GraphemeSize(max = 350, message = "메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다.")
         private String content;
     }
 }

--- a/src/test/java/org/sopt/app/common/validation/GraphemeSizeTest.java
+++ b/src/test/java/org/sopt/app/common/validation/GraphemeSizeTest.java
@@ -1,0 +1,27 @@
+package org.sopt.app.common.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GraphemeSizeTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    @DisplayName("확장 grapheme cluster를 기준으로 설정한 최소, 최대 글자 수를 검증한다")
+    void validateGraphemeSize() {
+        assertThat(validator.validate(new TestValue("👨‍👩‍👧‍👦"))).isNotEmpty();
+        assertThat(validator.validate(new TestValue("👨‍👩‍👧‍👦👍🏽"))).isEmpty();
+        assertThat(validator.validate(new TestValue("👨‍👩‍👧‍👦👍🏽🇰🇷"))).isNotEmpty();
+    }
+
+    private record TestValue(
+        @GraphemeSize(min = 2, max = 2)
+        String value
+    ) {
+    }
+}

--- a/src/test/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequestTest.java
+++ b/src/test/java/org/sopt/app/presentation/soptletter/dto/SoptLetterRequestTest.java
@@ -1,0 +1,54 @@
+package org.sopt.app.presentation.soptletter.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SoptLetterRequestTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"😀", "👨‍👩‍👧‍👦", "👍🏽", "🇰🇷", "é"})
+    @DisplayName("작성과 수정 요청에서 확장 grapheme cluster는 화면상 한 글자로 계산한다")
+    void SUCCESS_validateGraphemeLength(String grapheme) {
+        var requests = createRequestsWithContent(grapheme.repeat(350));
+
+        assertThat(requests).allSatisfy(request -> assertThat(validator.validate(request)).isEmpty());
+    }
+
+    @Test
+    @DisplayName("작성과 수정 요청에서 화면상 글자 수가 350자를 초과하면 검증에 실패한다")
+    void FAIL_validateCombinedEmojiLength_exceedsLimit() {
+        var requests = createRequestsWithContent("👨‍👩‍👧‍👦".repeat(351));
+
+        assertThat(requests).allSatisfy(request -> assertThat(validator.validate(request))
+            .extracting(violation -> violation.getMessage())
+            .containsExactly("메시지는 공백을 포함하여 1자 이상 350자 이하로 작성해야 합니다."));
+    }
+
+    @Test
+    @DisplayName("작성과 수정 요청에서 공백만 입력하면 필수값 검증에 실패한다")
+    void FAIL_validateContent_blank() {
+        var requests = createRequestsWithContent(" ");
+
+        assertThat(requests).allSatisfy(request -> assertThat(validator.validate(request))
+            .extracting(violation -> violation.getMessage())
+            .containsExactly("메시지 내용은 필수입니다."));
+    }
+
+    private List<Object> createRequestsWithContent(String content) {
+        var writeRequest = new SoptLetterRequest.WriteMessageRequest();
+        var updateRequest = new SoptLetterRequest.UpdateMessageRequest();
+        ReflectionTestUtils.setField(writeRequest, "content", content);
+        ReflectionTestUtils.setField(updateRequest, "content", content);
+        return List.of(writeRequest, updateRequest);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closes #809

## Work Description ✏️

- 확장 grapheme cluster 기준 글자 수 검증 어노테이션 구현
- 솝레터 메시지 작성/수정 요청에 화면상 글자 수 350자 제한 적용
- 조합형 이모지 저장을 위해 메시지 컬럼 타입을 TEXT로 변경
- 일반 이모지, 가족 이모지, 피부색 조합, 국기, 결합문자 경계값 테스트 추가

## Related ScreenShot 📷

N/A

## To Reviewers 📢

- 기존 `@Size`는 Java의 UTF-16 코드 유닛을 기준으로 문자열 길이를 계산하기 때문에 일반 이모지도 2자로 계산됩니다. 이로 인해 앱에서는 350자로 판단한 메시지가 서버에서는 제한을 초과하는 문제가 있었습니다.
- 단순히 code point 기준으로 변경하는 방법도 검토했지만, 가족 이모지나 피부색이 결합된 이모지처럼 여러 code point가 하나의 문자로 보이는 경우에는 여전히 앱의 글자 수와 달라질 수 있었습니다. 현재 프로젝트와 배포 환경이 모두 Java 21을 사용하고 있어, 사용자에게 보이는 문자 단위인 확장 grapheme cluster를 지원하는 `BreakIterator`를 사용했습니다.

- 동일한 글자 수 정책이 다른 기능에도 필요할 수 있다고 생각해 솝레터에 종속된 검증 대신 `min`, `max`를 전달할 수 있는 `@GraphemeSize`로 분리했습니다.
- 조합형 이모지는 화면상 한 글자여도 DB 기준으로는 여러 문자로 구성될 수 있어, 350개의 grapheme을 온전히 저장하려면 기존 `VARCHAR(350)`으로는 부족해 `message` 컬럼 매핑을 `TEXT`로 변경했습니다.