### PR TITLE
[Refactor] #819: 솝탬프 Redis 키에 기수 정보 추가, 배포 워크플로우 내 도커 이미지 삭제 추가 

### DIFF
--- a/.github/workflows/app-cd-dev.yml
+++ b/.github/workflows/app-cd-dev.yml
@@ -127,3 +127,5 @@ jobs:
             
             ./script/deploy.sh
             docker image prune -f
+            # SHA 태그 이미지는 dangling이 되지 않아 prune 대상이 아니다. 현재+직전(롤백용) 2개만 남긴다.
+            docker images ${{ env.APP_ECR_REPO }} -q | uniq | tail -n +3 | xargs -r docker rmi 2>/dev/null || true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -128,3 +128,5 @@ jobs:
             
             ./script/deploy.sh
             docker image prune -f
+            # SHA 태그 이미지는 dangling이 되지 않아 prune 대상이 아니다. 현재+직전(롤백용) 2개만 남긴다.
+            docker images ${{ env.APP_ECR_REPO }} -q | uniq | tail -n +3 | xargs -r docker rmi 2>/dev/null || true

--- a/script/deploy_container.sh
+++ b/script/deploy_container.sh
@@ -7,7 +7,8 @@ deploy_container() {
     echo "▶️ Switching to ${CONTAINER_NAME} at Port ${PORT} (Actuator: ${ACTUATOR_PORT}) ..."
     echo "docker-compose pull & up ..."
 
-    docker-compose pull redis
+    # redis는 pull X. 태그 고정과 함께 배포 시 캐시 전체 삭제를 막기 위함.
+    # docker-compose pull redis
     docker-compose up -d redis
     docker-compose pull ${CONTAINER_NAME}
     docker-compose up -d ${CONTAINER_NAME}

--- a/src/main/java/org/sopt/app/application/rank/RedisRankService.java
+++ b/src/main/java/org/sopt/app/application/rank/RedisRankService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.app.application.soptamp.SoptampUserInfo;
 import org.sopt.app.common.config.CacheType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Service;
@@ -18,11 +19,19 @@ import org.springframework.stereotype.Service;
 public class RedisRankService implements RankCacheService{
     private final RedisTemplate<String, Long> redisTemplate;
 
+    @Value("${sopt.current.generation}")
+    private Long currentGeneration;
+
+    //키에 기수 정보를 포함
+    private String scoreKey() {
+        return CacheType.SOPTAMP_SCORE.getCacheName() + ":" + currentGeneration;
+    }
+
     @Override
     public Set<TypedTuple<Long>> getRanking() {
         try {
             return redisTemplate.opsForZSet()
-                    .reverseRangeWithScores(CacheType.SOPTAMP_SCORE.getCacheName(), 0, -1);
+                    .reverseRangeWithScores(scoreKey(), 0, -1);
         }catch (Exception e){
             log.warn("Redis에서 Soptamp 랭킹 조회 중 오류 발생", e);
             return Collections.emptySet();
@@ -32,36 +41,36 @@ public class RedisRankService implements RankCacheService{
     // 랭크 신규 생성용
     @Override
     public void createNewRank(Long userId) {
-        redisTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), userId, 0);
+        redisTemplate.opsForZSet().add(scoreKey(), userId, 0);
     }
 
     @Override
     public void removeRank(Long userId) {
-        redisTemplate.opsForZSet().remove(CacheType.SOPTAMP_SCORE.getCacheName(), userId);
+        redisTemplate.opsForZSet().remove(scoreKey(), userId);
     }
 
     @Override
     public void incrementScore(Long userId, int score) {
         redisTemplate.opsForZSet()
-                .incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), userId, score);
+                .incrementScore(scoreKey(), userId, score);
     }
 
     @Override
     public void decreaseScore(Long userId, int score) {
         redisTemplate.opsForZSet()
-                .incrementScore(CacheType.SOPTAMP_SCORE.getCacheName(), userId, -1 * score);
+                .incrementScore(scoreKey(), userId, -1 * score);
     }
 
     // 점수 0으로 초기화
     @Override
     public void initScore(Long userId) {
         redisTemplate.opsForZSet()
-                .add(CacheType.SOPTAMP_SCORE.getCacheName(), userId, 0);
+                .add(scoreKey(), userId, 0);
     }
 
     @Override
     public void deleteAll() {
-        redisTemplate.delete(CacheType.SOPTAMP_SCORE.getCacheName());
+        redisTemplate.delete(scoreKey());
     }
 
     @Override
@@ -78,7 +87,7 @@ public class RedisRankService implements RankCacheService{
     @Override
     public void updateScore(Long userId, long currentUserScore) {
         redisTemplate.opsForZSet()
-            .add(CacheType.SOPTAMP_SCORE.getCacheName(), userId, currentUserScore);
+            .add(scoreKey(), userId, currentUserScore);
     }
 
     @Override
@@ -96,7 +105,7 @@ public class RedisRankService implements RankCacheService{
     public void addAll(List<SoptampUserInfo> userInfos) {
         try {
             Set<TypedTuple<Long>> scores = this.convertRankingSet(userInfos);
-            redisTemplate.opsForZSet().add(CacheType.SOPTAMP_SCORE.getCacheName(), scores);
+            redisTemplate.opsForZSet().add(scoreKey(), scores);
         } catch (Exception e) {
             log.warn("Redis에 랭킹 데이터를 추가하는 중 오류 발생", e);
         }

--- a/src/test/java/org/sopt/app/application/rank/RedisRankServiceTest.java
+++ b/src/test/java/org/sopt/app/application/rank/RedisRankServiceTest.java
@@ -1,0 +1,64 @@
+package org.sopt.app.application.rank;
+
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.app.common.fixtures.SoptampUserFixture;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RedisRankServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @Mock
+    private ZSetOperations<String, Long> zSetOperations;
+
+    @InjectMocks
+    private RedisRankService redisRankService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(redisRankService, "currentGeneration", SoptampUserFixture.CURRENT_GENERATION);
+    }
+
+    @Test
+    @DisplayName("SUCCESS_랭킹 캐시는 현재 기수가 붙은 키에 쓴다")
+    void SUCCESS_addAll_writesToCurrentGenerationKey() {
+        // given
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+
+        // when
+        redisRankService.addAll(List.of(SoptampUserFixture.SOPTAMP_USER_INFO_1));
+
+        // then
+        verify(zSetOperations).add(eq("soptamp_score:" + SoptampUserFixture.CURRENT_GENERATION), anySet());
+    }
+
+    @Test
+    @DisplayName("SUCCESS_구버전 기수 설정으로 뜬 프로세스는 자기 기수 키만 지운다")
+    void SUCCESS_deleteAll_staleGenerationCannotTouchCurrentKey() {
+        // given
+        final long staleGeneration = SoptampUserFixture.CURRENT_GENERATION - 1;
+        ReflectionTestUtils.setField(redisRankService, "currentGeneration", staleGeneration);
+
+        // when
+        redisRankService.deleteAll();
+
+        // then
+        verify(redisTemplate).delete("soptamp_score:" + staleGeneration);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #819 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 솝탬프 캐시 Redis 키에 기수 정보 추가
- 배포 워크플로우 내 도커 이미지 삭제 추가 
  - 기존 자동 삭제되고 있었는데, 이미지마다 SHA 태그로 버저닝을 하면서 삭제가 누락되었던 문제가 있어서 수정함
- redis 이미지 pull 받아오지 않도록 변경. 버전 최신화 시 기존 캐시가 삭제되는 경우가 있어서 지움
## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->