### PR TITLE
[Feat] #807: App Service 탭바 API 분리, 앱잼 모드 여부 응답 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/appservice/AppServiceService.java
+++ b/src/main/java/org/sopt/app/application/appservice/AppServiceService.java
@@ -2,6 +2,7 @@ package org.sopt.app.application.appservice;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.app.application.appservice.dto.AppServiceInfo;
 import org.sopt.app.domain.entity.AppService;
@@ -13,7 +14,25 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AppServiceService {
 
+    private static final Set<AppServiceName> HOME_APP_SERVICES = Set.of(
+        AppServiceName.SOPT_LETTER
+    );
+    private static final Set<AppServiceName> TAB_APP_SERVICES = Set.of(
+        AppServiceName.POKE,
+        AppServiceName.SOPTAMP
+    );
+
     private final AppServiceRepository appServiceRepository;
+
+    @Transactional(readOnly = true)
+    public List<AppServiceInfo> getHomeAppServices() {
+        return getAppServices(HOME_APP_SERVICES);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AppServiceInfo> getTabAppServices() {
+        return getAppServices(TAB_APP_SERVICES);
+    }
 
     @Transactional(readOnly = true)
     public List<AppServiceInfo> getAllAppService() {
@@ -34,5 +53,11 @@ public class AppServiceService {
     @Transactional(readOnly = true)
     public AppServiceInfo getAppService(String serviceName) {
         return AppServiceInfo.of(appServiceRepository.findByServiceName(serviceName));
+    }
+
+    private List<AppServiceInfo> getAppServices(Set<AppServiceName> appServiceNames) {
+        return getAllAppService().stream()
+            .filter(appService -> appServiceNames.contains(AppServiceName.of(appService.getServiceName())))
+            .toList();
     }
 }

--- a/src/main/java/org/sopt/app/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/org/sopt/app/common/security/config/WebSecurityConfig.java
@@ -45,6 +45,7 @@ public class WebSecurityConfig {
             "/internal/api/v1/members",
             "/internal/api/v1/members/{memberId}",
             "/api/v2/home/app-service",
+            "/api/v2/home/tab-app-service",
             "/api/v2/home/floating-button",
             "/api/v2/home/review-form",
             "/api/v2/admin/notification/**",

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -32,14 +32,19 @@ import org.sopt.app.common.utils.ActivityDurationCalculator;
 import org.sopt.app.domain.enums.UserStatus;
 import org.sopt.app.presentation.home.MeetingParamRequest;
 import org.sopt.app.presentation.home.response.FloatingButtonResponse;
+import org.sopt.app.presentation.home.response.HomeAppServiceResponse;
 import org.sopt.app.presentation.home.response.HomeDescriptionResponse;
 import org.sopt.app.presentation.home.response.ReviewFormResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class HomeFacade {
+
+    @Value("${makers.app.soptamp.appjam-mode:false}")
+    private boolean appjamMode;
 
     private final DescriptionService descriptionService;
     private final PlaygroundPostCacheService playgroundPostCacheService;
@@ -68,8 +73,12 @@ public class HomeFacade {
         );
     }
 
-    public List<AppServiceEntryStatusResponse> checkHomeAppServiceEntryStatus(Long userId) {
-        return checkAppServiceEntryStatus(appServiceService.getHomeAppServices(), userId);
+    public HomeAppServiceResponse getHomeAppServices(Long userId) {
+        List<AppServiceEntryStatusResponse> appServices = checkAppServiceEntryStatus(
+            appServiceService.getHomeAppServices(),
+            userId
+        );
+        return HomeAppServiceResponse.of(appjamMode, appServices);
     }
 
     public List<AppServiceEntryStatusResponse> checkTabAppServiceEntryStatus(Long userId) {

--- a/src/main/java/org/sopt/app/facade/HomeFacade.java
+++ b/src/main/java/org/sopt/app/facade/HomeFacade.java
@@ -68,14 +68,25 @@ public class HomeFacade {
         );
     }
 
-    public List<AppServiceEntryStatusResponse> checkAppServiceEntryStatus(Long userId) {
+    public List<AppServiceEntryStatusResponse> checkHomeAppServiceEntryStatus(Long userId) {
+        return checkAppServiceEntryStatus(appServiceService.getHomeAppServices(), userId);
+    }
+
+    public List<AppServiceEntryStatusResponse> checkTabAppServiceEntryStatus(Long userId) {
+        return checkAppServiceEntryStatus(appServiceService.getTabAppServices(), userId);
+    }
+
+    private List<AppServiceEntryStatusResponse> checkAppServiceEntryStatus(
+        List<AppServiceInfo> appServices,
+        Long userId
+    ) {
         if(userId == null){
-            return this.getOnlyAppServiceInfo();
+            return this.getOnlyAppServiceInfo(appServices);
         }
         PlatformUserInfoResponse platformUserInfo = platformService.getPlatformUserInfoResponse(userId);
         UserStatus status = platformService.getStatus(platformUserInfo);
 
-        List<CompletableFuture<AppServiceEntryStatusResponse>> futures = appServiceService.getAllAppService().stream()
+        List<CompletableFuture<AppServiceEntryStatusResponse>> futures = appServices.stream()
             .filter(appServiceInfo -> isServiceVisibleToUser(appServiceInfo, status))
             .map(appServiceInfo -> appServiceBadgeService.getAppServiceEntryStatusResponseAsync(appServiceInfo, userId))
             .toList();
@@ -85,8 +96,8 @@ public class HomeFacade {
             .toList();
     }
 
-    private List<AppServiceEntryStatusResponse> getOnlyAppServiceInfo() {
-        return appServiceService.getAllAppService().stream()
+    private List<AppServiceEntryStatusResponse> getOnlyAppServiceInfo(List<AppServiceInfo> appServices) {
+        return appServices.stream()
                 .map(AppServiceEntryStatusResponse::createOnlyAppServiceInfo)
                 .toList();
     }

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -39,18 +39,33 @@ public class HomeController {
         );
     }
 
-    @Operation(summary = "앱 서비스 진입 여부 조회")
+    @Operation(summary = "홈 앱 서비스 목록 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "success"),
             @ApiResponse(responseCode = "401", description = "token error", content = @Content),
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
     @GetMapping("/app-service")
-    public ResponseEntity<List<AppServiceEntryStatusResponse>> getAppService(
+    public ResponseEntity<List<AppServiceEntryStatusResponse>> getHomeAppService(
             @AuthenticationPrincipal Long userId
     ) {
         return ResponseEntity.ok(
-                homeFacade.checkAppServiceEntryStatus(userId)
+                homeFacade.checkHomeAppServiceEntryStatus(userId)
+        );
+    }
+
+    @Operation(summary = "탭바 앱 서비스 목록 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "success"),
+            @ApiResponse(responseCode = "401", description = "token error", content = @Content),
+            @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    @GetMapping("/tab-app-service")
+    public ResponseEntity<List<AppServiceEntryStatusResponse>> getTabAppService(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(
+                homeFacade.checkTabAppServiceEntryStatus(userId)
         );
     }
     

--- a/src/main/java/org/sopt/app/presentation/home/HomeController.java
+++ b/src/main/java/org/sopt/app/presentation/home/HomeController.java
@@ -46,11 +46,11 @@ public class HomeController {
             @ApiResponse(responseCode = "500", description = "server error", content = @Content)
     })
     @GetMapping("/app-service")
-    public ResponseEntity<List<AppServiceEntryStatusResponse>> getHomeAppService(
+    public ResponseEntity<HomeAppServiceResponse> getHomeAppService(
             @AuthenticationPrincipal Long userId
     ) {
         return ResponseEntity.ok(
-                homeFacade.checkHomeAppServiceEntryStatus(userId)
+                homeFacade.getHomeAppServices(userId)
         );
     }
 

--- a/src/main/java/org/sopt/app/presentation/home/response/HomeAppServiceResponse.java
+++ b/src/main/java/org/sopt/app/presentation/home/response/HomeAppServiceResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.app.presentation.home.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.app.application.appservice.dto.AppServiceEntryStatusResponse;
+
+@Schema(description = "홈 앱 서비스 목록 응답")
+public record HomeAppServiceResponse(
+    @Schema(description = "앱잼 모드 여부", example = "true")
+    boolean isAppjamMode,
+
+    @Schema(description = "홈 앱 서비스 목록")
+    List<AppServiceEntryStatusResponse> appServices
+) {
+
+    public static HomeAppServiceResponse of(
+        boolean isAppjamMode,
+        List<AppServiceEntryStatusResponse> appServices
+    ) {
+        return new HomeAppServiceResponse(isAppjamMode, appServices);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

closes #807

## Work Description ✏️

기존 `GET /api/v2/home/app-service`가 홈 영역에서 사용하는 `SOPT_LETTER`만 반환하도록 분리했습니다.

홈 진입 시 앱잼 모드 여부를 함께 확인할 수 있도록 응답에 `isAppjamMode`를 추가하고, `appServices`와 함께 반환하도록 구성했습니다.

탭바에서 사용하는 `POKE`, `SOPTAMP`를 조회할 수 있도록 `GET /api/v2/home/tab-app-service`를 추가했습니다.

회원 상태별 노출 조건, 비회원 처리, 서비스별 배지 계산 로직은 공통으로 유지했습니다.

## Related ScreenShot 📷

N/A

## To Reviewers 📢

N/A