### PR TITLE
[Feat] #814: 개별 주제 존재 여부 반환 추가

### DIFF
--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterInfo.java
@@ -84,6 +84,7 @@ public class SoptLetterInfo {
         private Integer totalCount;
         private Long nextCursor;
         private Boolean hasNext;
+        private Boolean hasNormalTopic;
         private List<TopicMessageSummary> messages;
 
         public static TopicMessageListResult of(
@@ -91,6 +92,7 @@ public class SoptLetterInfo {
             Integer totalCount,
             Long nextCursor,
             Boolean hasNext,
+            Boolean hasNormalTopic,
             List<TopicMessageSummary> messages
         ) {
             return TopicMessageListResult.builder()
@@ -99,6 +101,7 @@ public class SoptLetterInfo {
                 .totalCount(totalCount)
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
+                .hasNormalTopic(hasNormalTopic)
                 .messages(messages)
                 .build();
         }

--- a/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
+++ b/src/main/java/org/sopt/app/application/soptletter/SoptLetterService.java
@@ -110,7 +110,7 @@ public class SoptLetterService {
         val topic = soptLetterTopicRepository.findById(topicId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 
-        return getTopicMessageList(userId, topic, cursor, size);
+        return getTopicMessageList(userId, topic, cursor, size, null);
     }
 
     @Transactional(readOnly = true)
@@ -121,10 +121,17 @@ public class SoptLetterService {
             .findFirst()
             .orElseThrow(() -> new NotFoundException(ErrorCode.SOPT_LETTER_TOPIC_NOT_FOUND));
 
-        return getTopicMessageList(userId, topic, cursor, size);
+        val hasNormalTopic = soptLetterTopicRepository.existsNormalTopic();
+        return getTopicMessageList(userId, topic, cursor, size, hasNormalTopic);
     }
 
-    private TopicMessageListResult getTopicMessageList(Long userId, SoptLetterTopic topic, Long cursor, Integer size) {
+    private TopicMessageListResult getTopicMessageList(
+        Long userId,
+        SoptLetterTopic topic,
+        Long cursor,
+        Integer size,
+        Boolean hasNormalTopic
+    ) {
         val requesterProfile = getProfileByUserId(userId);
 
         val fetchedLetters = getTopicLetters(topic.getId(), cursor, size + 1);
@@ -137,7 +144,7 @@ public class SoptLetterService {
         val messageSummaries = toTopicMessageSummaries(letters, requesterProfile, likedLetterIds, authorNicknamesByProfileId);
         val totalCount = Math.toIntExact(soptLetterRepository.countByTopicId(topic.getId()));
 
-        return TopicMessageListResult.of(topic, totalCount, nextCursor, hasNext, messageSummaries);
+        return TopicMessageListResult.of(topic, totalCount, nextCursor, hasNext, hasNormalTopic, messageSummaries);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
+++ b/src/main/java/org/sopt/app/interfaces/postgres/soptletter/SoptLetterTopicRepository.java
@@ -17,6 +17,9 @@ public interface SoptLetterTopicRepository extends JpaRepository<SoptLetterTopic
     @Query("SELECT t FROM SoptLetterTopic t WHERE t.isDefault = false ORDER BY t.createdAt DESC")
     List<SoptLetterTopic> findAllNormalTopicsOrderByCreatedAtDesc();
 
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM SoptLetterTopic t WHERE t.isDefault = false")
+    boolean existsNormalTopic();
+
     @Query("""
         SELECT t FROM SoptLetterTopic t
         WHERE t.ctaText IS NOT NULL

--- a/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
+++ b/src/main/java/org/sopt/app/presentation/soptletter/dto/SoptLetterResponse.java
@@ -87,6 +87,8 @@ public class SoptLetterResponse {
         Long nextCursor,
         @Schema(description = "다음 페이지 존재 여부", example = "false")
         Boolean hasNext,
+        @Schema(description = "디폴트 주제를 제외한 개별 주제 존재 여부", example = "true", nullable = true)
+        Boolean hasNormalTopic,
         @Schema(description = "해당 주제 메시지 목록")
         List<TopicMessageResponse> messages
     ) {

--- a/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
+++ b/src/test/java/org/sopt/app/application/soptletter/SoptLetterServiceTest.java
@@ -1265,6 +1265,7 @@ class SoptLetterServiceTest {
         assertThat(result.getTitle()).isEqualTo("36기 회고");
         assertThat(result.getTotalCount()).isEqualTo(3);
         assertThat(result.getHasNext()).isTrue();
+        assertThat(result.getHasNormalTopic()).isNull();
         assertThat(result.getNextCursor()).isEqualTo(124L);
         assertThat(result.getMessages()).hasSize(2);
         assertThat(result.getMessages().get(0).getMessageId()).isEqualTo(125L);
@@ -1518,6 +1519,7 @@ class SoptLetterServiceTest {
                 .thenReturn(Set.of(125L));
         when(soptLetterProfileRepository.findAllById(any())).thenReturn(List.of(requesterProfile, otherProfile));
         when(soptLetterRepository.countByTopicId(topicId)).thenReturn(3L);
+        when(soptLetterTopicRepository.existsNormalTopic()).thenReturn(true);
 
         // when
         SoptLetterInfo.TopicMessageListResult result = soptLetterService.getDefaultTopicMessages(userId, null, size);
@@ -1527,6 +1529,7 @@ class SoptLetterServiceTest {
         assertThat(result.getTitle()).isEqualTo("36기 회고");
         assertThat(result.getTotalCount()).isEqualTo(3);
         assertThat(result.getHasNext()).isTrue();
+        assertThat(result.getHasNormalTopic()).isTrue();
         assertThat(result.getNextCursor()).isEqualTo(124L);
         assertThat(result.getMessages()).hasSize(2);
         assertThat(result.getMessages().get(0).getMessageId()).isEqualTo(125L);
@@ -1536,6 +1539,7 @@ class SoptLetterServiceTest {
         assertThat(result.getMessages().get(1).getMessageId()).isEqualTo(124L);
         assertThat(result.getMessages().get(1).getMine()).isTrue();
         verify(soptLetterTopicRepository, times(1)).findAllDefaultTopicsOrderByCreatedAtDesc();
+        verify(soptLetterTopicRepository, times(1)).existsNormalTopic();
         verify(soptLetterTopicRepository, never()).findById(anyLong());
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closes #814

## Work Description ✏️

- 기본 주제 솝레터 메시지 목록 조회 응답에 디폴트 주제를 제외한 개별 주제 존재 여부를 추가했습니다.
- 디폴트 주제가 아닌 주제가 1개 이상 있는지 확인하는 repository 메서드를 추가했습니다.
- 기본 주제 메시지 목록 조회 서비스 테스트에 hasNormalTopic 반환 검증을 추가했습니다.

## Related ScreenShot 📷

N/A

## To Reviewers 📢

메인 화면에서 햄버거 메뉴 노출 여부만 판단하기 위해 주제 목록 API를 추가 호출하지 않도록, 기존 기본 주제 메시지 목록 응답에 hasNormalTopic 값을 함께 내려주도록 했습니다.
개별 주제 메시지 목록 조회에서는 해당 값이 필요하지 않아 null로 유지했습니다.