### PR TITLE
[Feat] #816: 활동 유저와 비활동 유저 캐싱 물리 TTL 분리

### DIFF
--- a/src/main/java/org/sopt/app/application/platform/PlatformService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformService.java
@@ -179,10 +179,6 @@ public class PlatformService {
             .collect(Collectors.joining("/"));
     }
 
-    public boolean isCurrentGeneration(Long generation) {
-        return generation.equals(currentGeneration);
-    }
-
     public PlaygroundProfileInfo.UserActiveInfo getUserActiveInfo(Long userId) {
         return new PlaygroundProfileInfo.UserActiveInfo(currentGeneration, getStatus(userId));
     }

--- a/src/main/java/org/sopt/app/application/platform/PlatformUserCacheService.java
+++ b/src/main/java/org/sopt/app/application/platform/PlatformUserCacheService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.application.platform.dto.PlatformUserInfoResponse;
 import org.sopt.app.common.cache.CachePolicy;
 import org.sopt.app.common.cache.ResilientCacheTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Service;
@@ -16,21 +17,27 @@ public class PlatformUserCacheService {
 
     private static final String CACHE_KEY_PREFIX = "platformUserInfo::";
     private static final long LOGICAL_TTL_MS = 1000 * 60 * 5; // 5분
-    private static final Duration PHYSICAL_TTL = Duration.ofHours(6);
-
+    private static final Duration DEFAULT_PHYSICAL_TTL = Duration.ofHours(6);
+    private static final Duration ACTIVE_USER_PHYSICAL_TTL = Duration.ofDays(30);
     private final ResilientCacheTemplate resilientCacheTemplate;
     private final CachePolicy userCachePolicy;
+    private final Long currentGeneration;
 
     // AWS Lambda 프로필에서는 동기 갱신으로 진행하기 위함
-    public PlatformUserCacheService(ResilientCacheTemplate resilientCacheTemplate, Environment environment) {
+    public PlatformUserCacheService(
+        ResilientCacheTemplate resilientCacheTemplate,
+        Environment environment,
+        @Value("${sopt.current.generation}") Long currentGeneration
+    ) {
         this.resilientCacheTemplate = resilientCacheTemplate;
+        this.currentGeneration = currentGeneration;
 
         // 람다 프로필 여부에 따라 비동기 갱신
         boolean isAsync = !environment.acceptsProfiles(Profiles.of("lambda"));
 
         this.userCachePolicy = CachePolicy.of(
             LOGICAL_TTL_MS,
-            PHYSICAL_TTL,
+            DEFAULT_PHYSICAL_TTL,
             isAsync
         );
     }
@@ -42,7 +49,22 @@ public class PlatformUserCacheService {
             cacheKey,
             PlatformUserInfoResponse.class,
             userCachePolicy,
-            fetcher
+            fetcher,
+            this::resolvePhysicalTtl
         );
+    }
+
+    /**
+     * 물리 TTL 정책
+     */
+    private Duration resolvePhysicalTtl(PlatformUserInfoResponse user) {
+        if (isCurrentGenerationActiveUser(user)) {
+            return ACTIVE_USER_PHYSICAL_TTL;
+        }
+        return DEFAULT_PHYSICAL_TTL;
+    }
+
+    private boolean isCurrentGenerationActiveUser(PlatformUserInfoResponse user) {
+        return currentGeneration != null && user.getLastSoptGeneration() == currentGeneration;
     }
 }

--- a/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/RedisResilientCacheTemplate.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.common.exception.BaseException;
@@ -59,7 +60,13 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
      * 논리 TTL이 만료됐더라도, 우선 stale한 데이터를 반환함.
      */
     @Override
-    public <T> T get(String key, Class<T> type, CachePolicy policy, Supplier<T> fetcher) {
+    public <T> T get(
+            String key,
+            Class<T> type,
+            CachePolicy policy,
+            Supplier<T> fetcher,
+            Function<T, Duration> physicalTtlResolver
+    ) {
 
         JavaType wrapperType = objectMapper.getTypeFactory().constructParametricType(CacheWrapper.class, type);
 
@@ -74,12 +81,12 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
             staleData = cachedData;
 
             if(policy.asyncRefreshEnabled()){
-                dispatchAsyncRefresh(key, policy, fetcher, wrapperType);
+                dispatchAsyncRefresh(key, policy, fetcher, wrapperType, physicalTtlResolver);
                 return cachedData.data();
             }
         }
 
-        return blockingGet(key, policy, fetcher, staleData, wrapperType);
+        return blockingGet(key, policy, fetcher, staleData, wrapperType, physicalTtlResolver);
     }
 
     private <T> CacheWrapper<T> readCache(String key, JavaType wrapperType) {
@@ -97,7 +104,14 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     /**
      * stale 데이터도 없는 경우 or AWS Lambda 환경인 경우.
      */
-    private <T> T blockingGet(String key, CachePolicy policy, Supplier<T> fetcher, CacheWrapper<T> staleData, JavaType wrapperType) {
+    private <T> T blockingGet(
+            String key,
+            CachePolicy policy,
+            Supplier<T> fetcher,
+            CacheWrapper<T> staleData,
+            JavaType wrapperType,
+            Function<T, Duration> physicalTtlResolver
+    ) {
         String lockKey = LOCK_PREFIX + key;
         String lockValue = UUID.randomUUID().toString();
         long startTime = System.currentTimeMillis();
@@ -117,7 +131,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
                     if (isValid(doubleChecked) && isFresh(doubleChecked, policy.logicalTtlMs())) {
                         return doubleChecked.data();
                     }
-                    return fetchAndCache(key, policy.physicalTtl(), fetcher, wrapperType);
+                    return fetchAndCache(key, policy, fetcher, wrapperType, physicalTtlResolver);
                 } finally {
                     releaseLock(lockKey, lockValue);
                 }
@@ -155,7 +169,8 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
     /**
      * 비동기적으로 이미 누군가 락을 잡고 작업 중이라면 패스, 그렇지 않다면 락을 잡고 데이터 갱신
      */
-    private <T> void dispatchAsyncRefresh(String key, CachePolicy policy, Supplier<T> fetcher, JavaType wrapperType) {
+    private <T> void dispatchAsyncRefresh(String key, CachePolicy policy, Supplier<T> fetcher, JavaType wrapperType,
+        Function<T, Duration> physicalTtlResolver) {
         String markerKey = REFRESH_MARKER_PREFIX + key;
         Boolean markerAcquired = stringRedisTemplate.opsForValue().setIfAbsent(markerKey, "1", policy.lockTtl());
         if (!Boolean.TRUE.equals(markerAcquired)) return;
@@ -182,7 +197,7 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
                     if (isValid(doubleChecked) && isFresh(doubleChecked, policy.logicalTtlMs())) {
                         return;
                     }
-                    fetchAndCache(key, policy.physicalTtl(), fetcher, wrapperType);
+                    fetchAndCache(key, policy, fetcher, wrapperType, physicalTtlResolver);
                 } catch (Exception e) {
                     log.error("비동기 캐시 갱신 실패. Key: {}", key, e);
                 } finally {
@@ -199,10 +214,17 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
 
     }
 
-    private <T> T fetchAndCache(String key, Duration physicalTtl, Supplier<T> fetcher, JavaType wrapperType) {
+    private <T> T fetchAndCache(
+            String key,
+            CachePolicy policy,
+            Supplier<T> fetcher,
+            JavaType wrapperType,
+            Function<T, Duration> physicalTtlResolver
+    ) {
         long requestAt = System.currentTimeMillis();
 
         T data = fetcher.get(); // 외부에서 데이터를 가져옴
+        Duration physicalTtl = resolvePhysicalTtl(key, policy, data, physicalTtlResolver);
         CacheWrapper<T> wrapper = new CacheWrapper<>(data, requestAt);
 
         try {
@@ -222,6 +244,28 @@ public class RedisResilientCacheTemplate implements ResilientCacheTemplate {
             log.error("데이터 직렬화 및 레디스 저장 실패. key: {}", key, e);
         }
         return data;
+    }
+
+    /**
+     * fetch된 데이터로 물리 TTL을 계산. resolver가 null을 반환하거나 예외를 던지면 정책 고정값으로 폴백.
+     */
+    private <T> Duration resolvePhysicalTtl(
+            String key,
+            CachePolicy policy,
+            T data,
+            Function<T, Duration> physicalTtlResolver
+    ) {
+        if (physicalTtlResolver == null) {
+            return policy.physicalTtl();
+        }
+
+        try {
+            Duration resolved = physicalTtlResolver.apply(data);
+            return resolved != null ? resolved : policy.physicalTtl();
+        } catch (Exception e) {
+            log.warn("물리 TTL resolver 실행 실패. 정책 기본값으로 폴백. Key: {}", key, e);
+            return policy.physicalTtl();
+        }
     }
 
     private void releaseLock(String lockKey, String lockValue) {

--- a/src/main/java/org/sopt/app/common/cache/ResilientCacheTemplate.java
+++ b/src/main/java/org/sopt/app/common/cache/ResilientCacheTemplate.java
@@ -1,5 +1,7 @@
 package org.sopt.app.common.cache;
 
+import java.time.Duration;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface ResilientCacheTemplate {
@@ -10,10 +12,28 @@ public interface ResilientCacheTemplate {
      * @param policy 캐시 정책
      * @param fetcher 캐시 미스 시 데이터를 가져올 공급자(Supplier)
      */
-    <T> T get(
+    default <T> T get(
         String key,
         Class<T> type,
         CachePolicy policy,
         Supplier<T> fetcher
+    ) {
+        // 물리 TTL을 별도로 계산하지 않는 기본 경로. 정책 고정값을 그대로 사용.
+        return get(key, type, policy, fetcher, data -> policy.physicalTtl());
+    }
+
+    /**
+     * @param key 캐시 식별 키
+     * @param type 반환받을 객체의 타입 클래스
+     * @param policy 캐시 정책
+     * @param fetcher 캐시 미스 시 데이터를 가져올 공급자(Supplier)
+     * @param physicalTtlResolver fetch된 데이터로 물리 TTL(Redis TTL)을 계산하는 함수
+     */
+    <T> T get(
+        String key,
+        Class<T> type,
+        CachePolicy policy,
+        Supplier<T> fetcher,
+        Function<T, Duration> physicalTtlResolver
     );
 }

--- a/src/main/java/org/sopt/app/common/config/LazyDataSourceConfiguration.java
+++ b/src/main/java/org/sopt/app/common/config/LazyDataSourceConfiguration.java
@@ -3,8 +3,10 @@ package org.sopt.app.common.config;
 import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
@@ -12,12 +14,16 @@ import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 @EnableJpaRepositories(basePackages = "org.sopt.app")
 public class LazyDataSourceConfiguration {
     @Bean
-    public DataSource lazyDataSource(DataSourceProperties properties) {
-        HikariDataSource dataSource = new HikariDataSource();
-        dataSource.setJdbcUrl(properties.getUrl());
-        dataSource.setUsername(properties.getUsername());
-        dataSource.setPassword(properties.getPassword());
-        dataSource.setDriverClassName(properties.getDriverClassName());
-        return new LazyConnectionDataSourceProxy(dataSource);
+    @ConfigurationProperties("spring.datasource.hikari")
+    public HikariDataSource hikariDataSource(DataSourceProperties properties) {
+        return properties.initializeDataSourceBuilder()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    @Primary
+    public DataSource lazyDataSource(HikariDataSource hikariDataSource) {
+        return new LazyConnectionDataSourceProxy(hikariDataSource);
     }
 }

--- a/src/test/java/org/sopt/app/application/platform/PlatformUserCacheServiceTest.java
+++ b/src/test/java/org/sopt/app/application/platform/PlatformUserCacheServiceTest.java
@@ -6,6 +6,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +33,7 @@ class PlatformUserCacheServiceTest {
     private PlatformUserCacheService platformUserCacheService;
 
     private final Long userId = 1L;
+    private final Long currentGeneration = 34L;
     private final String expectedKey = "platformUserInfo::1";
 
     @Test
@@ -37,12 +41,12 @@ class PlatformUserCacheServiceTest {
     void SUCCESS_getPlatformUserInfo_DelegatesToTemplate() {
         // given
         when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(false); // 람다 환경이 아님 -> 비동기 처리 활성화
-        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment);
+        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment, currentGeneration);
 
-        PlatformUserInfoResponse expectedResponse = new PlatformUserInfoResponse(1, "test", null, null, null, null, 34, null);
+        PlatformUserInfoResponse expectedResponse = userWithLastSoptGeneration(34);
         Supplier<PlatformUserInfoResponse> fetcher = () -> expectedResponse;
 
-        when(resilientCacheTemplate.get(eq(expectedKey), eq(PlatformUserInfoResponse.class), any(CachePolicy.class), eq(fetcher)))
+        when(resilientCacheTemplate.get(eq(expectedKey), eq(PlatformUserInfoResponse.class), any(CachePolicy.class), eq(fetcher), any()))
             .thenReturn(expectedResponse);
 
         // when
@@ -52,7 +56,7 @@ class PlatformUserCacheServiceTest {
         assertThat(result).isEqualTo(expectedResponse);
 
         ArgumentCaptor<CachePolicy> policyCaptor = ArgumentCaptor.forClass(CachePolicy.class);
-        verify(resilientCacheTemplate).get(eq(expectedKey), eq(PlatformUserInfoResponse.class), policyCaptor.capture(), eq(fetcher));
+        verify(resilientCacheTemplate).get(eq(expectedKey), eq(PlatformUserInfoResponse.class), policyCaptor.capture(), eq(fetcher), any());
 
         CachePolicy capturedPolicy = policyCaptor.getValue();
         assertThat(capturedPolicy.asyncRefreshEnabled()).isTrue();
@@ -63,7 +67,7 @@ class PlatformUserCacheServiceTest {
     void SUCCESS_getPlatformUserInfo_LambdaProfile_SyncRefresh() {
         // given
         when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(true); // 람다 환경임 -> 비동기 처리 비활성화
-        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment);
+        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment, currentGeneration);
 
         Supplier<PlatformUserInfoResponse> fetcher = () -> null;
 
@@ -72,9 +76,77 @@ class PlatformUserCacheServiceTest {
 
         // then
         ArgumentCaptor<CachePolicy> policyCaptor = ArgumentCaptor.forClass(CachePolicy.class);
-        verify(resilientCacheTemplate).get(eq(expectedKey), eq(PlatformUserInfoResponse.class), policyCaptor.capture(), eq(fetcher));
+        verify(resilientCacheTemplate).get(eq(expectedKey), eq(PlatformUserInfoResponse.class), policyCaptor.capture(), eq(fetcher), any());
 
         CachePolicy capturedPolicy = policyCaptor.getValue();
         assertThat(capturedPolicy.asyncRefreshEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_현재 기수 활동 유저는 30일 물리 TTL 적용")
+    void SUCCESS_resolvePhysicalTtl_ActiveUser_30Days() {
+        // given
+        when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(false);
+        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment, currentGeneration);
+
+        PlatformUserInfoResponse activeUser = userWithLastSoptGeneration(34); // 현재 기수와 동일
+        platformUserCacheService.getPlatformUserInfo(userId, () -> activeUser);
+
+        // when
+        Function<PlatformUserInfoResponse, Duration> resolver = captureResolver();
+
+        // then
+        assertThat(resolver.apply(activeUser)).isEqualTo(Duration.ofDays(30));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_과거 기수 유저는 기본 6시간 물리 TTL 적용")
+    void SUCCESS_resolvePhysicalTtl_InactiveUser_6Hours() {
+        // given
+        when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(false);
+        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment, currentGeneration);
+
+        PlatformUserInfoResponse inactiveUser = userWithLastSoptGeneration(33); // 과거 기수
+        platformUserCacheService.getPlatformUserInfo(userId, () -> inactiveUser);
+
+        // when
+        Function<PlatformUserInfoResponse, Duration> resolver = captureResolver();
+
+        // then
+        assertThat(resolver.apply(inactiveUser)).isEqualTo(Duration.ofHours(6));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_솝트 활동 이력이 없는 유저는 기본 6시간 물리 TTL 적용")
+    void SUCCESS_resolvePhysicalTtl_NoActivities_6Hours() {
+        // given
+        when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(false);
+        platformUserCacheService = new PlatformUserCacheService(resilientCacheTemplate, environment, currentGeneration);
+
+        PlatformUserInfoResponse noActivityUser =
+            new PlatformUserInfoResponse(1, "test", null, null, null, null, 0, null);
+        platformUserCacheService.getPlatformUserInfo(userId, () -> noActivityUser);
+
+        // when
+        Function<PlatformUserInfoResponse, Duration> resolver = captureResolver();
+
+        // then
+        assertThat(resolver.apply(noActivityUser)).isEqualTo(Duration.ofHours(6));
+    }
+
+    private PlatformUserInfoResponse userWithLastSoptGeneration(int generation) {
+        return new PlatformUserInfoResponse(1, "test", null, null, null, null, generation, List.of(
+            new PlatformUserInfoResponse.SoptActivities(1, generation, "서버", "팀", true)
+        ));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Function<PlatformUserInfoResponse, Duration> captureResolver() {
+        ArgumentCaptor<Function<PlatformUserInfoResponse, Duration>> resolverCaptor =
+            ArgumentCaptor.forClass(Function.class);
+        verify(resilientCacheTemplate).get(
+            eq(expectedKey), eq(PlatformUserInfoResponse.class), any(CachePolicy.class), any(Supplier.class),
+            resolverCaptor.capture());
+        return resolverCaptor.getValue();
     }
 }

--- a/src/test/java/org/sopt/app/common/cache/RedisResilientCacheTemplateTest.java
+++ b/src/test/java/org/sopt/app/common/cache/RedisResilientCacheTemplateTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.time.Duration;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -297,6 +298,109 @@ class RedisResilientCacheTemplateTest {
 
         // then
         verify(fetcher, never()).get();
+    }
+
+    @Test
+    @DisplayName("SUCCESS_콜드 조회 시 resolver가 계산한 물리 TTL로 Redis에 저장")
+    void SUCCESS_get_ColdBlockingGet_UsesResolverTtl() throws Exception {
+        // given
+        Duration resolvedTtl = Duration.ofDays(30);
+        when(valueOperations.get(key)).thenReturn(null);
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(objectMapper.writeValueAsString(any())).thenReturn("new-json");
+
+        Function<String, Duration> resolver = data -> resolvedTtl;
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched", resolver);
+
+        // then
+        assertThat(result).isEqualTo("fetched");
+        verify(valueOperations).set(eq(key), eq("new-json"), eq(resolvedTtl));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_비동기 갱신 경로에서도 resolver가 계산한 물리 TTL로 저장")
+    void SUCCESS_get_AsyncRefresh_UsesResolverTtl() throws Exception {
+        // given
+        Duration resolvedTtl = Duration.ofDays(30);
+        long staleTime = System.currentTimeMillis() - 2000L;
+        RedisResilientCacheTemplate.CacheWrapper<String> staleWrapper = new RedisResilientCacheTemplate.CacheWrapper<>("stale", staleTime);
+        when(valueOperations.get(key)).thenReturn("stale-json");
+        when(objectMapper.readValue(eq("stale-json"), eq(javaType))).thenReturn(staleWrapper);
+
+        when(valueOperations.setIfAbsent(eq(markerKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(executorProvider.getIfAvailable()).thenReturn(executor);
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        cacheTemplate.get(key, String.class, policy, () -> "fetched", data -> resolvedTtl);
+
+        verify(executor).execute(runnableCaptor.capture());
+        Runnable asyncTask = runnableCaptor.getValue();
+
+        // 비동기 작업 락 획득 성공, 더블 체크 시 여전히 stale
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(objectMapper.writeValueAsString(any())).thenReturn("new-json");
+
+        // when
+        asyncTask.run();
+
+        // then
+        verify(valueOperations).set(eq(key), eq("new-json"), eq(resolvedTtl));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_4-arg 호출은 정책의 물리 TTL을 그대로 사용")
+    void SUCCESS_get_LegacyFourArg_UsesPolicyTtl() throws Exception {
+        // given
+        when(valueOperations.get(key)).thenReturn(null);
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(objectMapper.writeValueAsString(any())).thenReturn("new-json");
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched");
+
+        // then
+        assertThat(result).isEqualTo("fetched");
+        verify(valueOperations).set(eq(key), eq("new-json"), eq(policy.physicalTtl()));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_resolver가 null 반환 시 정책 물리 TTL로 폴백")
+    void SUCCESS_get_ResolverReturnsNull_FallbackToPolicyTtl() throws Exception {
+        // given
+        when(valueOperations.get(key)).thenReturn(null);
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(objectMapper.writeValueAsString(any())).thenReturn("new-json");
+
+        Function<String, Duration> resolver = data -> null;
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched", resolver);
+
+        // then
+        assertThat(result).isEqualTo("fetched");
+        verify(valueOperations).set(eq(key), eq("new-json"), eq(policy.physicalTtl()));
+    }
+
+    @Test
+    @DisplayName("SUCCESS_resolver가 예외를 던지면 정책 물리 TTL로 폴백")
+    void SUCCESS_get_ResolverThrows_FallbackToPolicyTtl() throws Exception {
+        // given
+        when(valueOperations.get(key)).thenReturn(null);
+        when(valueOperations.setIfAbsent(eq(lockKey), anyString(), any(Duration.class))).thenReturn(true);
+        when(objectMapper.writeValueAsString(any())).thenReturn("new-json");
+
+        Function<String, Duration> resolver = data -> {
+            throw new RuntimeException("resolver error");
+        };
+
+        // when
+        String result = cacheTemplate.get(key, String.class, policy, () -> "fetched", resolver);
+
+        // then
+        assertThat(result).isEqualTo("fetched");
+        verify(valueOperations).set(eq(key), eq("new-json"), eq(policy.physicalTtl()));
     }
 
     @Test


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #816

## Work Description ✏️

- 유저 정보 캐시의 물리 TTL을 전 유저 6시간 고정에서 현재 기수 활동 유저 30일 / 그 외 6시간으로 분리함
  - 세미나(출석)는 주간 주기인데 물리 TTL이 6시간이라, 출석 시점마다 활동 유저 전원의 캐시가 물리 만료된 상태였음 → 출석 요청이 매번 완전 동기식 대기(blockingGet)로 진입해 스레드 고갈 위험이 존재함.
  - 활동 유저는 한 달 이상 미사용 확률이 거의 없으므로, TTL을 30일로 두어 기수 내내 웜 상태를 유도하고자 함.
  - 신규 가입자는 가입 직후 첫 진입에서 자기 캐시를 적재하는데, 가입은 일괄적으로 진행하지 않으므로... 현재 구조가 괜찮다고 생각하여 진행함.


## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- 서버 레포 통합 이후엔 아마 이 부분이 불필요해질 것 같은데,, 우선 어떻게 될지 몰라서 작업해두었어요!
