### PR TITLE
[Feat] #812: 솝레터 CTA 조회 구현

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
@@ -53,6 +53,31 @@ public class SoptLetterInfo {
     @Builder
     @ToString
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CtaResult {
+
+        private boolean showCta;
+        private Long topicId;
+        private String ctaText;
+
+        public static CtaResult from(SoptLetterTopic topic) {
+            return CtaResult.builder()
+                .showCta(true)
+                .topicId(topic.getId())
+                .ctaText(topic.getCtaText())
+                .build();
+        }
+
+        public static CtaResult hidden() {
+            return CtaResult.builder()
+                .showCta(false)
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class TopicMessageListResult {
         private Long topicId;
         private String title;

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.sopt.app.application.appservice.OperationConfigService;
+import org.sopt.app.application.soptletter.SoptLetterInfo.CtaResult;
 import org.sopt.app.application.soptletter.SoptLetterInfo.Profile;
 import org.sopt.app.application.soptletter.SoptLetterInfo.TopicMessageListResult;
 import org.sopt.app.application.soptletter.SoptLetterInfo.TopicMessageSummary;
@@ -143,6 +144,16 @@ public class SoptLetterService {
     public SoptLetterInfo.TopicListResult getTopics(String type) {
         val topics = getTopicsByType(type);
         return SoptLetterInfo.TopicListResult.from(topics);
+    }
+
+    @Transactional(readOnly = true)
+    public CtaResult getCta() {
+        val now = LocalDateTime.now(clock);
+        val activeCtas = soptLetterTopicRepository.findActiveCtas(now);
+        if (activeCtas.isEmpty()) {
+            return CtaResult.hidden();
+        }
+        return CtaResult.from(activeCtas.get(0));
     }
 
     private List<SoptLetterTopic> getTopicsByType(String type) {

--- a/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
+++ b/src/main/java/org/sopt/app/domain/entity/soptletter/SoptLetterTopic.java
@@ -23,6 +23,9 @@ public class SoptLetterTopic extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
+    @Column(length = 50)
+    private String ctaText;
+
     @Column(nullable = false)
     private boolean isDefault;
 

--- a/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
+++ b/src/main/java/org/sopt/app/facade/SoptLetterFacade.java
@@ -36,6 +36,10 @@ public class SoptLetterFacade {
         return soptLetterService.getTopics(type);
     }
 
+    public SoptLetterInfo.CtaResult getCta() {
+        return soptLetterService.getCta();
+    }
+
     public SoptLetterInfo.TopicDetail getTopic(Long topicId) {
         return soptLetterService.getTopic(topicId);
     }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
@@ -1,9 +1,11 @@
 package org.sopt.app.interfaces.postgres.soptletter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.sopt.app.domain.entity.soptletter.SoptLetterTopic;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic, Long> {
 
@@ -14,4 +16,14 @@ public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic
 
     @Query("SELECT t FROM SoptLetterTopic t WHERE t.isDefault = false ORDER BY t.createdAt DESC")
     List<SoptLetterTopic> findAllNormalTopicsOrderByCreatedAtDesc();
+
+    @Query("""
+        SELECT t FROM SoptLetterTopic t
+        WHERE t.isDefault = false
+            AND t.ctaText IS NOT NULL
+            AND t.startedAt <= :now
+            AND t.endedAt >= :now
+        ORDER BY t.startedAt DESC, t.id DESC
+        """)
+    List<SoptLetterTopic> findActiveCtas(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
@@ -19,8 +19,7 @@ public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic
 
     @Query("""
         SELECT t FROM SoptLetterTopic t
-        WHERE t.isDefault = false
-            AND t.ctaText IS NOT NULL
+        WHERE t.ctaText IS NOT NULL
             AND t.startedAt <= :now
             AND t.endedAt >= :now
         ORDER BY t.startedAt DESC, t.id DESC

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterController.java
@@ -77,6 +77,18 @@ public class SoptLetterController {
         return ResponseEntity.ok(soptLetterResponseMapper.of(result));
     }
 
+    @Operation(summary = "솝레터 메인 CTA 조회")
+    @GetMapping("/cta")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "success"),
+        @ApiResponse(responseCode = "403", description = "forbidden", content = @Content),
+        @ApiResponse(responseCode = "500", description = "server error", content = @Content)
+    })
+    public ResponseEntity<SoptLetterResponse.CtaResponse> getCta() {
+        val result = soptLetterFacade.getCta();
+        return ResponseEntity.ok(soptLetterResponseMapper.of(result));
+    }
+
     @Operation(summary = "솝레터 주제 목록 조회")
     @GetMapping("/topics")
     @ApiResponses(value = {

--- a/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/SoptLetterResponseMapper.java
@@ -23,6 +23,8 @@ public interface SoptLetterResponseMapper {
 
     SoptLetterResponse.ReportFormResponse of(SoptLetterInfo.ReportFormResult info);
 
+    SoptLetterResponse.CtaResponse of(SoptLetterInfo.CtaResult result);
+
     SoptLetterResponse.TopicsResponse of(SoptLetterInfo.TopicListResult result);
 
     @Mapping(source = "default", target = "isDefault")

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -27,6 +27,17 @@ public class SoptLetterResponse {
     ) {
     }
 
+    @Schema(description = "솝레터 메인 CTA 조회 응답")
+    public record CtaResponse(
+        @Schema(description = "CTA 노출 여부", example = "true")
+        boolean showCta,
+        @Schema(description = "연결될 주제 ID", example = "3", nullable = true)
+        Long topicId,
+        @Schema(description = "CTA 문구", example = "이번 앱잼 회고하러 가볼까요?", nullable = true)
+        String ctaText
+    ) {
+    }
+
     @Schema(description = "솝레터 주제 목록 조회 응답")
     public record TopicsResponse(
         @Schema(description = "주제 목록")

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -269,6 +269,44 @@ class SoptLetterServiceTest {
     }
 
     @Test
+    @DisplayName("SUCCESS_현재 노출 기간인 최신 솝레터 CTA를 조회한다")
+    void SUCCESS_getCta() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 7, 25, 12, 0);
+        SoptLetterTopic topic = mock(SoptLetterTopic.class);
+        when(topic.getId()).thenReturn(3L);
+        when(topic.getCtaText()).thenReturn("38기 SOPT 활동 어떠셨나요? 👀");
+        when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
+        when(soptLetterTopicRepository.findActiveCtas(now)).thenReturn(List.of(topic));
+
+        // when
+        SoptLetterInfo.CtaResult result = soptLetterService.getCta();
+
+        // then
+        assertThat(result.isShowCta()).isTrue();
+        assertThat(result.getTopicId()).isEqualTo(3L);
+        assertThat(result.getCtaText()).isEqualTo("38기 SOPT 활동 어떠셨나요? 👀");
+        verify(soptLetterTopicRepository, times(1)).findActiveCtas(now);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_현재 노출할 솝레터 CTA가 없으면 미노출 응답을 반환한다")
+    void SUCCESS_getCta_hidden() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 8, 8, 0, 0);
+        when(clock.instant()).thenReturn(now.atZone(ZoneId.systemDefault()).toInstant());
+        when(soptLetterTopicRepository.findActiveCtas(now)).thenReturn(List.of());
+
+        // when
+        SoptLetterInfo.CtaResult result = soptLetterService.getCta();
+
+        // then
+        assertThat(result.isShowCta()).isFalse();
+        assertThat(result.getTopicId()).isNull();
+        assertThat(result.getCtaText()).isNull();
+    }
+
+    @Test
     @DisplayName("SUCCESS_솝레터 주제 목록을 최신순으로 조회한다")
     void SUCCESS_getTopics() {
         // given

--- a/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
+++ b/src/test/java/org/sopt/app/facade/SoptLetterFacadeTest.java
@@ -157,6 +157,27 @@ class SoptLetterFacadeTest {
     }
 
     @Test
+    @DisplayName("SUCCESS_솝레터 CTA 조회 파사드가 서비스 메서드를 정상 호출하고 반환한다")
+    void SUCCESS_getCta() {
+        // given
+        SoptLetterInfo.CtaResult expected = SoptLetterInfo.CtaResult.builder()
+            .showCta(true)
+            .topicId(3L)
+            .ctaText("이번 앱잼 회고하러 가볼까요?")
+            .build();
+        when(soptLetterService.getCta()).thenReturn(expected);
+
+        // when
+        SoptLetterInfo.CtaResult result = soptLetterFacade.getCta();
+
+        // then
+        assertThat(result.isShowCta()).isTrue();
+        assertThat(result.getTopicId()).isEqualTo(3L);
+        assertThat(result.getCtaText()).isEqualTo("이번 앱잼 회고하러 가볼까요?");
+        verify(soptLetterService, times(1)).getCta();
+    }
+
+    @Test
     @DisplayName("SUCCESS_솝레터 주제 단일 조회 파사드가 서비스 메서드를 정상 호출하고 반환한다")
     void SUCCESS_getTopic() {
         // given


### PR DESCRIPTION
## Related issue 🛠

- closes #812

## Work Description ✏️

- 솝레터 메인 CTA 조회 API 구현
- 주제별 CTA 문구 저장을 위한 `ctaText` 필드 추가
- 주제 노출 기간을 기준으로 현재 활성 CTA 조회
- CTA 노출/미노출 서비스 및 파사드 테스트 추가

## Related ScreenShot 📷

N/A

## To Reviewers 📢

- 기존 기능 명세에서 주제 CTA는 주제 생성 시 정한 기간 동안 메인 화면에 노출되는 것으로 정의돼 있어, 별도 on/off 값을 추가하지 않고 `startedAt`, `endedAt`을 기준으로 서버에서 노출 여부를 판단하도록 구현했습니다. 기간과 노출 여부를 각각 관리할 경우 두 값이 서로 어긋날 수 있어 기간을 단일 기준으로 사용하는 편이 관리하기 명확하다고 판단했습니다.

- 주제 목록에서 사용하는 제목과 메인 화면의 CTA 문구가 서로 다르기 때문에 `SoptLetterTopic`에 nullable `ctaText`를 추가했습니다. 기본 주제 여부와 관계없이 `ctaText`가 존재하고 현재 시각이 노출 기간에 포함되는 주제를 CTA 조회 대상으로 사용합니다. 이전 CTA가 종료되기 전에 다음 CTA가 시작되는 경우를 고려해 활성 주제가 여러 개라면 `startedAt`이 가장 최근인 CTA를 반환하며, 시작 시각이 같은 경우에는 최신 ID를 우선합니다. 현재 활성 CTA가 없으면 `showCta=false`, `topicId`와 `ctaText`는 null로 반환합니다.