### PR TITLE
[Fix] #821: 콕찌르기 동시 생성 관련 버그 해결

### DIFF
--- a/src/main/java/org/sopt/app/facade/PokeFacade.java
+++ b/src/main/java/org/sopt/app/facade/PokeFacade.java
@@ -4,6 +4,8 @@ import static org.sopt.app.application.poke.PokeInfo.NEW_FRIEND_MANY_MUTUAL;
 import static org.sopt.app.application.poke.PokeInfo.NEW_FRIEND_NO_MUTUAL;
 import static org.sopt.app.application.poke.PokeInfo.NEW_FRIEND_ONE_MUTUAL;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -39,6 +41,9 @@ public class PokeFacade {
     private final PokeHistoryService pokeHistoryService;
     private final PokeMessageService pokeMessageService;
     private final PlatformService platformService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     public List<PokeMessage> getPokingMessages(String type) {
         val messages = pokeMessageService.pickRandomMessageByTypeOf(type);
@@ -99,11 +104,22 @@ public class PokeFacade {
         // 앱 DB 존재 확인 (플랫폼에만 있는 유저 케이스 방지)
         if (!userService.isUserExist(pokedUserId)) throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
 
+        // 동일 방향(pokerUserId -> pokedUserId) 콕찌르기가 동시에 여러 번 들어와도
+        // 중복 체크와 히스토리 생성이 직렬화되도록 트랜잭션 종료 시 자동 해제되는 락을 건다.
+        acquirePokeLock(pokerUserId, pokedUserId);
+
         pokeHistoryService.checkDuplicate(pokerUserId, pokedUserId);
         PokeHistory newPoke = pokeService.poke(pokerUserId, pokedUserId, pokeMessage, isAnonymous);
 
         applyFriendship(pokerUserId, pokedUserId);
         return newPoke.getId();
+    }
+
+    private void acquirePokeLock(Long pokerUserId, Long pokedUserId) {
+        long lockKey = (pokerUserId << 32) | (pokedUserId & 0xFFFFFFFFL);
+        entityManager.createNativeQuery("SELECT pg_advisory_xact_lock(:key)")
+                .setParameter("key", lockKey)
+                .getSingleResult();
     }
 
     private void applyFriendship(Long pokerUserId, Long pokedUserId) {


### PR DESCRIPTION
## Related issue 🛠
closes #821

## Work Description ✏️
- 콕찌르기 요청이 짧은 간격으로 거의 동시에 여러 번 들어오면, 중복 체크(`checkDuplicate`)와 히스토리 생성(`poke`) 사이에 락이 없어서 같은 방향으로 답장 대기(`is_reply = false`) 상태의 히스토리가 중복 생성되는 문제가 있었습니다.
- 이후 상대방이 답장하면 중복 생성된 미답 히스토리 중 하나만 답장 처리되고, 나머지는 영구히 `is_reply = false`로 남습니다.
- 이 유령 히스토리가 `checkDuplicate`에 계속 걸려서, 이후 해당 방향으로의 콕찌르기가 실제로는 최근에 찌른 적이 없는데도 계속 "이미 찌름" 오류로 막히는 버그로 이어졌습니다.
- `pokeFriend()`에서 중복 체크 전에 `pg_advisory_xact_lock`으로 (pokerId, pokedId) 방향 기준 락을 걸어, 동일 방향 콕찌르기 요청이 직렬화되도록 수정했습니다. 트랜잭션 종료 시 자동 해제되는 락이라 별도 해제 로직이 필요 없습니다.

## To Reviewers 📢
- DB 스키마 변경 없이 애플리케이션 레벨에서만 해결한 방식입니다 (이 레포는 자동 마이그레이션이 없어 DDL 변경은 별도 수동 작업이 필요해서, 배포만으로 바로 적용되는 방식을 택했습니다).
- 기존에 이미 생성된 유령 히스토리(is_reply=false로 방치된 중복 row)는 별도로 데이터 정리가 필요합니다. 이 PR에는 포함하지 않았습니다.
- `PokeFacadeTest`, `PokeServiceTest`는 현재 전체 주석 처리되어 있어 영향 없음을 확인했습니다.
